### PR TITLE
fix: pools with low liquidity being included in routes

### DIFF
--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -153,12 +153,16 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 		// Compute candidate routes.
 		candidateRoutes, err := GetCandidateRoutes(pools, tokenIn, tokenOutDenom, options.MaxRoutes, options.MaxPoolsPerRoute, r.logger)
 		if err != nil {
-			r.logger.Error("error handling routes", zap.Error(err))
+			r.logger.Error("error handling routes for pricing", zap.Error(err))
 			return nil, err
 		}
 
 		// Get the route with out caching.
 		topSingleRouteQuote, rankedRoutes, err = r.rankRoutesByDirectQuote(ctx, candidateRoutes, tokenIn, tokenOutDenom, options.MaxRoutes)
+		if err != nil {
+			r.logger.Error("error ranking routes for pricing", zap.Error(err))
+			return nil, err
+		}
 	} else if len(candidateRankedRoutes.Routes) == 0 {
 		poolsAboveMinLiquidity := r.getSortedPoolsShallowCopy()
 
@@ -565,7 +569,6 @@ func (r *routerUseCaseImpl) handleCandidateRoutes(ctx context.Context, pools []s
 		if err != nil {
 			return sqsdomain.CandidateRoutes{}, err
 		}
-
 	}
 
 	r.logger.Debug("cached routes", zap.Int("num_routes", len(candidateRoutes.Routes)))

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -153,7 +153,7 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 		// Compute candidate routes.
 		candidateRoutes, err := GetCandidateRoutes(pools, tokenIn, tokenOutDenom, options.MaxRoutes, options.MaxPoolsPerRoute, r.logger)
 		if err != nil {
-			r.logger.Error("error handling routes for pricing", zap.Error(err))
+			r.logger.Error("error getting candidate routes for pricing", zap.Error(err))
 			return nil, err
 		}
 

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -147,7 +147,7 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 	// some pools have TVL incorrectly calculated as zero. For example, BRNCH / STRDST (1288).
 	// As a result, they are incorrectly excluded despite having appropriate liquidity.
 	// So we want to calculate price, but we never cache routes for pricing the are below the minOSMOLiquidity value, as these are returned to users.
-	if options.MinOSMOLiquidity == 0 && len(candidateRankedRoutes.Routes) == 0 {
+	if options.MinOSMOLiquidity == 0 {
 		pools := r.getSortedPoolsShallowCopy()
 
 		// Compute candidate routes.

--- a/tokens/usecase/pricing/chain/pricing_chain.go
+++ b/tokens/usecase/pricing/chain/pricing_chain.go
@@ -176,6 +176,9 @@ func (c *chainPricing) computePrice(ctx context.Context, baseDenom string, quote
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}
+	if quote == nil {
+		return osmomath.BigDec{}, fmt.Errorf("no quote found when computing pricing for %s (base) -> %s (quote)", baseDenom, quoteDenom)
+	}
 
 	routes := quote.GetRoute()
 	if len(routes) == 0 {

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -185,6 +185,10 @@ func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quot
 			defer wg.Done()
 
 			prices, err := t.getPricesForBaseDenom(ctx, baseDenom, quoteDenoms, pricingSourceType, opts...)
+			if err != nil {
+				// This should not panic, so just logging the error here and continue
+				fmt.Println(err.Error())
+			}
 			resultsChan <- priceResults{baseDenom: baseDenom, prices: prices, err: err}
 		}(baseDenom)
 	}


### PR DESCRIPTION
### Description

Users have reported getting high price impact for certain routes, this is because when sqs starts we calulate the prices for tokens, but we actually cache the routes, so when we query the routes and there is a cache hit, the incorrect routes will be returned to the end user.

This issue is much more apparent for tokens with many low liquidity pools.

The fix just makes sure that if there is no minimum liquidity value we compute prices without caching.
e.g
https://github.com/osmosis-labs/sqs/blob/v24.x/tokens/usecase/pricing/worker/pricing_worker.go#L92 

### How to test

Run this multiple time to see the price impact:
- `curl https://sqsprod-eu.osmosis.zone/router/quote\?tokenIn\=100000000ibc%2F498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4\&tokenOutDenom\=uion | jq`

then run this branch:
- `curl http://localhost:9092/router/quote\?tokenIn\=100000000ibc%2F498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4\&tokenOutDenom\=uion | jq`