### PR TITLE
Speedup Precompute Order of Magnitude

### DIFF
--- a/router/usecase/precompute.go
+++ b/router/usecase/precompute.go
@@ -1,53 +1,103 @@
 package usecase
 
-import "github.com/osmosis-labs/osmosis/osmomath"
-
-var (
-	TenE9 = osmomath.NewInt(1_000_000_000)
-	TenE8 = osmomath.NewInt(100_000_000)
-	TenE7 = osmomath.NewInt(10_000_000)
-	TenE6 = osmomath.NewInt(1_000_000)
-	TenE5 = osmomath.NewInt(100_000)
-	TenE4 = osmomath.NewInt(10_000)
-	TenE3 = osmomath.NewInt(1_000)
-	TenE2 = osmomath.NewInt(100)
-	TenE1 = osmomath.NewInt(10)
+import (
+	"github.com/osmosis-labs/osmosis/osmomath"
 )
+
+// OrderLookup struct holds the precomputed order of magnitudes, indexed by bit length.
+// A lookupEntry means that the bit length of the amount is the key, and the value is the order of magnitude.
+// if cmpValue is not nil, then if amount < cmpValue, the order of magnitude is order - 1.
+type orderLookup struct {
+	orderOfMagnitude int
+	cmpValue         *osmomath.Int
+}
+
+var bitLenToOrderOfMagnitude = []orderLookup{}
+var maxLookupPowTen = 9
+var maxLookupValue osmomath.Int
+
+// buildLookupTable
+func init() {
+	nextPowTen := osmomath.NewInt(10)
+	ten := osmomath.NewInt(10)
+	nextBitLen := nextPowTen.BigIntMut().BitLen()
+	curIndex := 0
+	curBitLen := 1
+	bitLenToOrderOfMagnitude = append(bitLenToOrderOfMagnitude, orderLookup{orderOfMagnitude: 0, cmpValue: nil})
+	for curIndex <= maxLookupPowTen {
+		if curBitLen < nextBitLen {
+			bitLenToOrderOfMagnitude = append(bitLenToOrderOfMagnitude, orderLookup{orderOfMagnitude: curIndex, cmpValue: nil})
+		} else {
+			cmpTen := nextPowTen
+			nextPowTen = nextPowTen.Mul(ten)
+			nextBitLen = nextPowTen.BigIntMut().BitLen()
+			curIndex++
+			bitLenToOrderOfMagnitude = append(bitLenToOrderOfMagnitude, orderLookup{orderOfMagnitude: curIndex, cmpValue: &cmpTen})
+		}
+
+		curBitLen++
+	}
+
+	maxLookupValue = nextPowTen.QuoRaw(100)
+}
 
 // GetPrecomputeOrderOfMagnitude returns the order of magnitude of the given amount.
 // Uses look up table for precomputed order of magnitudes.
 func GetPrecomputeOrderOfMagnitude(amount osmomath.Int) int {
-	if amount.GT(TenE9) {
-		a := amount.Quo(TenE9)
-		return 9 + GetPrecomputeOrderOfMagnitude(a)
-	}
-	if amount.GTE(TenE9) {
-		return 9
-	}
-	if amount.GTE(TenE8) {
-		return 8
-	}
-	if amount.GTE(TenE7) {
-		return 7
-	}
-	if amount.GTE(TenE6) {
-		return 6
-	}
-	if amount.GTE(TenE5) {
-		return 5
-	}
-	if amount.GTE(TenE4) {
-		return 4
-	}
-	if amount.GTE(TenE3) {
-		return 3
-	}
-	if amount.GTE(TenE2) {
-		return 2
-	}
-	if amount.GTE(TenE1) {
-		return 1
+	bitLen := amount.BigIntMut().BitLen()
+	if bitLen >= len(bitLenToOrderOfMagnitude) {
+		a := amount.Quo(maxLookupValue)
+		return maxLookupPowTen + GetPrecomputeOrderOfMagnitude(a)
 	}
 
-	return 0
+	// Lookup the result based on the bit length
+	val := bitLenToOrderOfMagnitude[bitLen]
+	if val.cmpValue == nil {
+		return val.orderOfMagnitude
+	}
+	if amount.LT(*val.cmpValue) {
+		return val.orderOfMagnitude - 1
+	}
+	return val.orderOfMagnitude
 }
+
+// func init() {
+// 	curPowTen := osmomath.NewInt(1)
+// 	ten := osmomath.NewInt(10)
+// 	orderOfMagnitudeLookup = append(orderOfMagnitudeLookup, curPowTen)
+// 	for i := 1; i <= maxLookupIndex; i++ {
+// 		curPowTen = curPowTen.Mul(ten)
+// 		orderOfMagnitudeLookup = append(orderOfMagnitudeLookup, curPowTen)
+// 	}
+// 	maxLookupValue = curPowTen
+// 	maxLookupValueBitLen = maxLookupValue.BigIntMut().BitLen()
+// }
+
+// GetPrecomputeOrderOfMagnitude returns the order of magnitude of the given amount.
+// Uses look up table for precomputed order of magnitudes.
+// func GetPrecomputeOrderOfMagnitude(amount osmomath.Int) int {
+// 	if amount.BigIntMut().BitLen() >= maxLookupValueBitLen {
+// 		if amount.GT(maxLookupValue) {
+// 			a := amount.Quo(maxLookupValue)
+// 			return maxLookupIndex + GetPrecomputeOrderOfMagnitude(a)
+// 		}
+// 	}
+// 	low, high := 0, len(orderOfMagnitudeLookup)-1
+
+// 	for low <= high {
+// 		mid := (low + high) / 2
+// 		if amount.GT(orderOfMagnitudeLookup[mid]) {
+// 			low = mid + 1
+// 		} else if amount.LT(orderOfMagnitudeLookup[mid]) {
+// 			high = mid - 1
+// 		} else {
+// 			return mid
+// 		}
+// 	}
+
+// 	// If not found, return 0
+// 	return 0
+// }
+
+// GetPrecomputeOrderOfMagnitude returns the order of magnitude of the given amount.
+// Uses look up table for precomputed order of magnitudes.

--- a/router/usecase/precompute.go
+++ b/router/usecase/precompute.go
@@ -16,18 +16,28 @@ var bitLenToOrderOfMagnitude = []orderLookup{}
 var maxLookupPowTen = 9
 var maxLookupValue osmomath.Int
 
-// buildLookupTable
+// buildLookupTable initializes the bitLenToOrderOfMagnitude lookup table and sets up precomputed values for order of magnitudes.
+// It iterates through bit lengths and determines the appropriate order of magnitude for each bit length.
+// If a new power of ten is encountered at a particular magnitude, it includes the cmpValue alongside the order of magnitude for that power of ten.
 func init() {
+	// Initialize variables for building the lookup table
 	nextPowTen := osmomath.NewInt(10)
 	ten := osmomath.NewInt(10)
 	nextBitLen := nextPowTen.BigIntMut().BitLen()
 	curIndex := 0
 	curBitLen := 1
+
+	// Add the initial entry for bit length 0
 	bitLenToOrderOfMagnitude = append(bitLenToOrderOfMagnitude, orderLookup{orderOfMagnitude: 0, cmpValue: nil})
+
+	// Iterate through bit lengths and populate the lookup table
 	for curIndex <= maxLookupPowTen {
+		// If the current bit length is less than the bit length of the next power of ten, add an entry with no cmpValue
 		if curBitLen < nextBitLen {
 			bitLenToOrderOfMagnitude = append(bitLenToOrderOfMagnitude, orderLookup{orderOfMagnitude: curIndex, cmpValue: nil})
 		} else {
+			// If the current bit length is equal to or greater than the bit length of the next power of ten,
+			// set cmpValue to the next power of ten and update variables for the next iteration
 			cmpTen := nextPowTen
 			nextPowTen = nextPowTen.Mul(ten)
 			nextBitLen = nextPowTen.BigIntMut().BitLen()
@@ -35,9 +45,11 @@ func init() {
 			bitLenToOrderOfMagnitude = append(bitLenToOrderOfMagnitude, orderLookup{orderOfMagnitude: curIndex, cmpValue: &cmpTen})
 		}
 
+		// Increment the current bit length
 		curBitLen++
 	}
 
+	// Set maxLookupValue to 100 times the next power of ten after maxLookupPowTen
 	maxLookupValue = nextPowTen.QuoRaw(100)
 }
 
@@ -51,6 +63,7 @@ func GetPrecomputeOrderOfMagnitude(amount osmomath.Int) int {
 	}
 
 	// Lookup the result based on the bit length
+	// If the cmpValue is not nil, then compare the amount with cmpValue.
 	val := bitLenToOrderOfMagnitude[bitLen]
 	if val.cmpValue == nil {
 		return val.orderOfMagnitude
@@ -60,44 +73,3 @@ func GetPrecomputeOrderOfMagnitude(amount osmomath.Int) int {
 	}
 	return val.orderOfMagnitude
 }
-
-// func init() {
-// 	curPowTen := osmomath.NewInt(1)
-// 	ten := osmomath.NewInt(10)
-// 	orderOfMagnitudeLookup = append(orderOfMagnitudeLookup, curPowTen)
-// 	for i := 1; i <= maxLookupIndex; i++ {
-// 		curPowTen = curPowTen.Mul(ten)
-// 		orderOfMagnitudeLookup = append(orderOfMagnitudeLookup, curPowTen)
-// 	}
-// 	maxLookupValue = curPowTen
-// 	maxLookupValueBitLen = maxLookupValue.BigIntMut().BitLen()
-// }
-
-// GetPrecomputeOrderOfMagnitude returns the order of magnitude of the given amount.
-// Uses look up table for precomputed order of magnitudes.
-// func GetPrecomputeOrderOfMagnitude(amount osmomath.Int) int {
-// 	if amount.BigIntMut().BitLen() >= maxLookupValueBitLen {
-// 		if amount.GT(maxLookupValue) {
-// 			a := amount.Quo(maxLookupValue)
-// 			return maxLookupIndex + GetPrecomputeOrderOfMagnitude(a)
-// 		}
-// 	}
-// 	low, high := 0, len(orderOfMagnitudeLookup)-1
-
-// 	for low <= high {
-// 		mid := (low + high) / 2
-// 		if amount.GT(orderOfMagnitudeLookup[mid]) {
-// 			low = mid + 1
-// 		} else if amount.LT(orderOfMagnitudeLookup[mid]) {
-// 			high = mid - 1
-// 		} else {
-// 			return mid
-// 		}
-// 	}
-
-// 	// If not found, return 0
-// 	return 0
-// }
-
-// GetPrecomputeOrderOfMagnitude returns the order of magnitude of the given amount.
-// Uses look up table for precomputed order of magnitudes.

--- a/router/usecase/precompute_test.go
+++ b/router/usecase/precompute_test.go
@@ -1,6 +1,7 @@
 package usecase_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -21,10 +22,10 @@ var (
 )
 
 func (s *RouterTestSuite) TestGetPrecomputeOrderOfMagnitude() {
-
-	tests := map[string]struct {
+	type testcase struct {
 		amount osmomath.Int
-	}{
+	}
+	tests := map[string]testcase{
 		"0 = 0": {
 			amount: osmomath.ZeroInt(),
 		},
@@ -34,21 +35,16 @@ func (s *RouterTestSuite) TestGetPrecomputeOrderOfMagnitude() {
 		"9.99 = 0": {
 			amount: osmomath.NewInt(9),
 		},
-		"10^9 - 1": {
-			amount: TenE9.Sub(osmomath.OneInt()),
-		},
-		"10^9": {
-			amount: TenE9,
-		},
-		"10^9 +1": {
-			amount: TenE9.Add(osmomath.OneInt()),
-		},
-		"10^18 +1": {
-			amount: TenE9.Mul(TenE9).Add(osmomath.OneInt()),
-		},
 		"10^15 +5": {
 			amount: TenE9.Mul(TenE6).Add(osmomath.OneInt()),
 		},
+	}
+	curPowTen := osmomath.OneInt()
+	for i := 1; i < 20; i++ {
+		curPowTen = curPowTen.Mul(TenE1)
+		tests[fmt.Sprintf("10^%d", i)] = testcase{amount: curPowTen}
+		tests[fmt.Sprintf("10^%d +1", i)] = testcase{amount: curPowTen.AddRaw(1)}
+		tests[fmt.Sprintf("10^%d -1", i)] = testcase{amount: curPowTen.SubRaw(1)}
 	}
 
 	for name, tc := range tests {

--- a/router/usecase/precompute_test.go
+++ b/router/usecase/precompute_test.go
@@ -9,6 +9,15 @@ import (
 
 var (
 	testAmount = osmomath.NewInt(1234567890323344555)
+	TenE9      = osmomath.NewInt(1_000_000_000)
+	TenE8      = osmomath.NewInt(100_000_000)
+	TenE7      = osmomath.NewInt(10_000_000)
+	TenE6      = osmomath.NewInt(1_000_000)
+	TenE5      = osmomath.NewInt(100_000)
+	TenE4      = osmomath.NewInt(10_000)
+	TenE3      = osmomath.NewInt(1_000)
+	TenE2      = osmomath.NewInt(100)
+	TenE1      = osmomath.NewInt(10)
 )
 
 func (s *RouterTestSuite) TestGetPrecomputeOrderOfMagnitude() {
@@ -26,19 +35,19 @@ func (s *RouterTestSuite) TestGetPrecomputeOrderOfMagnitude() {
 			amount: osmomath.NewInt(9),
 		},
 		"10^9 - 1": {
-			amount: usecase.TenE9.Sub(osmomath.OneInt()),
+			amount: TenE9.Sub(osmomath.OneInt()),
 		},
 		"10^9": {
-			amount: usecase.TenE9,
+			amount: TenE9,
 		},
 		"10^9 +1": {
-			amount: usecase.TenE9.Add(osmomath.OneInt()),
+			amount: TenE9.Add(osmomath.OneInt()),
 		},
 		"10^18 +1": {
-			amount: usecase.TenE9.Mul(usecase.TenE9).Add(osmomath.OneInt()),
+			amount: TenE9.Mul(TenE9).Add(osmomath.OneInt()),
 		},
 		"10^15 +5": {
-			amount: usecase.TenE9.Mul(usecase.TenE6).Add(osmomath.OneInt()),
+			amount: TenE9.Mul(TenE6).Add(osmomath.OneInt()),
 		},
 	}
 


### PR DESCRIPTION
This follows my comments in the Osmosis PR of making it be based off of bitlength. 

OLD:
```
BenchmarkGetPrecomputeOrderOfMagnitude-12    	 5726194	       214.0 ns/op	      96 B/op	       6 allocs/op
```
NEW:
```
BenchmarkGetPrecomputeOrderOfMagnitude-12    	13453051	        78.72 ns/op	      48 B/op	       3 allocs/op
```