### PR TITLE
Add an LRU cache for tick to sqrt price

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,8 @@ require (
 	google.golang.org/grpc v1.61.1
 )
 
+require github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+
 require (
 	cloud.google.com/go v0.112.0 // indirect
 	cloud.google.com/go/compute v1.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1074,6 +1074,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d h1:dg1dEPuWpEqDnvIw251EVy4zlP8gWbsGj4BsUKCRpYs=
 github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/router/usecase/pools/routable_concentrated_pool.go
+++ b/router/usecase/pools/routable_concentrated_pool.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/math"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	"github.com/osmosis-labs/sqs/domain"
@@ -26,6 +27,23 @@ type routableConcentratedPoolImpl struct {
 	TickModel     *sqsdomain.TickModel    "json:\"tick_model\""
 	TokenOutDenom string                  "json:\"token_out_denom\""
 	TakerFee      osmomath.Dec            "json:\"taker_fee\""
+}
+
+// Size is roughly `keys * (2.5 * Key_size + 2*value_size)`. (Plus whatever excess overhead hashmaps internally have)
+// key is 8 bytes, value is ~152 bytes
+// so at 100k keys its max RAM of ~30MB
+var tickToSqrtPriceCache, _ = lru.New2Q[int64, osmomath.BigDec](1000000)
+
+func getTickToSqrtPrice(tick int64) (osmomath.BigDec, error) {
+	if sqrtPrice, ok := tickToSqrtPriceCache.Get(tick); ok {
+		return sqrtPrice, nil
+	}
+
+	sqrtPrice, err := clmath.TickToSqrtPrice(tick)
+	if err != nil {
+		tickToSqrtPriceCache.Add(tick, sqrtPrice)
+	}
+	return sqrtPrice, err
 }
 
 // GetPoolDenoms implements sqsdomain.RoutablePool.
@@ -152,7 +170,7 @@ func (r *routableConcentratedPoolImpl) CalculateTokenOutByTokenIn(ctx context.Co
 		}
 
 		// Get the sqrt price for the next initialized tick index.
-		sqrtPriceTarget, err := clmath.TickToSqrtPrice(nextInitializedTickIndex)
+		sqrtPriceTarget, err := getTickToSqrtPrice(nextInitializedTickIndex)
 		if err != nil {
 			return sdk.Coin{}, err
 		}

--- a/router/usecase/pools/routable_concentrated_pool.go
+++ b/router/usecase/pools/routable_concentrated_pool.go
@@ -187,6 +187,7 @@ func (r *routableConcentratedPoolImpl) CalculateTokenOutByTokenIn(ctx context.Co
 	}
 
 	// Return the total amount out.
+	//nolint:all
 	return sdk.Coin{tokenOutDenom, amountOutTotal.TruncateInt()}, nil
 }
 

--- a/router/usecase/pools/routable_cw_transmuter_pool.go
+++ b/router/usecase/pools/routable_cw_transmuter_pool.go
@@ -69,6 +69,7 @@ func (r *routableTransmuterPoolImpl) CalculateTokenOutByTokenIn(ctx context.Cont
 
 	// No slippage swaps - just return the same amount of token out as token in
 	// as long as there is enough liquidity in the pool.
+	//nolint:all
 	return sdk.Coin{r.TokenOutDenom, tokenIn.Amount}, nil
 }
 


### PR DESCRIPTION
In CPU profiles we see Tick To Sqrt Price is costly, so here we just cache that call entirely. Along with https://github.com/osmosis-labs/osmosis/pull/8014 I expect this to eliminate most of the current per-call overhead of CL routings. 

This handles https://github.com/osmosis-labs/osmosis/issues/8015