### PR TITLE
Roman/price refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## v0.9.0
 
 - Support all asset list v1 tokens
+- Use spot price in pricing
 
 ## v0.8.4
 

--- a/router/usecase/pools/routable_cw_pool.go
+++ b/router/usecase/pools/routable_cw_pool.go
@@ -111,7 +111,6 @@ func (r *routableCosmWasmPoolImpl) SetTokenOutDenom(tokenOutDenom string) {
 
 // CalcSpotPrice implements sqsdomain.RoutablePool.
 func (r *routableCosmWasmPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
-
 	var request msg.SpotPriceQueryMsg
 	// HACK:
 	// AStroport PCL pool has the quote and base asset denoms reversed

--- a/router/usecase/precompute.go
+++ b/router/usecase/precompute.go
@@ -1,0 +1,53 @@
+package usecase
+
+import "github.com/osmosis-labs/osmosis/osmomath"
+
+var (
+	TenE9 = osmomath.NewInt(1_000_000_000)
+	TenE8 = osmomath.NewInt(100_000_000)
+	TenE7 = osmomath.NewInt(10_000_000)
+	TenE6 = osmomath.NewInt(1_000_000)
+	TenE5 = osmomath.NewInt(100_000)
+	TenE4 = osmomath.NewInt(10_000)
+	TenE3 = osmomath.NewInt(1_000)
+	TenE2 = osmomath.NewInt(100)
+	TenE1 = osmomath.NewInt(10)
+)
+
+// GetPrecomputeOrderOfMagnitude returns the order of magnitude of the given amount.
+// Uses look up table for precomputed order of magnitudes.
+func GetPrecomputeOrderOfMagnitude(amount osmomath.Int) int {
+	if amount.GT(TenE9) {
+		a := amount.Quo(TenE9)
+		return 9 + GetPrecomputeOrderOfMagnitude(a)
+	}
+	if amount.GTE(TenE9) {
+		return 9
+	}
+	if amount.GTE(TenE8) {
+		return 8
+	}
+	if amount.GTE(TenE7) {
+		return 7
+	}
+	if amount.GTE(TenE6) {
+		return 6
+	}
+	if amount.GTE(TenE5) {
+		return 5
+	}
+	if amount.GTE(TenE4) {
+		return 4
+	}
+	if amount.GTE(TenE3) {
+		return 3
+	}
+	if amount.GTE(TenE2) {
+		return 2
+	}
+	if amount.GTE(TenE1) {
+		return 1
+	}
+
+	return 0
+}

--- a/router/usecase/precompute_test.go
+++ b/router/usecase/precompute_test.go
@@ -1,0 +1,72 @@
+package usecase_test
+
+import (
+	"testing"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/router/usecase"
+)
+
+func (s *RouterTestSuite) TestGetPrecomputeOrderOfMagnitude() {
+
+	tests := map[string]struct {
+		amount osmomath.Int
+	}{
+		"0 = 0": {
+			amount: osmomath.ZeroInt(),
+		},
+		"1 = 0": {
+			amount: osmomath.OneInt(),
+		},
+		"9.99 = 0": {
+			amount: osmomath.NewInt(9),
+		},
+		"10^9 - 1": {
+			amount: usecase.TenE9.Sub(osmomath.OneInt()),
+		},
+		"10^9": {
+			amount: usecase.TenE9,
+		},
+		"10^9 +1": {
+			amount: usecase.TenE9.Add(osmomath.OneInt()),
+		},
+		"10^18 +1": {
+			amount: usecase.TenE9.Mul(usecase.TenE9).Add(osmomath.OneInt()),
+		},
+		"10^15 +5": {
+			amount: usecase.TenE9.Mul(usecase.TenE6).Add(osmomath.OneInt()),
+		},
+	}
+
+	for name, tc := range tests {
+		s.Run(name, func() {
+
+			actual := usecase.GetPrecomputeOrderOfMagnitude(tc.amount)
+
+			expected := osmomath.OrderOfMagnitude(tc.amount.ToLegacyDec())
+
+			s.Require().Equal(expected, actual)
+		})
+	}
+
+}
+
+// go test -benchmem -run=^$ -bench ^BenchmarkGetPrecomputeOrderOfMagnitude$ github.com/osmosis-labs/sqs/router/usecase -count=6
+func BenchmarkGetPrecomputeOrderOfMagnitude(b *testing.B) {
+	// Create a test amount. Change this based on what you expect to be typical inputs for your application.
+	testAmount := osmomath.NewInt(1234567890323344555) // You can adjust this value for different benchmark scenarios.
+
+	for i := 0; i < b.N; i++ {
+		_ = usecase.GetPrecomputeOrderOfMagnitude(testAmount)
+	}
+}
+
+// go test -benchmem -run=^$ -bench ^BenchmarkOrderOfMagnitude$ github.com/osmosis-labs/sqs/router/usecase -count=6 > old
+func BenchmarkOrderOfMagnitude(b *testing.B) {
+	// Create a test amount. Change this based on what you expect to be typical inputs for your application.
+	testAmount := osmomath.NewInt(1234567890323344555) // You can adjust this value for different benchmark scenarios.
+
+	for i := 0; i < b.N; i++ {
+		_ = osmomath.OrderOfMagnitude(testAmount.ToLegacyDec())
+	}
+}

--- a/router/usecase/precompute_test.go
+++ b/router/usecase/precompute_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/osmosis-labs/sqs/router/usecase"
 )
 
+var (
+	testAmount = osmomath.NewInt(1234567890323344555)
+)
+
 func (s *RouterTestSuite) TestGetPrecomputeOrderOfMagnitude() {
 
 	tests := map[string]struct {
@@ -53,9 +57,6 @@ func (s *RouterTestSuite) TestGetPrecomputeOrderOfMagnitude() {
 
 // go test -benchmem -run=^$ -bench ^BenchmarkGetPrecomputeOrderOfMagnitude$ github.com/osmosis-labs/sqs/router/usecase -count=6
 func BenchmarkGetPrecomputeOrderOfMagnitude(b *testing.B) {
-	// Create a test amount. Change this based on what you expect to be typical inputs for your application.
-	testAmount := osmomath.NewInt(1234567890323344555) // You can adjust this value for different benchmark scenarios.
-
 	for i := 0; i < b.N; i++ {
 		_ = usecase.GetPrecomputeOrderOfMagnitude(testAmount)
 	}
@@ -63,9 +64,6 @@ func BenchmarkGetPrecomputeOrderOfMagnitude(b *testing.B) {
 
 // go test -benchmem -run=^$ -bench ^BenchmarkOrderOfMagnitude$ github.com/osmosis-labs/sqs/router/usecase -count=6 > old
 func BenchmarkOrderOfMagnitude(b *testing.B) {
-	// Create a test amount. Change this based on what you expect to be typical inputs for your application.
-	testAmount := osmomath.NewInt(1234567890323344555) // You can adjust this value for different benchmark scenarios.
-
 	for i := 0; i < b.N; i++ {
 		_ = osmomath.OrderOfMagnitude(testAmount.ToLegacyDec())
 	}

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -137,7 +137,7 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 func (r *routerUseCaseImpl) GetOptimalQuoteFromConfig(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, config domain.RouterConfig) (domain.Quote, error) {
 	// Get an order of magnitude for the token in amount
 	// This is used for caching ranked routes as these might differ depending on the amount swapped in.
-	tokenInOrderOfMagnitude := osmomath.OrderOfMagnitude(tokenIn.Amount.ToLegacyDec())
+	tokenInOrderOfMagnitude := GetPrecomputeOrderOfMagnitude(tokenIn.Amount)
 
 	candidateRankedRoutes, err := r.GetCachedRankedRoutes(ctx, tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude)
 	if err != nil {
@@ -276,7 +276,7 @@ func (r *routerUseCaseImpl) rankRoutesByDirectQuote(ctx context.Context, router 
 
 // computeAndRankRoutesByDirectQuote computes candidate routes and ranks them by token out after estimating direct quotes.
 func (r *routerUseCaseImpl) computeAndRankRoutesByDirectQuote(ctx context.Context, router *Router, tokenIn sdk.Coin, tokenOutDenom string) (domain.Quote, []route.RouteImpl, error) {
-	tokenInOrderOfMagnitude := osmomath.OrderOfMagnitude(tokenIn.Amount.ToLegacyDec())
+	tokenInOrderOfMagnitude := GetPrecomputeOrderOfMagnitude(tokenIn.Amount)
 
 	// If top routes are not present in cache, retrieve unranked candidate routes
 	candidateRoutes, err := r.handleCandidateRoutes(ctx, router, tokenIn.Denom, tokenOutDenom)

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -84,7 +84,6 @@ func init() {
 
 // NewRouterUsecase will create a new pools use case object
 func NewRouterUsecase(timeout time.Duration, routerRepository routerredisrepo.RouterRepository, poolsUsecase mvc.PoolsUsecase, config domain.RouterConfig, cosmWasmPoolsConfig domain.CosmWasmPoolRouterConfig, logger log.Logger, rankedRouteCache *cache.Cache, candidateRouteCache *cache.Cache) mvc.RouterUsecase {
-
 	return &routerUseCaseImpl{
 		contextTimeout:      timeout,
 		routerRepository:    routerRepository,

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -157,6 +157,24 @@ var (
 		TransmuterCodeIDs:      []uint64{148, 254},
 		GeneralCosmWasmCodeIDs: []uint64{},
 	}
+
+	DefaultPricingRouterConfig = domain.RouterConfig{
+		PreferredPoolIDs:  []uint64{},
+		MaxRoutes:         5,
+		MaxPoolsPerRoute:  3,
+		MaxSplitRoutes:    3,
+		MinOSMOLiquidity:  50,
+		RouteCacheEnabled: true,
+	}
+
+	DefaultPricingConfig = domain.PricingConfig{
+		DefaultSource:          domain.ChainPricingSource,
+		CacheExpiryMs:          2000,
+		DefaultQuoteHumanDenom: "usdc",
+		MaxPoolsPerRoute:       4,
+		MaxRoutes:              5,
+		MinOSMOLiquidity:       50,
+	}
 )
 
 func init() {
@@ -305,4 +323,11 @@ func (s *RouterTestHelper) SetupRouterAndPoolsUsecase(router *routerusecase.Rout
 		Router: routerUsecase,
 		Tokens: tokensUsecase,
 	}
+}
+
+// helper to convert any to BigDec
+func (s *RouterTestHelper) ConvertAnyToBigDec(any any) osmomath.BigDec {
+	bigDec, ok := any.(osmomath.BigDec)
+	s.Require().True(ok)
+	return bigDec
 }

--- a/tokens/usecase/pricing/chain/pricing_chain.go
+++ b/tokens/usecase/pricing/chain/pricing_chain.go
@@ -158,7 +158,6 @@ func (c *chainPricing) GetPrice(ctx context.Context, baseDenom string, quoteDeno
 		// Get spot price for the pool.
 		poolSpotPrice, err := c.RUsecase.GetPoolSpotPrice(ctx, pool.GetId(), tempQuoteDenom, tempBaseDenom)
 		if err != nil || poolSpotPrice.IsNil() || poolSpotPrice.IsZero() {
-
 			// Increase price truncation counter
 			pricesSpotPriceError.WithLabelValues(baseDenom, quoteDenom).Inc()
 

--- a/tokens/usecase/pricing/chain/pricing_chain.go
+++ b/tokens/usecase/pricing/chain/pricing_chain.go
@@ -138,11 +138,13 @@ func (c *chainPricing) GetPrice(ctx context.Context, baseDenom string, quoteDeno
 
 	pools := route.GetPools()
 
-	tempQuoteDenom := quoteDenom
-	tempBaseDenom := baseDenom
-	useAlternativeMethod := false
-	for _, pool := range pools {
+	var (
+		tempQuoteDenom       = quoteDenom
+		tempBaseDenom        string
+		useAlternativeMethod = false
+	)
 
+	for _, pool := range pools {
 		tempBaseDenom = pool.GetTokenOutDenom()
 
 		// Get spot price for the pool.

--- a/tokens/usecase/pricing/chain/pricing_chain_test.go
+++ b/tokens/usecase/pricing/chain/pricing_chain_test.go
@@ -1,0 +1,73 @@
+package chainpricing_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/domain/cache"
+	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
+	"github.com/osmosis-labs/sqs/tokens/usecase/pricing"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestPricingTestSuite(t *testing.T) {
+	suite.Run(t, new(PricingTestSuite))
+}
+
+type PricingTestSuite struct {
+	routertesting.RouterTestHelper
+}
+
+var (
+	UOSMO   = routertesting.UOSMO
+	ATOM    = routertesting.ATOM
+	stOSMO  = routertesting.STOSMO
+	stATOM  = routertesting.STATOM
+	USDC    = routertesting.USDC
+	USDCaxl = routertesting.USDCaxl
+	USDT    = routertesting.USDT
+	WBTC    = routertesting.WBTC
+	ETH     = routertesting.ETH
+	AKT     = routertesting.AKT
+	UMEE    = routertesting.UMEE
+	UION    = routertesting.UION
+	CRE     = routertesting.CRE
+
+	defaultPricingRouterConfig = routertesting.DefaultPricingRouterConfig
+	defaultPricingConfig       = routertesting.DefaultPricingConfig
+)
+
+func (s *PricingTestSuite) TestGetPrices_Chain() {
+
+	// Set up mainnet mock state.
+	router, mainnetState := s.SetupMainnetRouter(defaultPricingRouterConfig)
+	mainnetUsecase := s.SetupRouterAndPoolsUsecase(router, mainnetState, cache.New(), cache.New())
+
+	// Set up on-chain pricing strategy
+	pricingStrategy, err := pricing.NewPricingStrategy(defaultPricingConfig, mainnetUsecase.Tokens, mainnetUsecase.Router)
+	s.Require().NoError(err)
+
+	s.Require().NotZero(len(routertesting.MainnetDenoms))
+	for _, mainnetDenom := range routertesting.MainnetDenoms {
+		mainnetDenom := mainnetDenom
+		s.Run(mainnetDenom, func() {
+
+			// System under test.
+			usdcPrice, err := pricingStrategy.GetPrice(context.Background(), mainnetDenom, USDC)
+			s.Require().NoError(err)
+
+			usdtPrice, err := pricingStrategy.GetPrice(context.Background(), mainnetDenom, USDT)
+			s.Require().NoError(err)
+
+			errTolerance := osmomath.ErrTolerance{
+				// 1% tolerance
+				MultiplicativeTolerance: osmomath.MustNewDecFromStr("0.07"),
+			}
+
+			result := errTolerance.CompareBigDec(usdcPrice, usdtPrice)
+			s.Require().Zero(result, fmt.Sprintf("denom: %s, usdcPrice: %s, usdtPrice: %s", mainnetDenom, usdcPrice, usdtPrice))
+		})
+	}
+}

--- a/tokens/usecase/tokens_usecase_test.go
+++ b/tokens/usecase/tokens_usecase_test.go
@@ -160,14 +160,14 @@ func (s *TokensUseCaseTestSuite) TestGetPrices_Chain() {
 
 		usdcQuoteAny, ok := baseAssetPrices[USDC]
 		s.Require().True(ok)
-		usdcQuote := s.convertAnyToBigDec(usdcQuoteAny)
+		usdcQuote := s.ConvertAnyToBigDec(usdcQuoteAny)
 
 		usdtQuoteAny, ok := baseAssetPrices[USDT]
 		s.Require().True(ok)
-		usdtQuote := s.convertAnyToBigDec(usdtQuoteAny)
+		usdtQuote := s.ConvertAnyToBigDec(usdtQuoteAny)
 
 		result := errTolerance.CompareBigDec(usdcQuote, usdtQuote)
-		s.Require().Zero(result)
+		s.Require().Zero(result, fmt.Sprintf("usdcQuote: %s, usdtQuote: %s", usdcQuote, usdtQuote))
 	}
 
 	// WBTC is around 50K at the time of creation of this test
@@ -183,7 +183,7 @@ func (s *TokensUseCaseTestSuite) TestGetPrices_Chain() {
 
 	actualwBTCUSDCPriceAny, ok := prices[WBTC][USDC]
 	s.Require().True(ok)
-	actualwBTCUSDCPrice := s.convertAnyToBigDec(actualwBTCUSDCPriceAny)
+	actualwBTCUSDCPrice := s.ConvertAnyToBigDec(actualwBTCUSDCPriceAny)
 
 	result := wbtcErrorTolerance.CompareBigDec(expectedwBTCPrice, actualwBTCUSDCPrice)
 	s.Require().Zero(result)
@@ -235,11 +235,4 @@ func (s *TokensUseCaseTestSuite) TestGetPrices_Chain_Specific() {
 	s.Require().NoError(err)
 
 	fmt.Println(price)
-}
-
-// helper to convert any to BigDec
-func (s *TokensUseCaseTestSuite) convertAnyToBigDec(any any) osmomath.BigDec {
-	bigDec, ok := any.(osmomath.BigDec)
-	s.Require().True(ok)
-	return bigDec
 }


### PR DESCRIPTION

## Benchmarks

### Pricing Logic


There isn't a meaningful change in performance
```
~/go/bin/benchstat old2 new2
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/tokens/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
            │     old2     │             new2              │
            │    sec/op    │   sec/op     vs base          │
GetPrices-8   7.377m ± 27%   7.443m ± 3%  ~ (p=0.853 n=10)

            │     old2     │                new2                 │
            │     B/op     │     B/op      vs base               │
GetPrices-8   9.942Mi ± 0%   9.923Mi ± 0%  -0.20% (p=0.000 n=10)

            │    old2     │                new2                │
            │  allocs/op  │  allocs/op   vs base               │
GetPrices-8   138.2k ± 0%   137.8k ± 0%  -0.28% (p=0.000 n=10)
```

### Precompute Logic

Precompute
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/router/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3527824	       371.8 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3109318	       328.9 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3569872	       349.1 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3276049	       352.9 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3739591	       322.9 ns/op	      96 B/op	       6 allocs/op
BenchmarkGetPrecomputeOrderOfMagnitude-8   	 3297483	       324.7 ns/op	      96 B/op	       6 allocs/op
PASS
ok  	github.com/osmosis-labs/sqs/router/usecase	10.494s
```

Non-precompute
```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/router/usecase
cpu: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
BenchmarkOrderOfMagnitude-8   	  229332	      5374 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  239371	      5549 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  257167	      5405 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  236186	      4932 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  233816	      5151 ns/op	    1256 B/op	      22 allocs/op
BenchmarkOrderOfMagnitude-8   	  222508	      8797 ns/op	    1256 B/op	      22 allocs/op
PASS
ok  	github.com/osmosis-labs/sqs/router/usecase	12.149s
```