### PR TITLE
feat: cache for prices

### DIFF
--- a/tokens/delivery/http/tokens_delivery.go
+++ b/tokens/delivery/http/tokens_delivery.go
@@ -216,7 +216,6 @@ func (a *TokensHandler) GetUSDPriceTest(c echo.Context) (err error) {
 		} else {
 			return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: fmt.Errorf("unsupported denom (%s)", denom).Error()})
 		}
-
 	}
 
 	return c.JSON(http.StatusOK, prices)


### PR DESCRIPTION
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/tokens/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
            │    bench_new    │             bench_new2              │
            │     sec/op      │    sec/op     vs base               │
GetPrices-8   12843.34µ ± 43%   59.14µ ± 14%  -99.54% (p=0.002 n=6)
```

new:
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/tokens/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkGetPrices-8   	   18961	     58384 ns/op
BenchmarkGetPrices-8   	   18310	     67164 ns/op
BenchmarkGetPrices-8   	   17830	     64263 ns/op
BenchmarkGetPrices-8   	   19742	     58305 ns/op
BenchmarkGetPrices-8   	   17390	     59895 ns/op
BenchmarkGetPrices-8   	   20012	     57231 ns/op
PASS
ok  	github.com/osmosis-labs/sqs/tokens/usecase	22.046s
```

old:
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/tokens/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkGetPrices-8   	      82	  12483772 ns/op
BenchmarkGetPrices-8   	      96	  10966886 ns/op
BenchmarkGetPrices-8   	      88	  12802985 ns/op
BenchmarkGetPrices-8   	     105	  12883695 ns/op
BenchmarkGetPrices-8   	     109	  16683643 ns/op
BenchmarkGetPrices-8   	      57	  18344654 ns/op
PASS
ok  	github.com/osmosis-labs/sqs/tokens/usecase	17.391s

```