### PR TITLE
chore: add v24.x backport to mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -46,3 +46,11 @@ pull_request_rules:
       backport:
         branches:
           - v23.x
+  - name: backport patches to v24.x branch
+    conditions:
+      - base=v23.x
+      - label=A:backport/v24.x
+    actions:
+      backport:
+        branches:
+          - v24.x


### PR DESCRIPTION
### Description

We are preparing for the v24 deployment of SQS and osmosis-main, we need to have both SQS and osmosis updated to `v24`, we need to do SQS first then update the osmosis node for our CI to be happy.