### PR TITLE
feat: concurrent prices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,4 +118,4 @@ sqs-update-mainnet-state:
 
 # Bench tests pricing
 bench-pricing:
-	go test -bench BenchmarkGetPrices -run BenchmarkGetPrices github.com/osmosis-labs/sqs/tokens/usecase -v
+	go test -bench BenchmarkGetPrices -run BenchmarkGetPrices github.com/osmosis-labs/sqs/tokens/usecase -count=6

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -261,9 +261,10 @@ func (s *RouterTestHelper) SetupMainnetRouter(config domain.RouterConfig) (*rout
 	tokensMetadata, err := parsing.ReadTokensMetadata(absolutePathToStateFiles + tokensMetadataFileName)
 	s.Require().NoError(err)
 
-	logger, err := log.NewLogger(false, "", "info")
-	s.Require().NoError(err)
-	router := routerusecase.NewRouter(config, logger)
+	// N.B. uncomment if logs are needed.
+	// logger, err := log.NewLogger(false, "", "info")
+	// s.Require().NoError(err)
+	router := routerusecase.NewRouter(config, &log.NoOpLogger{})
 	router = routerusecase.WithSortedPools(router, pools)
 
 	return router, MockMainnetState{

--- a/tokens/usecase/pricing/chain/pricing_chain.go
+++ b/tokens/usecase/pricing/chain/pricing_chain.go
@@ -26,6 +26,11 @@ func New(routerUseCase mvc.RouterUsecase, tokenUseCase mvc.TokensUsecase) domain
 
 // GetPrice implements pricing.PricingStrategy.
 func (c *chainPricing) GetPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+	// equal base and quote yield the price of one
+	if baseDenom == quoteDenom {
+		return osmomath.OneBigDec(), nil
+	}
+
 	// Get on-chain scaling factor for base denom.
 	baseDenomScalingFactor, err := c.TUsecase.GetChainScalingFactorByDenomMut(ctx, baseDenom)
 	if err != nil {


### PR DESCRIPTION
Closes #91

```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/tokens/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
            │  bench_old   │              bench_new              │
            │    sec/op    │    sec/op     vs base               │
GetPrices-8   24.88m ± 17%   12.84m ± 43%  -48.38% (p=0.002 n=6)
```

new:
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/tokens/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkGetPrices-8   	      82	  12483772 ns/op
BenchmarkGetPrices-8   	      96	  10966886 ns/op
BenchmarkGetPrices-8   	      88	  12802985 ns/op
BenchmarkGetPrices-8   	     105	  12883695 ns/op
BenchmarkGetPrices-8   	     109	  16683643 ns/op
BenchmarkGetPrices-8   	      57	  18344654 ns/op
PASS
ok  	github.com/osmosis-labs/sqs/tokens/usecase	17.391s
```

old:
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/tokens/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkGetPrices-8   	      43	  29004777 ns/op
BenchmarkGetPrices-8   	      42	  24896566 ns/op
BenchmarkGetPrices-8   	      43	  24728792 ns/op
BenchmarkGetPrices-8   	      42	  24405829 ns/op
BenchmarkGetPrices-8   	      46	  24869163 ns/op
BenchmarkGetPrices-8   	      44	  25706675 ns/op
PASS
ok  	github.com/osmosis-labs/sqs/tokens/usecase	16.864s

```