### PR TITLE
feat: custom direct route endpoint, bypassing min liqudity parmeter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,7 @@ build:
 
 docker-build:
 	@DOCKER_BUILDKIT=1 docker build \
-		-t sqs:local \
-		-t sqs:local-distroless \
+		-t osmolabs/sqs:v0.0.1 \
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg GIT_VERSION=$(VERSION) \
 		--build-arg GIT_COMMIT=$(COMMIT) \

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Parameters:
 
 Response example:
 ```bash
-curl "https://sqs.osmosis.zone/routes?tokenIn=uosmo&tokenOutDenom=uion" | jq .
+curl "https://sqs.osmosis.zone/router/routes?tokenIn=uosmo&tokenOutDenom=uion" | jq .
 {
   "Routes": [
     {
@@ -226,6 +226,9 @@ curl "https://sqs.osmosis.zone/routes?tokenIn=uosmo&tokenOutDenom=uion" | jq .
 4. GET `/router/custom-quote?tokenIn=<tokenIn>&tokenOutDenom=<tokenOutDenom>&poolIDs=<poolIDs>`
 
 Description: returns the quote over route with the given poolIDs. If such route does not exist, returns error.
+This endpoint uses the router route search. As a result, it is affected by the minimum liquidity parameter
+in the config. If your desired pool does not appead in the router, thy decreasing the minimum liquidity
+parameter. Alternatively, you can use the `/router/custom-direct-quote` endpoint.
 
 Parameters:
 - `tokenIn` the string representation of the sdk.Coin for the token in
@@ -234,7 +237,7 @@ Parameters:
 
 Response example:
 ```bash
-curl "https://sqs.osmosis.zone/router/custom-quote?tokenIn=1000000uosmo&tokenOutDenom=uion?poolIDs=2" | jq .
+curl "https://sqs.osmosis.zone/router/custom-quote?tokenIn=1000000uosmo&tokenOutDenom=uion&poolIDs=2" | jq .
 {
   "amount_in": {
     "denom": "uosmo",
@@ -261,8 +264,46 @@ curl "https://sqs.osmosis.zone/router/custom-quote?tokenIn=1000000uosmo&tokenOut
 }
 ```
 
+5. GET `/router/custom-direct-quote?tokenIn=<tokenIn>&tokenOutDenom=<tokenOutDenom>&poolIDs=<poolIDs>`
 
-5. GET `/router/cached-routes?tokenIn=uosmo&tokenOutDenom=uion`
+Description: returns the quote over route with the given poolIDs. If such route does not exist, returns error.
+This endpoint does not use the router route search. As a result, it is not affected by the minimum liquidity parameter. As long as the pool exists on-chain, it will return a quote.
+
+Parameters:
+- `tokenIn` the string representation of the sdk.Coin for the token in
+- `tokenOutDenom` the string representing the denom of the token out
+- `poolID` comma-separated list of pool IDs
+
+Response example:
+```bash
+curl "https://sqs.osmosis.zone/router/custom-direct-quote?tokenIn=1000000uosmo&tokenOutDenom=uion&poolID=2" | jq .
+{
+  "amount_in": {
+    "denom": "uosmo",
+    "amount": "1000000"
+  },
+  "amount_out": "1803",
+  "route": [
+    {
+      "pools": [
+        {
+          "id": 2,
+          "type": 0,
+          "balances": [],
+          "spread_factor": "0.005000000000000000",
+          "token_out_denom": "uion",
+          "taker_fee": "0.001000000000000000"
+        }
+      ],
+      "out_amount": "1803",
+      "in_amount": "1000000"
+    }
+  ],
+  "effective_fee": "0.006000000000000000"
+}
+```
+
+6. GET `/router/cached-routes?tokenIn=uosmo&tokenOutDenom=uion`
 
 Description: returns cached routes for the given tokenIn and tokenOutDenomn if cache
 is enabled. If not, returns error. Contrary to `/router/routes...` endpoint, does
@@ -341,7 +382,7 @@ curl "https://sqs.osmosis.zone/cached-routes?tokenIn=uosmo&tokenOutDenom=uion" |
 }
 ```
 
-6. POST `/router/store-state`
+7. POST `/router/store-state`
 
 Description: stores the current state of the router in a JSON file locally. Used for debugging purposes.
 This endpoint should be disabled in production.

--- a/domain/mvc/router.go
+++ b/domain/mvc/router.go
@@ -19,6 +19,10 @@ type RouterUsecase interface {
 	// It searches for the route that contains the specified poolIDs in the given order.
 	// If such route is not found it returns an error.
 	GetCustomQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, poolIDs []uint64) (domain.Quote, error)
+	// GetCustomDirectQuote returns the custom direct quote for the given tokenIn, tokenOutDenom and poolID.
+	// It does not search for the route. It directly computes the quote for the given poolID.
+	// This allows to bypass a min liquidity requirement in the router when attempting to swap over a specific pool.
+	GetCustomDirectQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, poolID uint64) (domain.Quote, error)
 	// GetCandidateRoutes returns the candidate routes for the given tokenIn and tokenOutDenom.
 	GetCandidateRoutes(ctx context.Context, tokenInDenom, tokenOutDenom string) (sqsdomain.CandidateRoutes, error)
 	// GetTakerFee returns the taker fee for all token pairs in a pool.

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -425,6 +425,60 @@ func (r *routerUseCaseImpl) GetCustomQuote(ctx context.Context, tokenIn sdk.Coin
 	return quote, nil
 }
 
+// GetCustomDirectQuote implements mvc.RouterUsecase.
+func (r *routerUseCaseImpl) GetCustomDirectQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, poolID uint64) (domain.Quote, error) {
+	pool, err := r.poolsUsecase.GetPool(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+
+	poolDenoms := pool.GetPoolDenoms()
+
+	if !osmoutils.Contains(poolDenoms, tokenIn.Denom) {
+		return nil, fmt.Errorf("token in denom %s not found in pool %d", tokenIn.Denom, poolID)
+	}
+	if !osmoutils.Contains(poolDenoms, tokenOutDenom) {
+		return nil, fmt.Errorf("token out denom %s not found in pool %d", tokenOutDenom, poolID)
+	}
+
+	// Retrieve taker fee for the pool
+	takerFee, err := r.routerRepository.GetTakerFee(ctx, tokenIn.Denom, tokenOutDenom)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a taker fee map with the taker fee for the pool
+	takerFeeMap := sqsdomain.TakerFeeMap{}
+	takerFeeMap.SetTakerFee(tokenIn.Denom, tokenOutDenom, takerFee)
+
+	// Create a candidate route with the desired pool
+	candidateRoutes := sqsdomain.CandidateRoutes{
+		Routes: []sqsdomain.CandidateRoute{
+			{
+				Pools: []sqsdomain.CandidatePool{
+					{
+						ID:            poolID,
+						TokenOutDenom: tokenOutDenom,
+					},
+				},
+			},
+		},
+		UniquePoolIDs: map[uint64]struct{}{
+			poolID: {},
+		},
+	}
+
+	// Convert candidate route into a route with all the pool data
+	routes, err := r.poolsUsecase.GetRoutesFromCandidates(ctx, candidateRoutes, takerFeeMap, tokenIn.Denom, tokenOutDenom)
+	if err != nil {
+		return nil, err
+	}
+
+	// Compute direct quote
+	router := r.initializeRouter()
+	return router.getBestSingleRouteQuote(tokenIn, routes)
+}
+
 // GetCandidateRoutes implements domain.RouterUsecase.
 func (r *routerUseCaseImpl) GetCandidateRoutes(ctx context.Context, tokenInDenom string, tokenOutDenom string) (sqsdomain.CandidateRoutes, error) {
 	router := r.initializeRouter()


### PR DESCRIPTION
GET `/router/custom-direct-quote?tokenIn=<tokenIn>&tokenOutDenom=<tokenOutDenom>&poolIDs=<poolIDs>`

Description: returns the quote over route with the given poolIDs. If such route does not exist, returns error.
This endpoint does not use the router route search. As a result, it is not affected by the minimum liquidity parameter. As long as the pool exists on-chain, it will return a quote.

Parameters:
- `tokenIn` the string representation of the sdk.Coin for the token in
- `tokenOutDenom` the string representing the denom of the token out
- `poolID` comma-separated list of pool IDs
