### PR TITLE
feat: implement RouterOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleases
 
 - Pricing options; pricing source wiring at the app level
+- Router options; remove GetOptimalQuoteFromConfig API.
 
 ## v0.15.0
 

--- a/domain/mvc/router.go
+++ b/domain/mvc/router.go
@@ -13,9 +13,7 @@ import (
 // RouterUsecase represent the router's usecases
 type RouterUsecase interface {
 	// GetOptimalQuote returns the optimal quote for the given tokenIn and tokenOutDenom.
-	GetOptimalQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string) (domain.Quote, error)
-	// GetOptimalQuoteFromConfig returns the optimal quote for the given tokenIn and tokenOutDenom from the given config.
-	GetOptimalQuoteFromConfig(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, config domain.RouterConfig) (domain.Quote, error)
+	GetOptimalQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, opts ...domain.RouterOption) (domain.Quote, error)
 	// GetBestSingleRouteQuote returns the best single route quote for the given tokenIn and tokenOutDenom.
 	GetBestSingleRouteQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string) (domain.Quote, error)
 	// GetCustomDirectQuote returns the custom direct quote for the given tokenIn, tokenOutDenom and poolID.
@@ -30,8 +28,6 @@ type RouterUsecase interface {
 	SetTakerFees(takerFees sqsdomain.TakerFeeMap)
 	// GetPoolSpotPrice returns the spot price of a pool.
 	GetPoolSpotPrice(ctx context.Context, poolID uint64, quoteAsset, baseAsset string) (osmomath.BigDec, error)
-	// GetConfig returns the config for the SQS service
-	GetConfig() domain.RouterConfig
 	// GetCachedCandidateRoutes returns the candidate routes for the given tokenIn and tokenOutDenom from cache.
 	// It does not recompute the routes if they are not present in cache.
 	// Returns error if cache is disabled.

--- a/domain/router.go
+++ b/domain/router.go
@@ -93,3 +93,47 @@ type RouterState struct {
 	TakerFees sqsdomain.TakerFeeMap
 	TickMap   map[uint64]*sqsdomain.TickModel
 }
+
+// RouterOptions defines the options for the router
+type RouterOptions struct {
+	// Config is used to configure the router.
+	// By default, the router config that is defined on the router usecase is set.
+	// The calles of GetQuote(...) may overwrite the config with the options provided here.
+	// This is useful for pricing where we may want to use different parameters than the default config.
+	// With pricing, it is desired to use more pools with lower min liquidity parameter.
+	Config RouterConfig
+}
+
+// DefaultRouterOptions defines the default options for the router
+var DefaultRouterOptions = RouterOptions{}
+
+// RouterOption configures the router options.
+type RouterOption func(*RouterOptions)
+
+// WithMinOSMOLiquidity configures the router options with the min OSMO liquidity.
+func WithMinOSMOLiquidity(minOSMOLiquidity int) RouterOption {
+	return func(o *RouterOptions) {
+		o.Config.MinOSMOLiquidity = minOSMOLiquidity
+	}
+}
+
+// WithMaxPoolsPerRoute configures the router options with the max pools per route.
+func WithMaxPoolsPerRoute(maxPoolsPerRoute int) RouterOption {
+	return func(o *RouterOptions) {
+		o.Config.MaxPoolsPerRoute = maxPoolsPerRoute
+	}
+}
+
+// WithMaxRoutes configures the router options with the max routes.
+func WithMaxRoutes(maxRoutes int) RouterOption {
+	return func(o *RouterOptions) {
+		o.Config.MaxRoutes = maxRoutes
+	}
+}
+
+// WithDisableSplitRoutes configures the router options with the disabled split routes.
+func WithDisableSplitRoutes() RouterOption {
+	return func(o *RouterOptions) {
+		o.Config.MaxSplitRoutes = DisableSplitRoutes
+	}
+}

--- a/router/usecase/optimized_routes.go
+++ b/router/usecase/optimized_routes.go
@@ -19,13 +19,6 @@ import (
 // getSingleRouteQuote returns the best single route quote for the given tokenIn and tokenOutDenom.
 // Returns error if router repository is not set on the router.
 func (r *Router) getBestSingleRouteQuote(ctx context.Context, tokenIn sdk.Coin, routes []route.RouteImpl) (quote domain.Quote, err error) {
-	if r.routerRepository == nil {
-		return nil, ErrNilRouterRepository
-	}
-	if r.poolsUsecase == nil {
-		return nil, ErrNilPoolsRepository
-	}
-
 	bestSingleRouteQuote, _, err := r.estimateAndRankSingleRouteQuote(ctx, routes, tokenIn)
 	if err != nil {
 		return nil, err

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -666,12 +666,10 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuote_Mainnet_UOSMOU
 	// Setup router repository mock
 	routerRepositoryMock := routerrepo.New()
 	routerRepositoryMock.SetTakerFees(mainnetState.TakerFeeMap)
-	routerusecase.WithRouterRepository(router, routerRepositoryMock)
 
 	// Setup pools usecase mock.
 	poolsUsecase := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder")
 	poolsUsecase.StorePools(router.GetSortedPools())
-	routerusecase.WithPoolsUsecase(router, poolsUsecase)
 
 	routerUsecase := routerusecase.NewRouterUsecase(routerRepositoryMock, poolsUsecase, config, emptyCosmWasmPoolsRouterConfig, &log.NoOpLogger{}, cache.New(), cache.New())
 

--- a/router/usecase/router.go
+++ b/router/usecase/router.go
@@ -5,11 +5,9 @@ import (
 
 	cosmwasmpooltypes "github.com/osmosis-labs/osmosis/v24/x/cosmwasmpool/types"
 	"github.com/osmosis-labs/sqs/domain"
-	routerrepo "github.com/osmosis-labs/sqs/router/repository"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"go.uber.org/zap"
 
-	"github.com/osmosis-labs/sqs/domain/mvc"
 	"github.com/osmosis-labs/sqs/log"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -21,10 +19,6 @@ type Router struct {
 
 	config             domain.RouterConfig
 	cosmWasmPoolConfig domain.CosmWasmPoolRouterConfig
-
-	routerRepository routerrepo.RouterRepository
-
-	poolsUsecase mvc.PoolsUsecase
 
 	// The logger.
 	logger log.Logger
@@ -144,18 +138,6 @@ func WithSortedPools(router *Router, allPools []sqsdomain.PoolI) *Router {
 	// sort pools so that the appropriate pools are at the top
 	router.sortedPools = sortPools(router.sortedPools, router.cosmWasmPoolConfig.TransmuterCodeIDs, totalTVL, preferredPoolIDsMap, router.logger)
 
-	return router
-}
-
-// WithRouterRepository instruments router by setting a router repository on it and returns the router.
-func WithRouterRepository(router *Router, routerRepository routerrepo.RouterRepository) *Router {
-	router.routerRepository = routerRepository
-	return router
-}
-
-// WithPoolsUsecase instruments router by setting a pools usecase on it and returns the router.
-func WithPoolsUsecase(router *Router, poolsUsecase mvc.PoolsUsecase) *Router {
-	router.poolsUsecase = poolsUsecase
 	return router
 }
 

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -322,14 +322,12 @@ func (s *RouterTestHelper) SetupRouterAndPoolsUsecase(router *routerusecase.Rout
 	// Setup router repository mock
 	routerRepositoryMock := routerrepo.New()
 	routerRepositoryMock.SetTakerFees(mainnetState.TakerFeeMap)
-	routerusecase.WithRouterRepository(router, routerRepositoryMock)
 	routerusecase.WithComputedSortedPools(router, router.GetSortedPools())
 
 	// Setup pools usecase mock.
 	poolsUsecase := poolsusecase.NewPoolsUsecase(&DefaultPoolsConfig, "node-uri-placeholder")
 	err := poolsUsecase.StorePools(router.GetSortedPools())
 	s.Require().NoError(err)
-	routerusecase.WithPoolsUsecase(router, poolsUsecase)
 
 	routerUsecase := routerusecase.NewRouterUsecase(routerRepositoryMock, poolsUsecase, router.GetConfig(), router.GetCosmWasmPoolConfig(), &log.NoOpLogger{}, cacheOptions.RankedRoutes, cacheOptions.CandidateRoutes)
 	err = routerUsecase.SortPools(context.Background(), router.GetSortedPools())

--- a/tokens/usecase/pricing/chain/pricing_chain.go
+++ b/tokens/usecase/pricing/chain/pricing_chain.go
@@ -140,15 +140,15 @@ func (c *chainPricing) ComputePrice(ctx context.Context, baseDenom string, quote
 
 	// Overwrite default config with custom values
 	// necessary for pricing.
-	routerConfig := c.RUsecase.GetConfig()
-	routerConfig.MaxRoutes = c.maxRoutes
-	routerConfig.MaxPoolsPerRoute = c.maxPoolsPerRoute
-	routerConfig.MinOSMOLiquidity = c.minOSMOLiquidity
-	// Disable split routes
-	routerConfig.MaxSplitIterations = domain.DisableSplitRoutes
+	routingOptions := []domain.RouterOption{
+		domain.WithMaxRoutes(c.maxRoutes),
+		domain.WithMaxPoolsPerRoute(c.maxPoolsPerRoute),
+		domain.WithMinOSMOLiquidity(c.minOSMOLiquidity),
+		domain.WithDisableSplitRoutes(),
+	}
 
 	// Compute a quote for one quote coin.
-	quote, err := c.RUsecase.GetOptimalQuoteFromConfig(ctx, tenQuoteCoin, baseDenom, routerConfig)
+	quote, err := c.RUsecase.GetOptimalQuote(ctx, tenQuoteCoin, baseDenom, routingOptions...)
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}


### PR DESCRIPTION
Introduces router options to allow the flexibility of using custom router configuration for different functional components.

For example, for quotes we may want to use a higher min liquidity parameter so that only high-liquidity pools are used for routing.

However, for prices we may want to use a lower one to ensure maximal support.

Additionally, for precomputing prices, we may want to have no filter at all to ensure that we can compute prices of as many on-chain tokens as possible