### PR TITLE
Updated Makefile to add make reproducible build for amd64 and arm64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,14 @@ VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
 PACKAGES_UNIT=$(shell go list ./...)
+DOCKER := $(shell which docker)
+BUILDDIR ?= $(CURDIR)/build
+RUNNER := ubuntu
 
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 # check for nostrip option
 ifeq (,$(findstring nostrip,$(OSMOSIS_BUILD_OPTIONS)))
-  BUILD_FLAGS += -trimpath
+	BUILD_FLAGS += -trimpath
 endif
 
 
@@ -37,26 +40,27 @@ run:
 	go run -ldflags="-X github.com/osmosis-labs/sqs/version=${VERSION}" app/*.go  --config config.json
 
 run-docker:
-	docker rm -f sqs
-	docker run -d --name sqs -p 9092:9092 -p 26657:26657 -v /root/sqs/config-testnet.json/:/osmosis/config.json --net host osmolabs/sqs:local "--config /osmosis/config.json"
-	docker logs -f sqs
+	$(DOCKER) rm -f sqs
+	$(DOCKER) run -d --name sqs -p 9092:9092 -p 26657:26657 -v /root/sqs/config-testnet.json/:/osmosis/config.json --net host osmolabs/sqs:local "--config /osmosis/config.json"
+	$(DOCKER) logs -f sqs
 
 # Note: we migrated away from Redis.
 # This is left in case we require more data in the near future
 # prompting the need for Redis.
 redis-start:
-	docker run -d --name redis-stack -p 6379:6379 -p 8001:8001 -v ./redis-cache/:/data redis/redis-stack:7.2.0-v3
+	$(DOCKER) run -d --name redis-stack -p 6379:6379 -p 8001:8001 -v ./redis-cache/:/data redis/redis-stack:7.2.0-v3
 
 # Note: we migrated away from Redis.
 # This is left in case we require more data in the near future
 # prompting the need for Redis.
 redis-stop:
-	docker container rm -f redis-stack
+	$(DOCKER) container rm -f redis-stack
+
 osmosis-start:
-	docker run -d --name osmosis -p 26657:26657 -p 9090:9090 -p 1317:1317 -p 9091:9091 -p 6060:6060 -p 50051:50051 -v $(HOME)/.osmosisd/:/osmosis/.osmosisd/ --net host osmolabs/osmosis-dev:v24.x-4c99a57e-1712870916 "start"
+	$(DOCKER) run -d --name osmosis -p 26657:26657 -p 9090:9090 -p 1317:1317 -p 9091:9091 -p 6060:6060 -p 50051:50051 -v $(HOME)/.osmosisd/:/osmosis/.osmosisd/ --net host osmolabs/osmosis-dev:v24.x-4c99a57e-1712870916 "start"
 
 osmosis-stop:
-	docker container rm -f osmosis
+	$(DOCKER) container rm -f osmosis
 
 all-stop: osmosis-stop
 
@@ -71,29 +75,69 @@ test-unit:
 
 build:
 	BUILD_TAGS=muslc LINK_STATICALLY=true GOWORK=off go build -mod=readonly \
-    -tags "netgo,ledger,muslc" \
-    -ldflags "-w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
-    -v -o /osmosis/build/sqsd app/*.go 
+	-tags "netgo,ledger,muslc" \
+	-ldflags "-w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
+	-v -o /osmosis/build/sqsd app/*.go 
 
 ###############################################################################
 ###                                Docker                                  ###
 ###############################################################################
 
 docker-build:
-	@DOCKER_BUILDKIT=1 docker build \
-		-t osmolabs/sqs:0.7.3 \
-		--build-arg GO_VERSION=$(GO_VERSION) \
-		--build-arg GIT_VERSION=$(VERSION) \
-		--build-arg GIT_COMMIT=$(COMMIT) \
-		-f Dockerfile .
+	@DOCKER_BUILDKIT=1 $(DOCKER) build \
+	-t osmolabs/sqs:$(VERSION) \
+	--build-arg GO_VERSION=$(GO_VERSION) \
+	--build-arg GIT_VERSION=$(VERSION) \
+	--build-arg GIT_COMMIT=$(COMMIT) \
+	-f Dockerfile .
 
+# Cross-building for arm64 from amd64 (or vice-versa) takes
+# a lot of time due to QEMU virtualization but it's the only way (afaik)
+# to get a statically linked binary with CosmWasm
 
+build-reproducible: build-reproducible-amd64 build-reproducible-arm64
+
+build-reproducible-amd64: go.sum
+	mkdir -p $(BUILDDIR)
+	$(DOCKER) buildx create --name osmobuilder || true
+	$(DOCKER) buildx use osmobuilder
+	$(DOCKER) buildx build \
+	--build-arg GO_VERSION=$(GO_VERSION) \
+	--build-arg GIT_VERSION=$(VERSION) \
+	--build-arg GIT_COMMIT=$(COMMIT) \
+	--build-arg RUNNER_IMAGE=${RUNNER} \
+	--platform linux/amd64 \
+	-t sqs:local-amd64 \
+	--load \
+	-f Dockerfile .
+	$(DOCKER) rm -f sqsbinary || true
+	$(DOCKER) create -ti --name sqsbinary sqs:local-amd64
+	$(DOCKER) cp sqsbinary:/bin/sqsd $(BUILDDIR)/sqsd-linux-amd64
+	$(DOCKER) rm -f sqsbinary
+
+build-reproducible-arm64: go.sum
+	mkdir -p $(BUILDDIR)
+	$(DOCKER) buildx create --name osmobuilder || true
+	$(DOCKER) buildx use osmobuilder
+	$(DOCKER) buildx build \
+	--build-arg GO_VERSION=$(GO_VERSION) \
+	--build-arg GIT_VERSION=$(VERSION) \
+	--build-arg GIT_COMMIT=$(COMMIT) \
+	--build-arg RUNNER_IMAGE=${RUNNER} \
+	--platform linux/arm64 \
+	-t sqs:local-arm64 \
+	--load \
+	-f Dockerfile .
+	$(DOCKER) rm -f sqsbinary || true
+	$(DOCKER) create -ti --name sqsbinary sqs:local-arm64
+	$(DOCKER) cp sqsbinary:/bin/sqsd $(BUILDDIR)/sqsd-linux-arm64
+	$(DOCKER) rm -f sqsbinary
 ###############################################################################
 ###                                Utils                                    ###
 ###############################################################################
 
 load-test-ui:
-	docker compose -f locust/docker-compose.yml up --scale worker=4
+	$(DOCKER) compose -f locust/docker-compose.yml up --scale worker=4
 
 profile:
 	go tool pprof -http=:8080 http://localhost:9092/debug/pprof/profile?seconds=60


### PR DESCRIPTION
### Changes Made:
- Added a `build-reproducible` target in the Makefile.
- Included `build-reproducible-amd64` and `build-reproducible-arm64` targets to build sqs binaries for the amd64 and arm64 architectures, respectively.
- Set the `DOCKER` variable to the Docker executable path using a shell command.

This pull request introduces the build-reproducible target to the Makefile, facilitating the reproducible building of sqs binaries for both amd64 and arm64 architectures. This ensures consistent builds across different environments and platforms. The results for both commands are the binary creations sqsd-linux-amd64 and sqsd-linux-arm64* inside the build folder.

Additionally, the DOCKER variable is set to the path of the Docker executable using the `which` command, enabling easy access to Docker commands within the Makefile.

Please review and provide feedback. Thank you!