### PR TITLE
feat: implement cosmwasm pools that query chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+<!--
+Guiding Principles:
+
+Changelogs are for humans, not machines.
+There should be an entry for every single version.
+The same types of changes should be grouped.
+Versions and sections should be linkable.
+The latest version comes first.
+The release date of each version is displayed.
+Mention whether you follow Semantic Versioning.
+
+Usage:
+
+Change log entries are to be added to the Unreleased section under the
+appropriate stanza (see below). Each entry should ideally include a tag and
+the Github issue reference in the following format:
+
+* (<tag>) \#<issue-number> message
+
+The issue numbers will later be link-ified during the release process so you do
+not have to worry about including a link manually, but you can if you wish.
+
+Types of changes (Stanzas):
+
+"Features" for new features.
+"Improvements" for changes in existing functionality.
+"Deprecated" for soon-to-be removed features.
+"Bug Fixes" for any bug fixes.
+"Client Breaking" for breaking CLI commands and REST routes used by end-users.
+"API Breaking" for breaking exported APIs used by developers building on SDK.
+"State Machine Breaking" for any changes that result in a different AppState
+given same genesisState and txList.
+Ref: https://keepachangelog.com/en/1.0.0/
+-->
+
+# Changelog
+
+## Unreleased
+
+* [#43](https://github.com/osmosis-labs/osmosis/pull/43) Implement generalized CosmWasm pools into router that interact with the chain for computing quotes. Expose spot price by pool ID API.

--- a/README.md
+++ b/README.md
@@ -389,6 +389,17 @@ This endpoint should be disabled in production.
 
 Parameters: none
 
+8. GET `/router/spot-price-pool/:id`
+
+Parameters:
+- `quoteAsset` the quote asset denom
+- `baseAsset` the base asset denom
+
+```bash
+curl "https://sqs.osmosis.zone/router/spot-price-pool/1212?quoteAsset=ibc/D189335C6E4A68B513C10AB227BF1C1D38C746766278BA3EEB4FB14124F1D858&baseAsset=ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+"1.000000000000000000000000000000000000"
+```
+
 ### System Resource
 
 1. GET `/healthcheck`

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ all pool data for performing the complex routing algorithm.
 Follow [this link](https://hackmd.io/@3DOBr1TJQ3mQAFDEO0BXgg/S1bsqPAr6) to find a guide on how to 
 integrate with the sidecar query server.
 
+## Custom CosmWasm Pools
+
+The sidecar query server supports custom CosmWasm pools. To enable this feature, the following
+
+
 ## Supported Endpoints
 
 ### Pools Resource

--- a/README.md
+++ b/README.md
@@ -18,8 +18,24 @@ integrate with the sidecar query server.
 
 ## Custom CosmWasm Pools
 
-The sidecar query server supports custom CosmWasm pools. To enable this feature, the following
+The sidecar query server supports custom CosmWasm pools.
+There are two options of integrating them into the Osmosis router:
+1. Implement a pool type similar to [transmuter](https://github.com/osmosis-labs/sqs/blob/e95c66e3ee6a22d57118c74a384253f016a9bb85/router/usecase/pools/routable_transmuter_pool.go#L19)
+   * This assumes that the pool quote and spot price logic is trivial enough for implementing
+   it directly in SQS without having to interact with the chain.
+2. Utilize a [generalized CosmWasm pool type](https://github.com/osmosis-labs/sqs/blob/437086c683f4f90d915f7e042617552c68410796/router/usecase/pools/routable_cw_pool.go#L24)
+   * This assumes that the pool quote and spot price logic is complex enough for requiring
+   interaction with the chain.
+   * For quotes and spot prices, SQS service would make network API queries to the chain.
+   * This is the simplest approach but it is less performant than the first option.
+   * Due to performance reasons, the routes containing these pools are not utilized in
+   more performant split quotes. Only direct quotes are supported.
 
+To enable support for either option, a [config.json](https://github.com/osmosis-labs/sqs/blob/437086c683f4f90d915f7e042617552c68410796/config.json#L22-L25)
+must be updated accordingly. For option 1, add a new field under `pools` and make a PR propagating
+this config to be able to create a new custom pool type similar to transmuter. For option 2, simply
+add your code id to `general-cosmwasm-code-ids` in this repository. Tag `@p0mvn` in the PR and
+follow up that the config is deployed to the sidecar query server service in production.
 
 ## Supported Endpoints
 

--- a/app/main.go
+++ b/app/main.go
@@ -89,7 +89,7 @@ func main() {
 	}
 	logger.Info("Starting sidecar query server")
 
-	sidecarQueryServer, err := NewSideCarQueryServer(encCfg.Marshaler, *config.Router, config.StorageHost, config.StoragePort, config.ServerAddress, config.ChainGRPCGatewayEndpoint, config.ServerTimeoutDurationSecs, logger)
+	sidecarQueryServer, err := NewSideCarQueryServer(encCfg.Marshaler, *config.Router, config.Pools, config.StorageHost, config.StoragePort, config.ServerAddress, config.ChainGRPCGatewayEndpoint, config.ServerTimeoutDurationSecs, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -143,7 +143,7 @@ func NewSideCarQueryServer(appCodec codec.Codec, routerConfig domain.RouterConfi
 	// Initialize pools repository, usecase and HTTP handler
 	poolsRepository := poolsredisrepo.New(appCodec, redisTxManager)
 	timeoutContext := time.Duration(useCaseTimeoutDuration) * time.Second
-	poolsUseCase := poolsUseCase.NewPoolsUsecase(timeoutContext, poolsRepository, redisTxManager)
+	poolsUseCase := poolsUseCase.NewPoolsUsecase(timeoutContext, poolsRepository, redisTxManager, &domain.PoolsConfig{})
 	poolsHttpDelivery.NewPoolsHandler(e, poolsUseCase)
 
 	// Create an overwrite route cache if enabled.

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -109,7 +109,7 @@ func (sqs *sideCarQueryServer) Start(context.Context) error {
 }
 
 // NewSideCarQueryServer creates a new sidecar query server (SQS).
-func NewSideCarQueryServer(appCodec codec.Codec, routerConfig domain.RouterConfig, dbHost, dbPort, sideCarQueryServerAddress, grpcAddress string, useCaseTimeoutDuration int, logger log.Logger) (SideCarQueryServer, error) {
+func NewSideCarQueryServer(appCodec codec.Codec, routerConfig domain.RouterConfig, poolsConfig *domain.PoolsConfig, dbHost, dbPort, sideCarQueryServerAddress, grpcAddress string, useCaseTimeoutDuration int, logger log.Logger) (SideCarQueryServer, error) {
 	// Setup echo server
 	e := echo.New()
 	middleware := middleware.InitMiddleware()
@@ -143,7 +143,7 @@ func NewSideCarQueryServer(appCodec codec.Codec, routerConfig domain.RouterConfi
 	// Initialize pools repository, usecase and HTTP handler
 	poolsRepository := poolsredisrepo.New(appCodec, redisTxManager)
 	timeoutContext := time.Duration(useCaseTimeoutDuration) * time.Second
-	poolsUseCase := poolsUseCase.NewPoolsUsecase(timeoutContext, poolsRepository, redisTxManager, &domain.PoolsConfig{})
+	poolsUseCase := poolsUseCase.NewPoolsUsecase(timeoutContext, poolsRepository, redisTxManager, poolsConfig, grpcAddress)
 	poolsHttpDelivery.NewPoolsHandler(e, poolsUseCase)
 
 	// Create an overwrite route cache if enabled.

--- a/app/sqs_config.go
+++ b/app/sqs_config.go
@@ -24,6 +24,9 @@ type Config struct {
 
 	// Router encapsulates the router config.
 	Router *domain.RouterConfig `mapstructure:"router"`
+
+	// Pools encapsulates the pools config.
+	Pools *domain.PoolsConfig `mapstructure:"pools"`
 }
 
 // DefaultConfig defines the default config for the sidecar query server.
@@ -50,5 +53,12 @@ var DefaultConfig = Config{
 		MinOSMOLiquidity:        10000, // 10_000 OSMO
 		RouteCacheEnabled:       false,
 		RouteCacheExpirySeconds: 600, // 10 minutes
+
+		EnableOverwriteRoutesCache: false,
+	},
+	Pools: &domain.PoolsConfig{
+		// This is what we have on mainnet as of Jan 2024.
+		TransmuterCodeIDs: []uint64{148},
+		AstroportCodeIDs:  []uint64{},
 	},
 }

--- a/app/sqs_config.go
+++ b/app/sqs_config.go
@@ -58,7 +58,7 @@ var DefaultConfig = Config{
 	},
 	Pools: &domain.PoolsConfig{
 		// This is what we have on mainnet as of Jan 2024.
-		TransmuterCodeIDs: []uint64{148},
-		AstroportCodeIDs:  []uint64{},
+		TransmuterCodeIDs:      []uint64{148},
+		GeneralCosmWasmCodeIDs: []uint64{},
 	},
 }

--- a/config.json
+++ b/config.json
@@ -20,8 +20,8 @@
       "route-cache-expiry-seconds": 600
     },
     "pools": {
-        "transmuter-code-id": [148],
-        "astroport-code-id": [149]
+        "transmuter-pool-ids": [148],
+        "astroport-code-ids": []
     },
     "enable-overwrite-routes-cache": true
   }

--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
     },
     "pools": {
         "transmuter-pool-ids": [148],
-        "astroport-code-ids": []
+        "general-cosmwasm-code-ids": []
     },
     "enable-overwrite-routes-cache": true
   }

--- a/config.json
+++ b/config.json
@@ -19,6 +19,10 @@
       "route-cache-enabled": true,
       "route-cache-expiry-seconds": 600
     },
+    "pools": {
+        "transmuter-code-id": [148],
+        "astroport-code-id": [149]
+    },
     "enable-overwrite-routes-cache": true
   }
   

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -25,6 +25,15 @@ func (e InvalidPoolTypeError) Error() string {
 	return "invalid pool type: " + string(e.PoolType)
 }
 
+// UnsupportedCosmWasmPoolTypeError is an error type for invalid cosmwasm pool type.
+type UnsupportedCosmWasmPoolTypeError struct {
+	PoolType int32
+}
+
+func (e UnsupportedCosmWasmPoolTypeError) Error() string {
+	return "unsupported pool type: " + string(e.PoolType)
+}
+
 type PoolNotFoundError struct {
 	PoolID uint64
 }

--- a/domain/mocks/pool_mock.go
+++ b/domain/mocks/pool_mock.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -72,7 +74,7 @@ func (mp *MockRoutablePool) GetSQSPoolModel() sqsdomain.SQSPool {
 }
 
 // CalculateTokenOutByTokenIn implements routerusecase.RoutablePool.
-func (mp *MockRoutablePool) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error) {
+func (mp *MockRoutablePool) CalculateTokenOutByTokenIn(_ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
 	// We allow the ability to mock out the token out amount.
 	if !mp.mockedTokenOut.IsNil() {
 		return mp.mockedTokenOut, nil

--- a/domain/mocks/pool_mock.go
+++ b/domain/mocks/pool_mock.go
@@ -153,6 +153,11 @@ func (mp *MockRoutablePool) GetType() poolmanagertypes.PoolType {
 	return mp.PoolType
 }
 
+// IsGeneralizedCosmWasmPool implements sqsdomain.RoutablePool.
+func (*MockRoutablePool) IsGeneralizedCosmWasmPool() bool {
+	return false
+}
+
 func deepCopyPool(mp *MockRoutablePool) *MockRoutablePool {
 	newDenoms := make([]string, len(mp.Denoms))
 	copy(newDenoms, mp.Denoms)

--- a/domain/mocks/pool_mock.go
+++ b/domain/mocks/pool_mock.go
@@ -29,7 +29,7 @@ type MockRoutablePool struct {
 }
 
 // CalcSpotPrice implements sqsdomain.RoutablePool.
-func (mp *MockRoutablePool) CalcSpotPrice(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+func (mp *MockRoutablePool) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	if mp.PoolType == poolmanagertypes.CosmWasm {
 		return osmomath.OneBigDec(), nil
 	}

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -38,7 +39,10 @@ func (pm *PoolsUsecaseMock) GetRoutesFromCandidates(ctx context.Context, candida
 			}
 
 			// TODO: note that taker fee is force set to zero
-			routablePool := pools.NewRoutablePool(foundPool, candidatePool.TokenOutDenom, osmomath.ZeroDec())
+			routablePool, err := pools.NewRoutablePool(foundPool, candidatePool.TokenOutDenom, osmomath.ZeroDec(), domain.CosmWasmCodeIDMaps{})
+			if err != nil {
+				return nil, err
+			}
 			routablePools = append(routablePools, routablePool)
 		}
 

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"cosmossdk.io/math"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
@@ -39,7 +40,7 @@ func (pm *PoolsUsecaseMock) GetRoutesFromCandidates(ctx context.Context, candida
 			}
 
 			// TODO: note that taker fee is force set to zero
-			routablePool, err := pools.NewRoutablePool(foundPool, candidatePool.TokenOutDenom, osmomath.ZeroDec(), domain.CosmWasmCodeIDMaps{})
+			routablePool, err := pools.NewRoutablePool(foundPool, candidatePool.TokenOutDenom, osmomath.ZeroDec(), domain.CosmWasmPoolRouterConfig{})
 			if err != nil {
 				return nil, err
 			}
@@ -66,6 +67,11 @@ func (pm *PoolsUsecaseMock) GetTickModelMap(ctx context.Context, poolIDs []uint6
 
 // GetPool implements mvc.PoolsUsecase.
 func (pm *PoolsUsecaseMock) GetPool(ctx context.Context, poolID uint64) (sqsdomain.PoolI, error) {
+	panic("unimplemented")
+}
+
+// GetPoolSpotPrice implements mvc.PoolsUsecase.
+func (*PoolsUsecaseMock) GetPoolSpotPrice(ctx context.Context, poolID uint64, takerFee math.LegacyDec, baseAsset, quoteAsset string) (osmomath.BigDec, error) {
 	panic("unimplemented")
 }
 

--- a/domain/mvc/pools.go
+++ b/domain/mvc/pools.go
@@ -3,6 +3,7 @@ package mvc
 import (
 	"context"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	"github.com/osmosis-labs/sqs/router/usecase/route"
@@ -19,4 +20,6 @@ type PoolsUsecase interface {
 	GetTickModelMap(ctx context.Context, poolIDs []uint64) (map[uint64]sqsdomain.TickModel, error)
 	// GetPool returns the pool with the given ID.
 	GetPool(ctx context.Context, poolID uint64) (sqsdomain.PoolI, error)
+	// GetPoolSpotPrice returns the spot price of the given pool given the taker fee, quote and base assets.
+	GetPoolSpotPrice(ctx context.Context, poolID uint64, takerFee osmomath.Dec, quoteAsset, baseAsset string) (osmomath.BigDec, error)
 }

--- a/domain/mvc/router.go
+++ b/domain/mvc/router.go
@@ -5,6 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 )
@@ -27,6 +28,8 @@ type RouterUsecase interface {
 	GetCandidateRoutes(ctx context.Context, tokenInDenom, tokenOutDenom string) (sqsdomain.CandidateRoutes, error)
 	// GetTakerFee returns the taker fee for all token pairs in a pool.
 	GetTakerFee(ctx context.Context, poolID uint64) ([]sqsdomain.TakerFeeForPair, error)
+	// GetPoolSpotPrice returns the spot price of a pool.
+	GetPoolSpotPrice(ctx context.Context, poolID uint64, quoteAsset, baseAsset string) (osmomath.BigDec, error)
 	// GetConfig returns the config for the SQS service
 	GetConfig() domain.RouterConfig
 	// GetCachedCandidateRoutes returns the candidate routes for the given tokenIn and tokenOutDenom from cache.

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -1,9 +1,11 @@
 package domain
 
-// code IDs for various implementations of the cosmwasm pool types
-type CosmWasmCodeIDMaps struct {
+// CosmWasmPoolRouterConfig is the config for the CosmWasm pools in the router
+type CosmWasmPoolRouterConfig struct {
 	// code IDs for the transmuter pool type
 	TransmuterCodeIDs map[uint64]struct{}
 	// code IDs for the astroport pool type
 	AstroportCodeIDs map[uint64]struct{}
+	// node URI
+	NodeURI string
 }

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -1,0 +1,9 @@
+package domain
+
+// code IDs for various implementations of the cosmwasm pool types
+type CosmWasmCodeIDMaps struct {
+	// code IDs for the transmuter pool type
+	TransmuterCodeIDs map[uint64]struct{}
+	// code IDs for the astroport pool type
+	AstroportCodeIDs map[uint64]struct{}
+}

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -4,8 +4,8 @@ package domain
 type CosmWasmPoolRouterConfig struct {
 	// code IDs for the transmuter pool type
 	TransmuterCodeIDs map[uint64]struct{}
-	// code IDs for the astroport pool type
-	AstroportCodeIDs map[uint64]struct{}
+	// code IDs for the generalized cosmwasm pool type
+	GeneralCosmWasmCodeIDs map[uint64]struct{}
 	// node URI
 	NodeURI string
 }

--- a/domain/route_test.go
+++ b/domain/route_test.go
@@ -1,6 +1,7 @@
 package domain_test
 
 import (
+	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -124,7 +125,7 @@ func (s *RouterTestSuite) TestPrepareResultPools() {
 		s.Run(name, func() {
 
 			// Note: token in is chosen arbitrarily since it is irrelevant for this test
-			_, _, err := tc.route.PrepareResultPools(sdk.NewCoin(DenomTwo, DefaultAmt0))
+			_, _, err := tc.route.PrepareResultPools(context.TODO(), sdk.NewCoin(DenomTwo, DefaultAmt0))
 			s.Require().NoError(err)
 
 			s.ValidateRoutePools(tc.expectedPools, tc.route.GetPools())

--- a/domain/router.go
+++ b/domain/router.go
@@ -14,8 +14,6 @@ type RoutableResultPool interface {
 
 type Route interface {
 	GetPools() []sqsdomain.RoutablePool
-	// AddPool adds pool to route.
-	AddPool(pool sqsdomain.PoolI, tokenOut string, takerFee osmomath.Dec)
 	// CalculateTokenOutByTokenIn calculates the token out amount given the token in amount.
 	// Returns error if the calculation fails.
 	CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error)
@@ -68,4 +66,9 @@ type RouterConfig struct {
 	RouteCacheExpirySeconds uint64 `mapstructure:"route-cache-expiry-seconds"`
 	// Flag indicating whether we should have a cache for overwrite routes enabled.
 	EnableOverwriteRoutesCache bool `mapstructure:"enable-overwrite-routes-cache"`
+}
+
+type PoolsConfig struct {
+	TransmuterCodeIDs []uint64 `mapstructure:"transmuter-pool-ids"`
+	AstroportCodeIDs  []uint64 `mapstructure:"astroport-pool-ids"`
 }

--- a/domain/router.go
+++ b/domain/router.go
@@ -15,6 +15,12 @@ type RoutableResultPool interface {
 }
 
 type Route interface {
+	// ContainsGeneralizedCosmWasmPool returns true if the route contains a generalized cosmwasm pool.
+	// We track whether a route contains a generalized cosmwasm pool
+	// so that we can exclude it from split quote logic.
+	// The reason for this is that making network requests to chain is expensive.
+	// As a result, we want to minimize the number of requests we make.
+	ContainsGeneralizedCosmWasmPool() bool
 	GetPools() []sqsdomain.RoutablePool
 	// CalculateTokenOutByTokenIn calculates the token out amount given the token in amount.
 	// Returns error if the calculation fails.
@@ -71,6 +77,6 @@ type RouterConfig struct {
 }
 
 type PoolsConfig struct {
-	TransmuterCodeIDs []uint64 `mapstructure:"transmuter-pool-ids"`
-	AstroportCodeIDs  []uint64 `mapstructure:"astroport-pool-ids"`
+	TransmuterCodeIDs      []uint64 `mapstructure:"transmuter-pool-ids"`
+	GeneralCosmWasmCodeIDs []uint64 `mapstructure:"general-cosmwasm-pool-ids"`
 }

--- a/domain/router.go
+++ b/domain/router.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
@@ -16,7 +18,7 @@ type Route interface {
 	GetPools() []sqsdomain.RoutablePool
 	// CalculateTokenOutByTokenIn calculates the token out amount given the token in amount.
 	// Returns error if the calculation fails.
-	CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error)
+	CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error)
 
 	GetTokenOutDenom() string
 
@@ -27,7 +29,7 @@ type Route interface {
 	// Note that it mutates the route.
 	// Computes the spot price of the route.
 	// Returns the spot price before swap and effective spot price.
-	PrepareResultPools(tokenIn sdk.Coin) (osmomath.Dec, osmomath.Dec, error)
+	PrepareResultPools(ctx context.Context, tokenIn sdk.Coin) (osmomath.Dec, osmomath.Dec, error)
 
 	String() string
 }
@@ -47,7 +49,7 @@ type Quote interface {
 
 	// PrepareResult mutates the quote to prepare
 	// it with the data formatted for output to the client.
-	PrepareResult() ([]SplitRoute, osmomath.Dec)
+	PrepareResult(ctx context.Context) ([]SplitRoute, osmomath.Dec)
 
 	String() string
 }

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -113,7 +113,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 			expectedRoutes: []route.RouteImpl{
 				{
 					Pools: []sqsdomain.RoutablePool{
-						s.newRoutablePool(defaultPool, denomTwo, defaultTakerFee, domain.CosmWasmCodeIDMaps{}),
+						s.newRoutablePool(defaultPool, denomTwo, defaultTakerFee, domain.CosmWasmPoolRouterConfig{}),
 					},
 				},
 			},
@@ -133,7 +133,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 			expectedRoutes: []route.RouteImpl{
 				{
 					Pools: []sqsdomain.RoutablePool{
-						s.newRoutablePool(defaultPool, denomTwo, sqsdomain.DefaultTakerFee, domain.CosmWasmCodeIDMaps{}),
+						s.newRoutablePool(defaultPool, denomTwo, sqsdomain.DefaultTakerFee, domain.CosmWasmPoolRouterConfig{}),
 					},
 				},
 			},
@@ -170,7 +170,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 			}
 
 			// Create pools use case
-			poolsUsecase := usecase.NewPoolsUsecase(time.Second, poolsRepository, nil, &domain.PoolsConfig{})
+			poolsUsecase := usecase.NewPoolsUsecase(time.Second, poolsRepository, nil, &domain.PoolsConfig{}, "node-uri-placeholder")
 
 			// System under test
 			actualRoutes, err := poolsUsecase.GetRoutesFromCandidates(context.Background(), tc.candidateRoutes, tc.takerFeeMap, tc.tokenInDenom, tc.tokenOutDenom)
@@ -207,7 +207,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 	}
 }
 
-func (s *PoolsUsecaseTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolIDs domain.CosmWasmCodeIDMaps) sqsdomain.RoutablePool {
+func (s *PoolsUsecaseTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolIDs domain.CosmWasmPoolRouterConfig) sqsdomain.RoutablePool {
 	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolIDs)
 	s.Require().NoError(err)
 	return routablePool

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -192,9 +192,9 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 				// helper method for validation.
 				// Note token in is chosen arbitrarily since it is irrelevant for this test
 				tokenIn := sdk.NewCoin(tc.tokenInDenom, sdk.NewInt(100))
-				_, _, err := actualRoute.PrepareResultPools(tokenIn)
+				_, _, err := actualRoute.PrepareResultPools(context.TODO(), tokenIn)
 				s.Require().NoError(err)
-				_, _, err = expectedRoute.PrepareResultPools(tokenIn)
+				_, _, err = expectedRoute.PrepareResultPools(context.TODO(), tokenIn)
 				s.Require().NoError(err)
 
 				// Validates:

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"github.com/stretchr/testify/suite"
 
@@ -112,7 +113,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 			expectedRoutes: []route.RouteImpl{
 				{
 					Pools: []sqsdomain.RoutablePool{
-						pools.NewRoutablePool(defaultPool, denomTwo, defaultTakerFee),
+						s.newRoutablePool(defaultPool, denomTwo, defaultTakerFee, domain.CosmWasmCodeIDMaps{}),
 					},
 				},
 			},
@@ -132,7 +133,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 			expectedRoutes: []route.RouteImpl{
 				{
 					Pools: []sqsdomain.RoutablePool{
-						pools.NewRoutablePool(defaultPool, denomTwo, sqsdomain.DefaultTakerFee),
+						s.newRoutablePool(defaultPool, denomTwo, sqsdomain.DefaultTakerFee, domain.CosmWasmCodeIDMaps{}),
 					},
 				},
 			},
@@ -169,7 +170,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 			}
 
 			// Create pools use case
-			poolsUsecase := usecase.NewPoolsUsecase(time.Second, poolsRepository, nil)
+			poolsUsecase := usecase.NewPoolsUsecase(time.Second, poolsRepository, nil, &domain.PoolsConfig{})
 
 			// System under test
 			actualRoutes, err := poolsUsecase.GetRoutesFromCandidates(context.Background(), tc.candidateRoutes, tc.takerFeeMap, tc.tokenInDenom, tc.tokenOutDenom)
@@ -204,4 +205,10 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 			}
 		})
 	}
+}
+
+func (s *PoolsUsecaseTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolIDs domain.CosmWasmCodeIDMaps) sqsdomain.RoutablePool {
+	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolIDs)
+	s.Require().NoError(err)
+	return routablePool
 }

--- a/router/delivery/http/router_handler.go
+++ b/router/delivery/http/router_handler.go
@@ -68,7 +68,7 @@ func (a *RouterHandler) GetOptimalQuote(c echo.Context) error {
 		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
 	}
 
-	quote.PrepareResult()
+	quote.PrepareResult(ctx)
 
 	err = c.JSON(http.StatusOK, quote)
 	if err != nil {
@@ -92,7 +92,7 @@ func (a *RouterHandler) GetBestSingleRouteQuote(c echo.Context) error {
 		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
 	}
 
-	quote.PrepareResult()
+	quote.PrepareResult(ctx)
 
 	return c.JSON(http.StatusOK, quote)
 }
@@ -123,7 +123,7 @@ func (a *RouterHandler) GetCustomQuote(c echo.Context) error {
 		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
 	}
 
-	quote.PrepareResult()
+	quote.PrepareResult(ctx)
 
 	return c.JSON(http.StatusOK, quote)
 }
@@ -154,7 +154,7 @@ func (a *RouterHandler) GetDirectCustomQuote(c echo.Context) error {
 		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
 	}
 
-	quote.PrepareResult()
+	quote.PrepareResult(ctx)
 
 	return c.JSON(http.StatusOK, quote)
 }

--- a/router/usecase/export_test.go
+++ b/router/usecase/export_test.go
@@ -35,8 +35,8 @@ func (r *routerUseCaseImpl) HandleRoutes(ctx context.Context, router *Router, to
 	return r.handleCandidateRoutes(ctx, router, tokenInDenom, tokenOutDenom)
 }
 
-func (r *Router) EstimateAndRankSingleRouteQuote(routes []route.RouteImpl, tokenIn sdk.Coin) (domain.Quote, []RouteWithOutAmount, error) {
-	return r.estimateAndRankSingleRouteQuote(routes, tokenIn)
+func (r *Router) EstimateAndRankSingleRouteQuote(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Coin) (domain.Quote, []RouteWithOutAmount, error) {
+	return r.estimateAndRankSingleRouteQuote(ctx, routes, tokenIn)
 }
 
 // GetSortedPoolIDs returns the sorted pool IDs.

--- a/router/usecase/optimized_routes.go
+++ b/router/usecase/optimized_routes.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"context"
 	"errors"
 	"sort"
 
@@ -17,7 +18,7 @@ import (
 
 // getSingleRouteQuote returns the best single route quote for the given tokenIn and tokenOutDenom.
 // Returns error if router repository is not set on the router.
-func (r *Router) getBestSingleRouteQuote(tokenIn sdk.Coin, routes []route.RouteImpl) (quote domain.Quote, err error) {
+func (r *Router) getBestSingleRouteQuote(ctx context.Context, tokenIn sdk.Coin, routes []route.RouteImpl) (quote domain.Quote, err error) {
 	if r.routerRepository == nil {
 		return nil, ErrNilRouterRepository
 	}
@@ -25,7 +26,7 @@ func (r *Router) getBestSingleRouteQuote(tokenIn sdk.Coin, routes []route.RouteI
 		return nil, ErrNilPoolsRepository
 	}
 
-	bestSingleRouteQuote, _, err := r.estimateAndRankSingleRouteQuote(routes, tokenIn)
+	bestSingleRouteQuote, _, err := r.estimateAndRankSingleRouteQuote(ctx, routes, tokenIn)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +37,7 @@ func (r *Router) getBestSingleRouteQuote(tokenIn sdk.Coin, routes []route.RouteI
 // Returns best quote as well as all routes sorted by amount out and error if any.
 // CONTRACT: router repository must be set on the router.
 // CONTRACT: pools reporitory must be set on the router
-func (r *Router) estimateAndRankSingleRouteQuote(routes []route.RouteImpl, tokenIn sdk.Coin) (quote domain.Quote, sortedRoutesByAmtOut []RouteWithOutAmount, err error) {
+func (r *Router) estimateAndRankSingleRouteQuote(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Coin) (quote domain.Quote, sortedRoutesByAmtOut []RouteWithOutAmount, err error) {
 	if len(routes) == 0 {
 		return nil, nil, errors.New("no routes were provided")
 	}
@@ -46,7 +47,7 @@ func (r *Router) estimateAndRankSingleRouteQuote(routes []route.RouteImpl, token
 	errors := []error{}
 
 	for _, route := range routes {
-		directRouteTokenOut, err := route.CalculateTokenOutByTokenIn(tokenIn)
+		directRouteTokenOut, err := route.CalculateTokenOutByTokenIn(ctx, tokenIn)
 		if err != nil {
 			r.logger.Debug("skipping single route due to error in estimate", zap.Error(err))
 			errors = append(errors, err)

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -202,7 +202,7 @@ func (s *RouterTestSuite) TestGetBestSplitRoutesQuote() {
 
 			r := routerusecase.NewRouter([]uint64{}, 0, 0, 0, tc.maxSplitIterations, 0, logger)
 
-			quote, err := r.GetSplitQuote(tc.routes, tc.tokenIn)
+			quote, err := r.GetSplitQuote(context.TODO(), tc.routes, tc.tokenIn)
 
 			if tc.expectError != nil {
 				s.Require().Error(err)

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -707,7 +707,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuote_Mainnet_UOSMOU
 		Pools:     router.GetSortedPools(),
 		TickModel: tickMap,
 	}
-	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil, &domain.PoolsConfig{})
+	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil, &domain.PoolsConfig{}, "node-uri-placeholder")
 	routerusecase.WithPoolsUsecase(router, poolsUsecase)
 
 	routerUsecase := routerusecase.NewRouterUsecase(time.Hour, &routerRepositoryMock, poolsUsecase, config, &log.NoOpLogger{}, cache.New(), cache.NewNoOpRoutesOverwrite())
@@ -759,7 +759,7 @@ func (s *RouterTestSuite) setupRouterAndPoolsUsecase(router *routerusecase.Route
 		Pools:     router.GetSortedPools(),
 		TickModel: tickMap,
 	}
-	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil, &domain.PoolsConfig{})
+	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil, &domain.PoolsConfig{}, "node-uri-placeholder")
 	routerusecase.WithPoolsUsecase(router, poolsUsecase)
 
 	routerUsecase := usecase.NewRouterUsecase(time.Hour, &routerRepositoryMock, poolsUsecase, defaultRouterConfig, &log.NoOpLogger{}, rankedRoutesCache, routesOverwrite)

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -707,7 +707,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuote_Mainnet_UOSMOU
 		Pools:     router.GetSortedPools(),
 		TickModel: tickMap,
 	}
-	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil)
+	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil, &domain.PoolsConfig{})
 	routerusecase.WithPoolsUsecase(router, poolsUsecase)
 
 	routerUsecase := routerusecase.NewRouterUsecase(time.Hour, &routerRepositoryMock, poolsUsecase, config, &log.NoOpLogger{}, cache.New(), cache.NewNoOpRoutesOverwrite())
@@ -759,7 +759,7 @@ func (s *RouterTestSuite) setupRouterAndPoolsUsecase(router *routerusecase.Route
 		Pools:     router.GetSortedPools(),
 		TickModel: tickMap,
 	}
-	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil)
+	poolsUsecase := poolsusecase.NewPoolsUsecase(time.Hour, &poolsRepositoryMock, nil, &domain.PoolsConfig{})
 	routerusecase.WithPoolsUsecase(router, poolsUsecase)
 
 	routerUsecase := usecase.NewRouterUsecase(time.Hour, &routerRepositoryMock, poolsUsecase, defaultRouterConfig, &log.NoOpLogger{}, rankedRoutesCache, routesOverwrite)

--- a/router/usecase/pools/cosmwasm_utils.go
+++ b/router/usecase/pools/cosmwasm_utils.go
@@ -1,0 +1,45 @@
+package pools
+
+import (
+	"context"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/osmosis-labs/sqs/sqsdomain/json"
+)
+
+// initializeWasmClient initializes the wasm client given the node URI
+// Returns error if fails to initialize the client
+func initializeWasmClient(nodeURI string) (wasmtypes.QueryClient, error) {
+	clientContext := client.Context{}
+	httpClient, err := client.NewClientFromNode(nodeURI)
+	if err != nil {
+		return nil, err
+	}
+	clientContext = clientContext.WithClient(httpClient)
+	wasmClient := wasmtypes.NewQueryClient(clientContext)
+
+	return wasmClient, nil
+}
+
+// queryCosmwasmContract queries the cosmwasm contract given the contract address, request and response
+// Returns error if fails to query the contract, serialize request or deserialize response.
+func queryCosmwasmContract[T any, K any](ctx context.Context, wasmClient wasmtypes.QueryClient, contractAddress string, cosmWasmRequest T, cosmWasmResponse K) error {
+	// Marshal the message
+	bz, err := json.Marshal(cosmWasmRequest)
+	if err != nil {
+		return err
+	}
+
+	// Query the pool
+	queryResponse, err := wasmClient.SmartContractState(ctx, &wasmtypes.QuerySmartContractStateRequest{
+		Address:   contractAddress,
+		QueryData: bz,
+	})
+
+	if err := json.Unmarshal(queryResponse.Data, cosmWasmResponse); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/router/usecase/pools/cosmwasm_utils.go
+++ b/router/usecase/pools/cosmwasm_utils.go
@@ -36,6 +36,9 @@ func queryCosmwasmContract[T any, K any](ctx context.Context, wasmClient wasmtyp
 		Address:   contractAddress,
 		QueryData: bz,
 	})
+	if err != nil {
+		return err
+	}
 
 	if err := json.Unmarshal(queryResponse.Data, cosmWasmResponse); err != nil {
 		return err

--- a/router/usecase/pools/pool_factory.go
+++ b/router/usecase/pools/pool_factory.go
@@ -15,7 +15,7 @@ import (
 
 // NewRoutablePool creates a new RoutablePool.
 // Panics if pool is of invalid type or if does not contain tick data when a concentrated pool.
-func NewRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec) sqsdomain.RoutablePool {
+func NewRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolIDs domain.CosmWasmCodeIDMaps) (sqsdomain.RoutablePool, error) {
 	poolType := pool.GetType()
 	chainPool := pool.GetUnderlyingPool()
 	if poolType == poolmanagertypes.Concentrated {
@@ -38,7 +38,7 @@ func NewRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmoma
 			TickModel:     tickModel,
 			TokenOutDenom: tokenOutDenom,
 			TakerFee:      takerFee,
-		}
+		}, nil
 	}
 
 	if poolType == poolmanagertypes.Balancer {
@@ -57,11 +57,19 @@ func NewRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmoma
 			ChainPool:     balancerPool,
 			TokenOutDenom: tokenOutDenom,
 			TakerFee:      takerFee,
-		}
+		}, nil
 	}
 
-	if pool.GetType() == poolmanagertypes.CosmWasm {
-		cosmwasmPool, ok := chainPool.(*cwpoolmodel.CosmWasmPool)
+	if pool.GetType() == poolmanagertypes.Stableswap {
+		// Must be stableswap
+		if poolType != poolmanagertypes.Stableswap {
+			panic(domain.InvalidPoolTypeError{
+				PoolType: int32(poolType),
+			})
+		}
+
+		// Check if pools is balancer
+		stableswapPool, ok := chainPool.(*stableswap.Pool)
 		if !ok {
 			panic(domain.FailedToCastPoolModelError{
 				ExpectedModel: poolmanagertypes.PoolType_name[int32(poolmanagertypes.Balancer)],
@@ -69,36 +77,58 @@ func NewRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmoma
 			})
 		}
 
-		sqsPoolModel := pool.GetSQSPoolModel().SpreadFactor
+		return &routableStableswapPoolImpl{
+			ChainPool:     stableswapPool,
+			TokenOutDenom: tokenOutDenom,
+			TakerFee:      takerFee,
+		}, nil
+	}
+
+	return newRoutableCosmWasmPool(pool, cosmWasmPoolIDs, tokenOutDenom, takerFee)
+}
+
+// newRoutableCosmWasmPool creates a new RoutablePool for CosmWasm pools.
+// Panics if the given pool is not a cosmwasm pool or if the
+func newRoutableCosmWasmPool(pool sqsdomain.PoolI, cosmWasmPoolIDs domain.CosmWasmCodeIDMaps, tokenOutDenom string, takerFee osmomath.Dec) (sqsdomain.RoutablePool, error) {
+	chainPool := pool.GetUnderlyingPool()
+	poolType := pool.GetType()
+
+	cosmwasmPool, ok := chainPool.(*cwpoolmodel.CosmWasmPool)
+	if !ok {
+		return nil, domain.FailedToCastPoolModelError{
+			ExpectedModel: poolmanagertypes.PoolType_name[int32(poolmanagertypes.Balancer)],
+			ActualModel:   poolmanagertypes.PoolType_name[int32(poolType)],
+		}
+	}
+
+	_, isTransmuter := cosmWasmPoolIDs.TransmuterCodeIDs[cosmwasmPool.CodeId]
+	if isTransmuter {
+		spreadFactor := pool.GetSQSPoolModel().SpreadFactor
 
 		return &routableTransmuterPoolImpl{
 			ChainPool:     cosmwasmPool,
 			Balances:      pool.GetSQSPoolModel().Balances,
 			TokenOutDenom: tokenOutDenom,
 			TakerFee:      takerFee,
-			SpreadFactor:  sqsPoolModel,
-		}
+			SpreadFactor:  spreadFactor,
+		}, nil
 	}
 
-	// Must be stableswap
-	if poolType != poolmanagertypes.Stableswap {
-		panic(domain.InvalidPoolTypeError{
-			PoolType: int32(poolType),
-		})
+	_, isAstroport := cosmWasmPoolIDs.AstroportCodeIDs[cosmwasmPool.CodeId]
+	if isAstroport {
+		spreadFactor := pool.GetSQSPoolModel().SpreadFactor
+
+		// introduce custom anstroport implementation
+		return &routableTransmuterPoolImpl{
+			ChainPool:     cosmwasmPool,
+			Balances:      pool.GetSQSPoolModel().Balances,
+			TokenOutDenom: tokenOutDenom,
+			TakerFee:      takerFee,
+			SpreadFactor:  spreadFactor,
+		}, nil
 	}
 
-	// Check if pools is balancer
-	stableswapPool, ok := chainPool.(*stableswap.Pool)
-	if !ok {
-		panic(domain.FailedToCastPoolModelError{
-			ExpectedModel: poolmanagertypes.PoolType_name[int32(poolmanagertypes.Balancer)],
-			ActualModel:   poolmanagertypes.PoolType_name[int32(poolType)],
-		})
-	}
-
-	return &routableStableswapPoolImpl{
-		ChainPool:     stableswapPool,
-		TokenOutDenom: tokenOutDenom,
-		TakerFee:      takerFee,
+	return nil, domain.UnsupportedCosmWasmPoolTypeError{
+		PoolType: int32(poolType),
 	}
 }

--- a/router/usecase/pools/pool_factory.go
+++ b/router/usecase/pools/pool_factory.go
@@ -121,8 +121,8 @@ func newRoutableCosmWasmPool(pool sqsdomain.PoolI, cosmWasmConfig domain.CosmWas
 		return nil, err
 	}
 
-	_, isAstroport := cosmWasmConfig.AstroportCodeIDs[cosmwasmPool.CodeId]
-	if isAstroport {
+	_, isGeneralizedCosmWasmPool := cosmWasmConfig.GeneralCosmWasmCodeIDs[cosmwasmPool.CodeId]
+	if isGeneralizedCosmWasmPool {
 		spreadFactor := pool.GetSQSPoolModel().SpreadFactor
 
 		// for most other cosm wasm pools, interaction with the chain will

--- a/router/usecase/pools/routable_balancer_pool.go
+++ b/router/usecase/pools/routable_balancer_pool.go
@@ -1,6 +1,7 @@
 package pools
 
 import (
+	"context"
 	"fmt"
 
 	"cosmossdk.io/math"
@@ -24,7 +25,7 @@ type routableBalancerPoolImpl struct {
 }
 
 // CalculateTokenOutByTokenIn implements RoutablePool.
-func (r *routableBalancerPoolImpl) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error) {
+func (r *routableBalancerPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
 	tokenOut, err := r.ChainPool.CalcOutAmtGivenIn(sdk.Context{}, sdk.NewCoins(tokenIn), r.TokenOutDenom, r.GetSpreadFactor())
 	if err != nil {
 		return sdk.Coin{}, err

--- a/router/usecase/pools/routable_balancer_pool.go
+++ b/router/usecase/pools/routable_balancer_pool.go
@@ -89,3 +89,8 @@ func (r *routableBalancerPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom 
 	}
 	return spotPrice, nil
 }
+
+// IsGeneralizedCosmWasmPool implements sqsdomain.RoutablePool.
+func (*routableBalancerPoolImpl) IsGeneralizedCosmWasmPool() bool {
+	return false
+}

--- a/router/usecase/pools/routable_balancer_pool.go
+++ b/router/usecase/pools/routable_balancer_pool.go
@@ -82,7 +82,7 @@ func (*routableBalancerPoolImpl) GetType() poolmanagertypes.PoolType {
 }
 
 // CalcSpotPrice implements sqsdomain.RoutablePool.
-func (r *routableBalancerPoolImpl) CalcSpotPrice(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+func (r *routableBalancerPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	spotPrice, err := r.ChainPool.SpotPrice(sdk.Context{}, quoteDenom, baseDenom)
 	if err != nil {
 		return osmomath.BigDec{}, err

--- a/router/usecase/pools/routable_concentrated_pool.go
+++ b/router/usecase/pools/routable_concentrated_pool.go
@@ -203,3 +203,8 @@ func (r *routableConcentratedPoolImpl) CalcSpotPrice(ctx context.Context, baseDe
 	}
 	return spotPrice, nil
 }
+
+// IsGeneralizedCosmWasmPool implements sqsdomain.RoutablePool.
+func (*routableConcentratedPoolImpl) IsGeneralizedCosmWasmPool() bool {
+	return false
+}

--- a/router/usecase/pools/routable_concentrated_pool.go
+++ b/router/usecase/pools/routable_concentrated_pool.go
@@ -196,7 +196,7 @@ func (r *routableConcentratedPoolImpl) SetTokenOutDenom(tokenOutDenom string) {
 }
 
 // CalcSpotPrice implements sqsdomain.RoutablePool.
-func (r *routableConcentratedPoolImpl) CalcSpotPrice(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+func (r *routableConcentratedPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	spotPrice, err := r.ChainPool.SpotPrice(sdk.Context{}, quoteDenom, baseDenom)
 	if err != nil {
 		return osmomath.BigDec{}, err

--- a/router/usecase/pools/routable_concentrated_pool.go
+++ b/router/usecase/pools/routable_concentrated_pool.go
@@ -1,6 +1,7 @@
 package pools
 
 import (
+	"context"
 	"fmt"
 
 	"cosmossdk.io/math"
@@ -61,7 +62,7 @@ func (r *routableConcentratedPoolImpl) GetTakerFee() math.LegacyDec {
 // - tick model has no liquidity flag set
 // - the current sqrt price is zero
 // - rans out of ticks during swap (token in is too high for liquidity in the pool)
-func (r *routableConcentratedPoolImpl) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error) {
+func (r *routableConcentratedPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
 	concentratedPool := r.ChainPool
 	tickModel := r.TickModel
 

--- a/router/usecase/pools/routable_concentrated_pool_test.go
+++ b/router/usecase/pools/routable_concentrated_pool_test.go
@@ -87,7 +87,8 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 					PoolDenoms:            []string{"foo", "bar"},
 				},
 			}
-			routablePool := pools.NewRoutablePool(poolWrapper, tc.TokenOutDenom, noTakerFee)
+			routablePool, err := pools.NewRoutablePool(poolWrapper, tc.TokenOutDenom, noTakerFee, domain.CosmWasmCodeIDMaps{})
+			s.Require().NoError(err)
 
 			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(tc.TokenIn)
 

--- a/router/usecase/pools/routable_concentrated_pool_test.go
+++ b/router/usecase/pools/routable_concentrated_pool_test.go
@@ -1,6 +1,7 @@
 package pools_test
 
 import (
+	"context"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -90,7 +91,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 			routablePool, err := pools.NewRoutablePool(poolWrapper, tc.TokenOutDenom, noTakerFee, domain.CosmWasmCodeIDMaps{})
 			s.Require().NoError(err)
 
-			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(tc.TokenIn)
+			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(context.TODO(), tc.TokenIn)
 
 			s.Require().NoError(err)
 			s.Require().Equal(tc.ExpectedTokenOut.String(), tokenOut.String())
@@ -268,7 +269,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Erro
 				TakerFee:      osmomath.ZeroDec(),
 			}
 
-			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(tc.tokenIn)
+			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(context.TODO(), tc.tokenIn)
 
 			if tc.expectError != nil {
 				s.Require().Error(err)

--- a/router/usecase/pools/routable_concentrated_pool_test.go
+++ b/router/usecase/pools/routable_concentrated_pool_test.go
@@ -88,7 +88,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 					PoolDenoms:            []string{"foo", "bar"},
 				},
 			}
-			routablePool, err := pools.NewRoutablePool(poolWrapper, tc.TokenOutDenom, noTakerFee, domain.CosmWasmCodeIDMaps{})
+			routablePool, err := pools.NewRoutablePool(poolWrapper, tc.TokenOutDenom, noTakerFee, domain.CosmWasmPoolRouterConfig{})
 			s.Require().NoError(err)
 
 			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(context.TODO(), tc.TokenIn)
@@ -273,7 +273,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Erro
 
 			if tc.expectError != nil {
 				s.Require().Error(err)
-				s.Require().ErrorIs(err, tc.expectError)
+				s.Require().ErrorContains(err, tc.expectError.Error())
 				return
 			}
 			s.Require().NoError(err)

--- a/router/usecase/pools/routable_cw_pool.go
+++ b/router/usecase/pools/routable_cw_pool.go
@@ -85,7 +85,7 @@ func (r *routableCosmWasmPoolImpl) GetTokenOutDenom() string {
 
 // String implements sqsdomain.RoutablePool.
 func (r *routableCosmWasmPoolImpl) String() string {
-	return fmt.Sprintf("pool (%d), pool type (%d) Astroport, pool denoms (%v), token out (%s)", r.ChainPool.PoolId, poolmanagertypes.CosmWasm, r.GetPoolDenoms(), r.TokenOutDenom)
+	return fmt.Sprintf("pool (%d), pool type (%d) Generalized CosmWasm, pool denoms (%v), token out (%s)", r.ChainPool.PoolId, poolmanagertypes.CosmWasm, r.GetPoolDenoms(), r.TokenOutDenom)
 }
 
 // ChargeTakerFeeExactIn implements sqsdomain.RoutablePool.
@@ -120,4 +120,9 @@ func (r *routableCosmWasmPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom 
 	}
 
 	return osmomath.MustNewBigDecFromStr(response.SpotPrice), nil
+}
+
+// IsGeneralizedCosmWasmPool implements sqsdomain.RoutablePool.
+func (*routableCosmWasmPoolImpl) IsGeneralizedCosmWasmPool() bool {
+	return true
 }

--- a/router/usecase/pools/routable_cw_pool.go
+++ b/router/usecase/pools/routable_cw_pool.go
@@ -1,0 +1,123 @@
+package pools
+
+import (
+	"context"
+	"fmt"
+
+	"cosmossdk.io/math"
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/sqsdomain"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v21/x/cosmwasmpool/cosmwasm/msg"
+	cwpoolmodel "github.com/osmosis-labs/osmosis/v21/x/cosmwasmpool/model"
+	"github.com/osmosis-labs/osmosis/v21/x/poolmanager"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v21/x/poolmanager/types"
+)
+
+var _ sqsdomain.RoutablePool = &routableCosmWasmPoolImpl{}
+
+// routableCosmWasmPool is an implemenation of the cosm wasm pool
+// that interacts with the chain for quotes and spot price.
+type routableCosmWasmPoolImpl struct {
+	ChainPool     *cwpoolmodel.CosmWasmPool "json:\"pool\""
+	Balances      sdk.Coins                 "json:\"balances\""
+	TokenOutDenom string                    "json:\"token_out_denom\""
+	TakerFee      osmomath.Dec              "json:\"taker_fee\""
+	SpreadFactor  osmomath.Dec              "json:\"spread_factor\""
+	wasmClient    wasmtypes.QueryClient     "json:\"-\""
+}
+
+// GetId implements sqsdomain.RoutablePool.
+func (r *routableCosmWasmPoolImpl) GetId() uint64 {
+	return r.ChainPool.PoolId
+}
+
+// GetPoolDenoms implements sqsdomain.RoutablePool.
+func (r *routableCosmWasmPoolImpl) GetPoolDenoms() []string {
+	return r.Balances.Denoms()
+}
+
+// GetType implements sqsdomain.RoutablePool.
+func (*routableCosmWasmPoolImpl) GetType() poolmanagertypes.PoolType {
+	return poolmanagertypes.CosmWasm
+}
+
+// GetSpreadFactor implements sqsdomain.RoutablePool.
+func (r *routableCosmWasmPoolImpl) GetSpreadFactor() math.LegacyDec {
+	return r.SpreadFactor
+}
+
+// CalculateTokenOutByTokenIn implements sqsdomain.RoutablePool.
+// It calculates the amount of token out given the amount of token in for a transmuter pool.
+// Transmuter pool allows no slippage swaps. It just returns the same amount of token out as token in
+// Returns error if:
+// - the underlying chain pool set on the routable pool is not of transmuter type
+// - the token in amount is greater than the balance of the token in
+// - the token in amount is greater than the balance of the token out
+func (r *routableCosmWasmPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
+	poolType := r.GetType()
+
+	// Ensure that the pool is cosmwasm
+	if poolType != poolmanagertypes.CosmWasm {
+		return sdk.Coin{}, domain.InvalidPoolTypeError{PoolType: int32(poolType)}
+	}
+
+	// Configure the calc query message
+	calcMessage := msg.NewCalcOutAmtGivenInRequest(tokenIn, r.TokenOutDenom, r.SpreadFactor)
+
+	calcOutAmtGivenInResponse := msg.CalcOutAmtGivenInResponse{}
+	if err := queryCosmwasmContract(ctx, r.wasmClient, r.ChainPool.ContractAddress, &calcMessage, &calcOutAmtGivenInResponse); err != nil {
+		return sdk.Coin{}, err
+	}
+
+	// No slippage swaps - just return the same amount of token out as token in
+	// as long as there is enough liquidity in the pool.
+	return calcOutAmtGivenInResponse.TokenOut, nil
+}
+
+// GetTokenOutDenom implements RoutablePool.
+func (r *routableCosmWasmPoolImpl) GetTokenOutDenom() string {
+	return r.TokenOutDenom
+}
+
+// String implements sqsdomain.RoutablePool.
+func (r *routableCosmWasmPoolImpl) String() string {
+	return fmt.Sprintf("pool (%d), pool type (%d) Astroport, pool denoms (%v), token out (%s)", r.ChainPool.PoolId, poolmanagertypes.CosmWasm, r.GetPoolDenoms(), r.TokenOutDenom)
+}
+
+// ChargeTakerFeeExactIn implements sqsdomain.RoutablePool.
+// Returns tokenInAmount and does not charge any fee for transmuter pools.
+func (r *routableCosmWasmPoolImpl) ChargeTakerFeeExactIn(tokenIn sdk.Coin) (inAmountAfterFee sdk.Coin) {
+	tokenInAfterTakerFee, _ := poolmanager.CalcTakerFeeExactIn(tokenIn, r.GetTakerFee())
+	return tokenInAfterTakerFee
+}
+
+// GetTakerFee implements sqsdomain.RoutablePool.
+func (r *routableCosmWasmPoolImpl) GetTakerFee() math.LegacyDec {
+	return r.TakerFee
+}
+
+// SetTokenOutDenom implements sqsdomain.RoutablePool.
+func (r *routableCosmWasmPoolImpl) SetTokenOutDenom(tokenOutDenom string) {
+	r.TokenOutDenom = tokenOutDenom
+}
+
+// CalcSpotPrice implements sqsdomain.RoutablePool.
+func (r *routableCosmWasmPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+	request := msg.SpotPriceQueryMsg{
+		SpotPrice: msg.SpotPrice{
+			QuoteAssetDenom: quoteDenom,
+			BaseAssetDenom:  baseDenom,
+		},
+	}
+
+	response := &msg.SpotPriceQueryMsgResponse{}
+	if err := queryCosmwasmContract(ctx, r.wasmClient, r.ChainPool.ContractAddress, &request, response); err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	return osmomath.MustNewBigDecFromStr(response.SpotPrice), nil
+}

--- a/router/usecase/pools/routable_cw_transmuter_pool.go
+++ b/router/usecase/pools/routable_cw_transmuter_pool.go
@@ -122,3 +122,8 @@ func (r *routableTransmuterPoolImpl) SetTokenOutDenom(tokenOutDenom string) {
 func (r *routableTransmuterPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	return osmomath.OneBigDec(), nil
 }
+
+// IsGeneralizedCosmWasmPool implements sqsdomain.RoutablePool.
+func (*routableTransmuterPoolImpl) IsGeneralizedCosmWasmPool() bool {
+	return false
+}

--- a/router/usecase/pools/routable_cw_transmuter_pool.go
+++ b/router/usecase/pools/routable_cw_transmuter_pool.go
@@ -84,7 +84,7 @@ func (r *routableTransmuterPoolImpl) GetTokenOutDenom() string {
 
 // String implements sqsdomain.RoutablePool.
 func (r *routableTransmuterPoolImpl) String() string {
-	return fmt.Sprintf("pool (%d), pool type (%d), pool denoms (%v), token out (%s)", r.ChainPool.PoolId, poolmanagertypes.CosmWasm, r.GetPoolDenoms(), r.TokenOutDenom)
+	return fmt.Sprintf("pool (%d), pool type (%d) Transmuter, pool denoms (%v), token out (%s)", r.ChainPool.PoolId, poolmanagertypes.CosmWasm, r.GetPoolDenoms(), r.TokenOutDenom)
 }
 
 // ChargeTakerFeeExactIn implements sqsdomain.RoutablePool.
@@ -119,6 +119,6 @@ func (r *routableTransmuterPoolImpl) SetTokenOutDenom(tokenOutDenom string) {
 }
 
 // CalcSpotPrice implements sqsdomain.RoutablePool.
-func (r *routableTransmuterPoolImpl) CalcSpotPrice(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+func (r *routableTransmuterPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	return osmomath.OneBigDec(), nil
 }

--- a/router/usecase/pools/routable_cw_transmuter_pool_test.go
+++ b/router/usecase/pools/routable_cw_transmuter_pool_test.go
@@ -65,7 +65,11 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Transmuter() {
 			poolType := cosmwasmPool.GetType()
 
 			mock := &mocks.MockRoutablePool{ChainPoolModel: cosmwasmPool.AsSerializablePool(), Balances: tc.balances, PoolType: poolType}
-			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmCodeIDMaps{})
+			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmPoolRouterConfig{
+				TransmuterCodeIDs: map[uint64]struct{}{
+					cosmwasmPool.GetCodeId(): {},
+				},
+			})
 			s.Require().NoError(err)
 
 			// Overwrite pool type for edge case testing

--- a/router/usecase/pools/routable_pool_test.go
+++ b/router/usecase/pools/routable_pool_test.go
@@ -1,6 +1,7 @@
 package pools_test
 
 import (
+	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -95,7 +96,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_CFMM() {
 			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmCodeIDMaps{})
 			s.Require().NoError(err)
 
-			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(tc.tokenIn)
+			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(context.TODO(), tc.tokenIn)
 
 			if tc.expectError != nil {
 				s.Require().Error(err)

--- a/router/usecase/pools/routable_pool_test.go
+++ b/router/usecase/pools/routable_pool_test.go
@@ -93,7 +93,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_CFMM() {
 			s.Require().NoError(err)
 
 			mock := &mocks.MockRoutablePool{ChainPoolModel: pool, PoolType: tc.poolType}
-			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmCodeIDMaps{})
+			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmPoolRouterConfig{})
 			s.Require().NoError(err)
 
 			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(context.TODO(), tc.tokenIn)

--- a/router/usecase/pools/routable_pool_test.go
+++ b/router/usecase/pools/routable_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"github.com/stretchr/testify/suite"
 
@@ -91,7 +92,8 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_CFMM() {
 			s.Require().NoError(err)
 
 			mock := &mocks.MockRoutablePool{ChainPoolModel: pool, PoolType: tc.poolType}
-			routablePool := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee)
+			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmCodeIDMaps{})
+			s.Require().NoError(err)
 
 			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(tc.tokenIn)
 

--- a/router/usecase/pools/routable_result_pool.go
+++ b/router/usecase/pools/routable_result_pool.go
@@ -1,6 +1,7 @@
 package pools
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -93,7 +94,7 @@ func (*routableResultPoolImpl) Validate(minUOSMOTVL math.Int) error {
 }
 
 // CalculateTokenOutByTokenIn implements RoutablePool.
-func (r *routableResultPoolImpl) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error) {
+func (r *routableResultPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
 	return sdk.Coin{}, errors.New("not implemented")
 }
 

--- a/router/usecase/pools/routable_result_pool.go
+++ b/router/usecase/pools/routable_result_pool.go
@@ -139,3 +139,8 @@ func (r *routableResultPoolImpl) GetSpreadFactor() math.LegacyDec {
 func (r *routableResultPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	panic("not implemented")
 }
+
+// IsGeneralizedCosmWasmPool implements sqsdomain.RoutablePool.
+func (*routableResultPoolImpl) IsGeneralizedCosmWasmPool() bool {
+	return false
+}

--- a/router/usecase/pools/routable_result_pool.go
+++ b/router/usecase/pools/routable_result_pool.go
@@ -136,6 +136,6 @@ func (r *routableResultPoolImpl) GetSpreadFactor() math.LegacyDec {
 }
 
 // CalcSpotPrice implements sqsdomain.RoutablePool.
-func (r *routableResultPoolImpl) CalcSpotPrice(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+func (r *routableResultPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	panic("not implemented")
 }

--- a/router/usecase/pools/routable_stableswap_pool.go
+++ b/router/usecase/pools/routable_stableswap_pool.go
@@ -89,3 +89,8 @@ func (r *routableStableswapPoolImpl) CalcSpotPrice(ctx context.Context, baseDeno
 	}
 	return spotPrice, nil
 }
+
+// IsGeneralizedCosmWasmPool implements sqsdomain.RoutablePool.
+func (*routableStableswapPoolImpl) IsGeneralizedCosmWasmPool() bool {
+	return false
+}

--- a/router/usecase/pools/routable_stableswap_pool.go
+++ b/router/usecase/pools/routable_stableswap_pool.go
@@ -82,7 +82,7 @@ func (r *routableStableswapPoolImpl) GetType() poolmanagertypes.PoolType {
 }
 
 // CalcSpotPrice implements sqsdomain.RoutablePool.
-func (r *routableStableswapPoolImpl) CalcSpotPrice(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+func (r *routableStableswapPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	spotPrice, err := r.ChainPool.SpotPrice(sdk.Context{}, quoteDenom, baseDenom)
 	if err != nil {
 		return osmomath.BigDec{}, err

--- a/router/usecase/pools/routable_stableswap_pool.go
+++ b/router/usecase/pools/routable_stableswap_pool.go
@@ -1,6 +1,7 @@
 package pools
 
 import (
+	"context"
 	"fmt"
 
 	"cosmossdk.io/math"
@@ -24,7 +25,7 @@ type routableStableswapPoolImpl struct {
 }
 
 // CalculateTokenOutByTokenIn implements RoutablePool.
-func (r *routableStableswapPoolImpl) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error) {
+func (r *routableStableswapPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
 	tokenOut, err := r.ChainPool.CalcOutAmtGivenIn(sdk.Context{}, sdk.NewCoins(tokenIn), r.TokenOutDenom, r.GetSpreadFactor())
 	if err != nil {
 		return sdk.Coin{}, err

--- a/router/usecase/pools/routable_transmuter_pool.go
+++ b/router/usecase/pools/routable_transmuter_pool.go
@@ -1,6 +1,7 @@
 package pools
 
 import (
+	"context"
 	"fmt"
 
 	"cosmossdk.io/math"
@@ -51,7 +52,7 @@ func (r *routableTransmuterPoolImpl) GetSpreadFactor() math.LegacyDec {
 // - the underlying chain pool set on the routable pool is not of transmuter type
 // - the token in amount is greater than the balance of the token in
 // - the token in amount is greater than the balance of the token out
-func (r *routableTransmuterPoolImpl) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error) {
+func (r *routableTransmuterPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
 	poolType := r.GetType()
 
 	// Esnure that the pool is concentrated

--- a/router/usecase/pools/routable_transmuter_pool_test.go
+++ b/router/usecase/pools/routable_transmuter_pool_test.go
@@ -1,6 +1,8 @@
 package pools_test
 
 import (
+	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/sqs/domain"
@@ -71,7 +73,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Transmuter() {
 				mock.PoolType = poolmanagertypes.Concentrated
 			}
 
-			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(tc.tokenIn)
+			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(context.TODO(), tc.tokenIn)
 
 			if tc.expectError != nil {
 				s.Require().Error(err)

--- a/router/usecase/pools/routable_transmuter_pool_test.go
+++ b/router/usecase/pools/routable_transmuter_pool_test.go
@@ -63,7 +63,8 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Transmuter() {
 			poolType := cosmwasmPool.GetType()
 
 			mock := &mocks.MockRoutablePool{ChainPoolModel: cosmwasmPool.AsSerializablePool(), Balances: tc.balances, PoolType: poolType}
-			routablePool := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee)
+			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmCodeIDMaps{})
+			s.Require().NoError(err)
 
 			// Overwrite pool type for edge case testing
 			if tc.isInvalidPoolType {

--- a/router/usecase/quote.go
+++ b/router/usecase/quote.go
@@ -1,6 +1,7 @@
 package usecase
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -33,7 +34,7 @@ var _ domain.Quote = &quoteImpl{}
 // Computes an effective spread factor from all routes.
 //
 // Returns the updated route and the effective spread factor.
-func (q *quoteImpl) PrepareResult() ([]domain.SplitRoute, osmomath.Dec) {
+func (q *quoteImpl) PrepareResult(ctx context.Context) ([]domain.SplitRoute, osmomath.Dec) {
 	totalAmountIn := q.AmountIn.Amount.ToLegacyDec()
 	totalFeeAcrossRoutes := osmomath.ZeroDec()
 
@@ -60,7 +61,7 @@ func (q *quoteImpl) PrepareResult() ([]domain.SplitRoute, osmomath.Dec) {
 		// Update the spread factor pro-rated by the amount in
 		totalFeeAcrossRoutes.AddMut(routeTotalFee.MulMut(routeAmountInFraction))
 
-		routeSpotPriceInOverOut, effectiveSpotPriceInOverOut, err := q.Route[i].PrepareResultPools(q.AmountIn)
+		routeSpotPriceInOverOut, effectiveSpotPriceInOverOut, err := q.Route[i].PrepareResultPools(ctx, q.AmountIn)
 		if err != nil {
 			panic(err)
 		}

--- a/router/usecase/quote_test.go
+++ b/router/usecase/quote_test.go
@@ -133,13 +133,13 @@ func (s *RouterTestSuite) TestPrepareResult() {
 							sqsdomain.NewPool(poolOne, poolOne.GetSpreadFactor(sdk.Context{}), poolOneBalances),
 							USDT,
 							takerFeeOne,
-							domain.CosmWasmCodeIDMaps{},
+							domain.CosmWasmPoolRouterConfig{},
 						),
 						s.newRoutablePool(
 							sqsdomain.NewPool(poolTwo, poolTwo.GetSpreadFactor(sdk.Context{}), poolTwoBalances),
 							USDC,
 							takerFeeTwo,
-							domain.CosmWasmCodeIDMaps{},
+							domain.CosmWasmPoolRouterConfig{},
 						),
 					},
 				},
@@ -156,7 +156,7 @@ func (s *RouterTestSuite) TestPrepareResult() {
 							sqsdomain.NewPool(poolThree, poolThree.GetSpreadFactor(sdk.Context{}), poolThreeBalances),
 							USDC,
 							takerFeeThree,
-							domain.CosmWasmCodeIDMaps{},
+							domain.CosmWasmPoolRouterConfig{},
 						),
 					},
 				},
@@ -329,8 +329,8 @@ func (s *RouterTestSuite) validateRoutes(expectedRoutes []domain.SplitRoute, act
 	}
 }
 
-func (s *RouterTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolIDs domain.CosmWasmCodeIDMaps) sqsdomain.RoutablePool {
-	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolIDs)
+func (s *RouterTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmConfig domain.CosmWasmPoolRouterConfig) sqsdomain.RoutablePool {
+	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmConfig)
 	s.Require().NoError(err)
 	return routablePool
 }

--- a/router/usecase/quote_test.go
+++ b/router/usecase/quote_test.go
@@ -127,15 +127,17 @@ func (s *RouterTestSuite) TestPrepareResult() {
 			&usecase.RouteWithOutAmount{
 				RouteImpl: route.RouteImpl{
 					Pools: []sqsdomain.RoutablePool{
-						pools.NewRoutablePool(
+						s.newRoutablePool(
 							sqsdomain.NewPool(poolOne, poolOne.GetSpreadFactor(sdk.Context{}), poolOneBalances),
 							USDT,
 							takerFeeOne,
+							domain.CosmWasmCodeIDMaps{},
 						),
-						pools.NewRoutablePool(
+						s.newRoutablePool(
 							sqsdomain.NewPool(poolTwo, poolTwo.GetSpreadFactor(sdk.Context{}), poolTwoBalances),
 							USDC,
 							takerFeeTwo,
+							domain.CosmWasmCodeIDMaps{},
 						),
 					},
 				},
@@ -148,10 +150,11 @@ func (s *RouterTestSuite) TestPrepareResult() {
 			&usecase.RouteWithOutAmount{
 				RouteImpl: route.RouteImpl{
 					Pools: []sqsdomain.RoutablePool{
-						pools.NewRoutablePool(
+						s.newRoutablePool(
 							sqsdomain.NewPool(poolThree, poolThree.GetSpreadFactor(sdk.Context{}), poolThreeBalances),
 							USDC,
 							takerFeeThree,
+							domain.CosmWasmCodeIDMaps{},
 						),
 					},
 				},
@@ -322,4 +325,10 @@ func (s *RouterTestSuite) validateRoutes(expectedRoutes []domain.SplitRoute, act
 		// Validate out amount
 		s.Require().Equal(expectedRoute.GetAmountOut().String(), actualRoute.GetAmountOut().String())
 	}
+}
+
+func (s *RouterTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolIDs domain.CosmWasmCodeIDMaps) sqsdomain.RoutablePool {
+	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolIDs)
+	s.Require().NoError(err)
+	return routablePool
 }

--- a/router/usecase/quote_test.go
+++ b/router/usecase/quote_test.go
@@ -1,6 +1,8 @@
 package usecase_test
 
 import (
+	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/sqs/sqsdomain"
@@ -224,7 +226,7 @@ func (s *RouterTestSuite) TestPrepareResult() {
 	expectedEffectiveSpreadFactor := expectedRouteOneFee.Add(expectedRouteTwoFee)
 
 	// System under test
-	routes, effectiveSpreadFactor := testQuote.PrepareResult()
+	routes, effectiveSpreadFactor := testQuote.PrepareResult(context.TODO())
 
 	// Validate routes.
 	s.validateRoutes(expectedRoutes, routes)
@@ -299,7 +301,7 @@ func (s *RouterTestSuite) TestPrepareResult_PriceImpact() {
 	}
 
 	// System under test.
-	testQuote.PrepareResult()
+	testQuote.PrepareResult(context.TODO())
 
 	// Validate price impact.
 	s.Require().Equal(expectedPriceImpact.String(), testQuote.GetPriceImpact().String())

--- a/router/usecase/route/route.go
+++ b/router/usecase/route/route.go
@@ -1,6 +1,7 @@
 package route
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -31,7 +32,7 @@ type RouteImpl struct {
 // - Taker Fee
 // Note that it mutates the route.
 // Returns spot price before swap and the effective spot price
-func (r *RouteImpl) PrepareResultPools(tokenIn sdk.Coin) (osmomath.Dec, osmomath.Dec, error) {
+func (r *RouteImpl) PrepareResultPools(ctx context.Context, tokenIn sdk.Coin) (osmomath.Dec, osmomath.Dec, error) {
 	var (
 		routeSpotPriceInOverOut     = osmomath.OneDec()
 		effectiveSpotPriceInOverOut = osmomath.OneDec()
@@ -47,7 +48,7 @@ func (r *RouteImpl) PrepareResultPools(tokenIn sdk.Coin) (osmomath.Dec, osmomath
 		// Charge taker fee
 		tokenIn = pool.ChargeTakerFeeExactIn(tokenIn)
 
-		tokenOut, err := pool.CalculateTokenOutByTokenIn(tokenIn)
+		tokenOut, err := pool.CalculateTokenOutByTokenIn(ctx, tokenIn)
 		if err != nil {
 			return osmomath.Dec{}, osmomath.Dec{}, err
 		}
@@ -77,7 +78,7 @@ func (r *RouteImpl) GetPools() []sqsdomain.RoutablePool {
 }
 
 // CalculateTokenOutByTokenIn implements Route.
-func (r *RouteImpl) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (tokenOut sdk.Coin, err error) {
+func (r *RouteImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (tokenOut sdk.Coin, err error) {
 	defer func() {
 		// TODO: cover this by test
 		if r := recover(); r != nil {
@@ -95,7 +96,7 @@ func (r *RouteImpl) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (tokenOut sdk.C
 			return sdk.Coin{}, nil
 		}
 
-		tokenOut, err = pool.CalculateTokenOutByTokenIn(tokenIn)
+		tokenOut, err = pool.CalculateTokenOutByTokenIn(ctx, tokenIn)
 		if err != nil {
 			return sdk.Coin{}, err
 		}

--- a/router/usecase/route/route.go
+++ b/router/usecase/route/route.go
@@ -18,6 +18,12 @@ var _ domain.Route = &RouteImpl{}
 
 type RouteImpl struct {
 	Pools []sqsdomain.RoutablePool "json:\"pools\""
+	// HasGeneralizedCosmWasmPool is true if the route contains a generalized cosmwasm pool.
+	// We track whether a route contains a generalized cosmwasm pool
+	// so that we can exclude it from split quote logic.
+	// The reason for this is that making network requests to chain is expensive.
+	// As a result, we want to minimize the number of requests we make.
+	HasGeneralizedCosmWasmPool bool "json:\"has-cw-pool\""
 }
 
 // PrepareResultPools implements domain.Route.
@@ -129,4 +135,9 @@ func (r *RouteImpl) GetTokenOutDenom() string {
 	}
 
 	return r.Pools[len(r.Pools)-1].GetTokenOutDenom()
+}
+
+// ContainsGeneralizedCosmWasmPool implements domain.Route.
+func (r *RouteImpl) ContainsGeneralizedCosmWasmPool() bool {
+	return r.HasGeneralizedCosmWasmPool
 }

--- a/router/usecase/route/route.go
+++ b/router/usecase/route/route.go
@@ -76,10 +76,6 @@ func (r *RouteImpl) GetPools() []sqsdomain.RoutablePool {
 	return r.Pools
 }
 
-func (r *RouteImpl) AddPool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec) {
-	r.Pools = append(r.Pools, pools.NewRoutablePool(pool, tokenOutDenom, takerFee))
-}
-
 // CalculateTokenOutByTokenIn implements Route.
 func (r *RouteImpl) CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (tokenOut sdk.Coin, err error) {
 	defer func() {

--- a/router/usecase/route/route.go
+++ b/router/usecase/route/route.go
@@ -40,7 +40,7 @@ func (r *RouteImpl) PrepareResultPools(ctx context.Context, tokenIn sdk.Coin) (o
 
 	for i, pool := range r.Pools {
 		// Compute spot price before swap.
-		spotPriceInOverOut, err := pool.CalcSpotPrice(pool.GetTokenOutDenom(), tokenIn.Denom)
+		spotPriceInOverOut, err := pool.CalcSpotPrice(ctx, pool.GetTokenOutDenom(), tokenIn.Denom)
 		if err != nil {
 			return osmomath.Dec{}, osmomath.Dec{}, err
 		}

--- a/router/usecase/route/route_test.go
+++ b/router/usecase/route/route_test.go
@@ -1,6 +1,7 @@
 package route_test
 
 import (
+	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -198,7 +199,7 @@ func (s *RouterTestSuite) TestPrepareResultPools() {
 		s.Run(name, func() {
 
 			// Note: token in is chosen arbitrarily since it is irrelevant for this test
-			spotPriceBeforeInOverOut, _, err := tc.route.PrepareResultPools(tc.tokenIn)
+			spotPriceBeforeInOverOut, _, err := tc.route.PrepareResultPools(context.TODO(), tc.tokenIn)
 			s.Require().NoError(err)
 
 			s.Require().Equal(tc.expectedSpotPriceInOverOut, spotPriceBeforeInOverOut)

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -35,7 +35,6 @@ type routerUseCaseImpl struct {
 	routerRepository routerredisrepo.RouterRepository
 	poolsUsecase     mvc.PoolsUsecase
 	config           domain.RouterConfig
-	poolsConfig      domain.PoolsConfig
 	logger           log.Logger
 
 	routesOverwrite *cache.RoutesOverwrite

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -196,7 +196,7 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 	}
 
 	// Compute split route quote
-	topSplitQuote, err := router.GetSplitQuote(rankedRoutes, tokenIn)
+	topSplitQuote, err := router.GetSplitQuote(ctx, rankedRoutes, tokenIn)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +292,7 @@ func (r *routerUseCaseImpl) rankRoutesByDirectQuote(ctx context.Context, router 
 		return nil, nil, err
 	}
 
-	topQuote, routes, err := estimateDirectQuote(router, routes, tokenIn)
+	topQuote, routes, err := estimateDirectQuote(ctx, router, routes, tokenIn)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -304,8 +304,8 @@ func (r *routerUseCaseImpl) rankRoutesByDirectQuote(ctx context.Context, router 
 // Also, returns the routes ranked by amount out in decreasing order.
 // Returns error if:
 // - fails to estimate direct quotes
-func estimateDirectQuote(router *Router, routes []route.RouteImpl, tokenIn sdk.Coin) (domain.Quote, []route.RouteImpl, error) {
-	topQuote, routesSortedByAmtOut, err := router.estimateAndRankSingleRouteQuote(routes, tokenIn)
+func estimateDirectQuote(ctx context.Context, router *Router, routes []route.RouteImpl, tokenIn sdk.Coin) (domain.Quote, []route.RouteImpl, error) {
+	topQuote, routesSortedByAmtOut, err := router.estimateAndRankSingleRouteQuote(ctx, routes, tokenIn)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -351,7 +351,7 @@ func (r *routerUseCaseImpl) GetBestSingleRouteQuote(ctx context.Context, tokenIn
 		return nil, err
 	}
 
-	return router.getBestSingleRouteQuote(tokenIn, routes)
+	return router.getBestSingleRouteQuote(ctx, tokenIn, routes)
 }
 
 // GetCustomQuote implements mvc.RouterUsecase.
@@ -417,7 +417,7 @@ func (r *routerUseCaseImpl) GetCustomQuote(ctx context.Context, tokenIn sdk.Coin
 
 	// Compute direct quote
 	foundRoute := routes[routeIndex]
-	quote, _, err := router.estimateAndRankSingleRouteQuote([]route.RouteImpl{foundRoute}, tokenIn)
+	quote, _, err := router.estimateAndRankSingleRouteQuote(ctx, []route.RouteImpl{foundRoute}, tokenIn)
 	if err != nil {
 		return nil, err
 	}
@@ -476,7 +476,7 @@ func (r *routerUseCaseImpl) GetCustomDirectQuote(ctx context.Context, tokenIn sd
 
 	// Compute direct quote
 	router := r.initializeRouter()
-	return router.getBestSingleRouteQuote(tokenIn, routes)
+	return router.getBestSingleRouteQuote(ctx, tokenIn, routes)
 }
 
 // GetCandidateRoutes implements domain.RouterUsecase.

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -823,3 +823,18 @@ func convertRankedToCandidateRoutes(rankedRoutes []route.RouteImpl) sqsdomain.Ca
 	}
 	return candidateRoutes
 }
+
+// GetPoolSpotPrice implements mvc.RouterUsecase.
+func (r *routerUseCaseImpl) GetPoolSpotPrice(ctx context.Context, poolID uint64, quoteAsset, baseAsset string) (osmomath.BigDec, error) {
+	poolTakerFee, err := r.routerRepository.GetTakerFee(ctx, quoteAsset, baseAsset)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	spotPrice, err := r.poolsUsecase.GetPoolSpotPrice(ctx, poolID, poolTakerFee, baseAsset, quoteAsset)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	return spotPrice, nil
+}

--- a/sqsdomain/routable_pool.go
+++ b/sqsdomain/routable_pool.go
@@ -1,6 +1,8 @@
 package sqsdomain
 
 import (
+	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -18,7 +20,7 @@ type RoutablePool interface {
 
 	CalcSpotPrice(baseDenom string, quoteDenom string) (osmomath.BigDec, error)
 
-	CalculateTokenOutByTokenIn(tokenIn sdk.Coin) (sdk.Coin, error)
+	CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error)
 	ChargeTakerFeeExactIn(tokenIn sdk.Coin) (tokenInAfterFee sdk.Coin)
 
 	// SetTokenOutDenom sets the token out denom on the routable pool.

--- a/sqsdomain/routable_pool.go
+++ b/sqsdomain/routable_pool.go
@@ -14,6 +14,12 @@ type RoutablePool interface {
 
 	GetType() poolmanagertypes.PoolType
 
+	// IsGeneralizedCosmWasmPool returns true if this is a generalized cosmwasm pool.
+	// Pools with such code ID are enabled in the router. For computing quotes or spot price,
+	// they interact with the chain. Additionally, routes that contain such pools are disabled
+	// in the router.
+	IsGeneralizedCosmWasmPool() bool
+
 	GetPoolDenoms() []string
 
 	GetTokenOutDenom() string

--- a/sqsdomain/routable_pool.go
+++ b/sqsdomain/routable_pool.go
@@ -18,7 +18,7 @@ type RoutablePool interface {
 
 	GetTokenOutDenom() string
 
-	CalcSpotPrice(baseDenom string, quoteDenom string) (osmomath.BigDec, error)
+	CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
 
 	CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error)
 	ChargeTakerFeeExactIn(tokenIn sdk.Coin) (tokenInAfterFee sdk.Coin)


### PR DESCRIPTION
## Custom CosmWasm Pools

The sidecar query server supports custom CosmWasm pools.
There are two options of integrating them into the Osmosis router:
1. Implement a pool type similar to [transmuter](https://github.com/osmosis-labs/sqs/blob/e95c66e3ee6a22d57118c74a384253f016a9bb85/router/usecase/pools/routable_transmuter_pool.go#L19)
   * This assumes that the pool quote and spot price logic is trivial enough for implementing
   it directly in SQS without having to interact with the chain.
2. Utilize a [generalized CosmWasm pool type](https://github.com/osmosis-labs/sqs/blob/437086c683f4f90d915f7e042617552c68410796/router/usecase/pools/routable_cw_pool.go#L24)
   * This assumes that the pool quote and spot price logic is complex enough for requiring
   interaction with the chain.
   * For quotes and spot prices, SQS service would make network API queries to the chain.
   * This is the simplest approach but it is less performant than the first option.
   * Due to performance reasons, the routes containing these pools are not utilized in
   more performant split quotes. Only direct quotes are supported.

To enable support for either option, a [config.json](https://github.com/osmosis-labs/sqs/blob/437086c683f4f90d915f7e042617552c68410796/config.json#L22-L25)
must be updated accordingly. For option 1, add a new field under `pools` and make a PR propagating
this config to be able to create a new custom pool type similar to transmuter. For option 2, simply
add your code id to `general-cosmwasm-code-ids` in this repository. Tag `@p0mvn` in the PR and
follow up that the config is deployed to the sidecar query server service in production.