### PR TITLE
e2e test: foundation for getting desired testing tokens based on pool type, liquidity and volume

### DIFF
--- a/tests/data_service.py
+++ b/tests/data_service.py
@@ -1,0 +1,56 @@
+import requests
+
+# Endpoint URLs
+NUMIA_API_URL = 'https://data.numia-stage.osmosis.zone'
+TOKENS_ENDPOINT = '/tokens/v2/all'
+POOLS_ENDPOINT = '/stream/pool/v1/all'
+
+def fetch_tokens():
+    """Fetches all tokens from the specified endpoint and returns them."""
+    url = NUMIA_API_URL + TOKENS_ENDPOINT
+    try:
+        response = requests.get(url)
+        response.raise_for_status()  # Raise an error for unsuccessful requests
+        tokens = response.json()
+        return tokens
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching data from Numia: {e}")
+        return []
+
+def fetch_pools():
+    """Fetches all pools by iterating through paginated results and caches the results in memory."""
+    global cached_pool_data
+    url = NUMIA_API_URL + POOLS_ENDPOINT
+    all_pools = []
+    next_offset = 0
+    batch_size = 100  # Adjust if a different pagination size is needed
+
+    while True:
+        params = {'offset': next_offset, 'limit': batch_size}
+        try:
+            response = requests.get(url, params=params)
+            response.raise_for_status()
+            data = response.json()
+            pools = data.get('pools', [])
+            pagination = data.get('pagination', {})
+
+            # Add this batch to the accumulated pool data
+            all_pools.extend(pools)
+
+            # Determine if more pools are available
+            next_offset = pagination.get('next_offset')
+            if not next_offset:
+                break
+
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching data from Numia: {e}")
+            break
+
+    # retunr the pool data
+    return all_pools
+
+# Fetch all token data once
+all_tokens_data = fetch_tokens()
+
+# Fetch all pools data once
+all_pools_data = fetch_pools()

--- a/tests/data_service.py
+++ b/tests/data_service.py
@@ -18,7 +18,7 @@ def fetch_tokens():
         return []
 
 def fetch_pools():
-    """Fetches all pools by iterating through paginated results and caches the results in memory."""
+    """Fetches all pools by iterating through paginated results."""
     url = NUMIA_API_URL + POOLS_ENDPOINT
     all_pools = []
     next_offset = 0
@@ -45,7 +45,6 @@ def fetch_pools():
             print(f"Error fetching data from Numia: {e}")
             break
 
-    # retunr the pool data
     return all_pools
 
 # Fetch all token data once

--- a/tests/data_service.py
+++ b/tests/data_service.py
@@ -19,7 +19,6 @@ def fetch_tokens():
 
 def fetch_pools():
     """Fetches all pools by iterating through paginated results and caches the results in memory."""
-    global cached_pool_data
     url = NUMIA_API_URL + POOLS_ENDPOINT
     all_pools = []
     next_offset = 0

--- a/tests/main.py
+++ b/tests/main.py
@@ -1,9 +1,11 @@
 from setup import *
 
 # DEMO - to be removed in a subsequent PR
-print("Transmuter ", chain_denoms_to_display(choose_transmuter_tokens_by_liq_asc()))
+transmuter_token_pairs = choose_transmuter_pool_tokens_by_liq_asc(1)
+print("Transmuter ", [chain_denoms_to_display(pool_tokens[1]) for pool_tokens in transmuter_token_pairs])
 
-print("Astroport PCL ", chain_denoms_to_display(choose_pcl_tokens_by_liq_asc()))
+astroport_token_pairs = choose_pcl_pool_tokens_by_liq_asc(2)
+print("Astroport PCL ", [chain_denoms_to_display(pool_tokens[1]) for pool_tokens in astroport_token_pairs])
 
 print("Top Liquidity Token ", chain_denoms_to_display(choose_tokens_liq_range()))
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -4,7 +4,7 @@ from setup import *
 transmuter_token_pairs = choose_transmuter_pool_tokens_by_liq_asc(1)
 print("Transmuter ", [chain_denoms_to_display(pool_tokens[1]) for pool_tokens in transmuter_token_pairs])
 
-astroport_token_pairs = choose_pcl_pool_tokens_by_liq_asc(2)
+astroport_token_pairs = choose_pcl_pool_tokens_by_liq_asc(2, 1000, 10000)
 print("Astroport PCL ", [chain_denoms_to_display(pool_tokens[1]) for pool_tokens in astroport_token_pairs])
 
 print("Top Liquidity Token ", chain_denoms_to_display(choose_tokens_liq_range()))

--- a/tests/main.py
+++ b/tests/main.py
@@ -1,0 +1,14 @@
+from setup import *
+
+# DEMO - to be removed in a subsequent PR
+print("Transmuter ", chain_denoms_to_display(choose_transmuter_tokens_by_liq_asc()))
+
+print("Astroport PCL ", chain_denoms_to_display(choose_pcl_tokens_by_liq_asc()))
+
+print("Top Liquidity Token ", chain_denoms_to_display(choose_tokens_liq_range()))
+
+print("Top Volume Token ", chain_denoms_to_display(choose_tokens_volume_range()))
+
+print("2 Low Liquidity Tokens ", chain_denoms_to_display(choose_tokens_liq_range(2, 5000, 10000)))
+
+print("3 Low Volume Tokens ", chain_denoms_to_display(choose_tokens_volume_range(3, 5000, 10000)))

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -137,28 +137,46 @@ def get_token_data_copy():
     return copy.deepcopy(all_tokens_data)
 
 
+def choose_tokens_generic(tokens, filter_key, min_value, max_value, sort_key, num_tokens=1, asc=False):
+    """
+    A generic function to choose tokens based on given criteria.
+
+    Args:
+        tokens (list): The list of token data dictionaries.
+        filter_key (str): The field name used to filter tokens.
+        min_value (float): The minimum value for filtering.
+        max_value (float): The maximum value for filtering.
+        sort_key (str): The field name used for sorting tokens.
+        num_tokens (int): The number of tokens to return.
+        asc (bool): Whether to sort in ascending order.
+
+    Returns:
+        list: A list of denoms matching the given criteria.
+    """
+    # Filter tokens based on the specified filter_key range
+    filtered_tokens = [
+        t['denom'] for t in tokens if filter_key in t and t[filter_key] is not None and min_value <= t[filter_key] <= max_value
+    ]
+
+    # Sort tokens based on the specified sort_key
+    sorted_tokens = sorted(
+        filtered_tokens, key=lambda x: next(t[sort_key] for t in tokens if t['denom'] == x), reverse=not asc
+    )
+
+    return sorted_tokens[:num_tokens]
+
+
 def choose_tokens_liq_range(num_tokens=1, min_liq=0, max_liq=float('inf'), asc=False):
     """Function to choose tokens based on liquidity."""
     tokens = get_token_data_copy()
-    filtered_tokens = [
-        t['denom'] for t in tokens if 'liquidity' in t and t['liquidity'] is not None and min_liq <= t['liquidity'] <= max_liq
-    ]
-    sorted_tokens = sorted(
-        filtered_tokens, key=lambda x: next(t['liquidity'] for t in tokens if t['denom'] == x), reverse=not asc
-    )
-    return sorted_tokens[:num_tokens]
+    return choose_tokens_generic(tokens, 'liquidity', min_liq, max_liq, 'liquidity', num_tokens, asc)
+
 
 def choose_tokens_volume_range(num_tokens=1, min_vol=0, max_vol=float('inf'), asc=False):
     """Function to choose tokens based on volume."""
-
     tokens = get_token_data_copy()
-    filtered_tokens = [
-        t['denom'] for t in tokens if 'volume_24h' in t and t['volume_24h'] is not None and min_vol <= t['volume_24h'] <= max_vol
-    ]
-    sorted_tokens = sorted(
-        filtered_tokens, key=lambda x: next(t['volume_24h'] for t in tokens if t['denom'] == x), reverse=not asc
-    )
-    return sorted_tokens[:num_tokens]
+    return choose_tokens_generic(tokens, 'volume_24h', min_vol, max_vol, 'volume_24h', num_tokens, asc)
+
 
 def choose_pool_type_tokens_by_liq_asc(pool_type, num_pairs=1, min_liq=0, max_liq=float('inf'), asc=False):
     """Function to choose pool ID and tokens associated with a specific pool type based on liquidity.

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -109,25 +109,28 @@ def map_pool_type_to_pool_data(pool_data):
 
     return pool_type_to_data
 
-def create_display_to_data_map(tokens_data):
-    """Function to map display field to the data of that token."""
+def create_field_to_data_map(tokens_data, key_field):
+    """Maps a specified key field to the data of that token.
 
-    display_map = {}
+    Args:
+        tokens_data (list): List of token data dictionaries.
+        key_field (str): The field to use as the mapping key.
+
+    Returns:
+        dict: A dictionary mapping the specified key field to the token data.
+    """
+    mapping = {}
     for token in tokens_data:
-        display_field = token.get('display')
-        if display_field:
-            display_map[display_field] = token
-    return display_map
+        key_value = token.get(key_field)
+        if key_value:
+            mapping[key_value] = token
+    return mapping
+
+def create_display_to_data_map(tokens_data):
+    return create_field_to_data_map(tokens_data, 'display')
 
 def create_chain_denom_to_data_map(tokens_data):
-    """Function to map chain denom to the data of that token."""
-
-    display_map = {}
-    for token in tokens_data:
-        display_field = token.get('denom')
-        if display_field:
-            display_map[display_field] = token
-    return display_map
+    return create_field_to_data_map(tokens_data, 'denom')
 
 def get_token_data_copy():
     """Return deep copy of all tokens."""

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -179,28 +179,50 @@ def choose_tokens_volume_range(num_tokens=1, min_vol=0, max_vol=float('inf'), as
 
 
 def choose_pool_type_tokens_by_liq_asc(pool_type, num_pairs=1, min_liq=0, max_liq=float('inf'), asc=False):
-    """Function to choose pool ID and tokens associated with a specific pool type based on liquidity.
-    Returns [pool ID, [tokens]]"""
-    
-    pools_tokens_of_type = pool_type_to_denoms.get(pool_type)
+    """
+    Function to choose pool ID and tokens associated with a specific pool type based on liquidity.
 
-    sorted_pools = sorted(pools_tokens_of_type, key=lambda x: x[1], reverse=not asc)
+    Args:
+        pool_type (E2EPoolType): The pool type to filter by.
+        num_pairs (int): The number of pool pairs to return.
+        min_liq (float): The minimum liquidity value.
+        max_liq (float): The maximum liquidity value.
+        asc (bool): Whether to sort in ascending or descending order.
 
-    return [[pool_data[1], pool_data[2]] for pool_data in sorted_pools[:num_pairs]]
+    Returns:
+        list: [[pool ID, [tokens]], ...]
+    """
+    # Retrieve pools associated with the specified pool type
+    pools_tokens_of_type = pool_type_to_denoms.get(pool_type, [])
+
+    # Filter pools based on the provided min_liq and max_liq values
+    filtered_pools = [
+        pool for pool in pools_tokens_of_type if min_liq <= pool[1] <= max_liq
+    ]
+
+    # Sort the filtered pools based on liquidity
+    sorted_pools = sorted(filtered_pools, key=lambda x: x[1], reverse=not asc)
+
+    # Extract only the required number of pairs
+    return [[pool_data[0], pool_data[2]] for pool_data in sorted_pools[:num_pairs]]
+
 
 def choose_transmuter_pool_tokens_by_liq_asc(num_pairs=1, min_liq=0, max_liq=float('inf'), asc=False):
     """Function to choose pool ID and tokens associated with a transmuter V1 pool type based on liquidity.
     Returns [pool ID, [tokens]]"""
     return choose_pool_type_tokens_by_liq_asc(E2EPoolType.COSMWASM_TRANSMUTER_V1, num_pairs, min_liq, max_liq, asc)
 
+
 def choose_pcl_pool_tokens_by_liq_asc(num_pairs=1, min_liq=0, max_liq=float('inf'), asc=False):
     """Function to choose pool ID and tokens associated with a Astroport PCL pool type based on liquidity.
     Returns [pool ID, [tokens]]"""
     return choose_pool_type_tokens_by_liq_asc(E2EPoolType.COSMWASM_ASTROPORT, num_pairs, min_liq, max_liq, asc)
 
+
 def chain_denom_to_display(chain_denom):
     """Function to map chain denom to display."""
     return chain_denom_to_data_map.get(chain_denom, {}).get('display', chain_denom)
+
 
 def chain_denoms_to_display(chain_denoms):
     """Function to map chain denoms to display."""

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -85,10 +85,6 @@ def map_pool_type_to_pool_data(pool_data):
 
     return pool_type_to_data
 
-def filter_neq(source_list, neq_value):
-    """Keeps items that are not equal to value."""
-    return [element for element in source_list if element != neq_value]
-
 def create_display_to_data_map(tokens_data):
     """Function to map display field to the data of that token."""
 
@@ -100,7 +96,7 @@ def create_display_to_data_map(tokens_data):
     return display_map
 
 def create_chain_denom_to_data_map(tokens_data):
-    """Function to map chain denom the data of that token."""
+    """Function to map chain denom to the data of that token."""
 
     display_map = {}
     for token in tokens_data:
@@ -171,5 +167,5 @@ display_to_data_map = create_display_to_data_map(all_tokens_data)
 # Create a map of chain denom to token data
 chain_denom_to_data_map = create_chain_denom_to_data_map(all_tokens_data)
 
-# Create a map of pool type to denoms
+# Create a map of pool type to pool data
 pool_type_to_denoms = map_pool_type_to_pool_data(all_pools_data)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -32,6 +32,7 @@ NUMIA_TO_E2E_MAP = {
 # Misc constants
 UOSMO = "uosmo"
 
+
 def get_e2e_pool_type_from_numia_pool(pool):
     """Gets an e2e pool type from a Numia pool."""
     numia_pool_type = pool.get("type")
@@ -52,6 +53,7 @@ def get_e2e_pool_type_from_numia_pool(pool):
 
     # Raise an error for unknown pool types
     raise ValueError(f"Unknown pool type: {numia_pool_type}")
+
 
 def get_denoms_from_pool_tokens(pool_tokens):
     """
@@ -109,6 +111,7 @@ def map_pool_type_to_pool_data(pool_data):
 
     return pool_type_to_data
 
+
 def create_field_to_data_map(tokens_data, key_field):
     """Maps a specified key field to the data of that token.
 
@@ -126,11 +129,14 @@ def create_field_to_data_map(tokens_data, key_field):
             mapping[key_value] = token
     return mapping
 
+
 def create_display_to_data_map(tokens_data):
     return create_field_to_data_map(tokens_data, 'display')
 
+
 def create_chain_denom_to_data_map(tokens_data):
     return create_field_to_data_map(tokens_data, 'denom')
+
 
 def get_token_data_copy():
     """Return deep copy of all tokens."""


### PR DESCRIPTION
https://linear.app/osmosis/issue/STABI-141/[sqs-automated-tests-in-ci][shared-setup]

## Background

For most tests, we will frequently need to use certain heuristics for picking the tokens that we want to test. As a result, we should implement this as a shared package.

- Choose X tokens with high liquidity, specifying min and max range in USD

- Choose X tokens with low liquidity, specifying min and max range in USD

- Choose X tokens with high volume, specifying min and max range in USD

- Choose X tokens with low volume, specifying min and max range in USD

- Choose X tokens for which we know, there is a transmuter USDC/USDC.axl, WBTC/WBTC.axl

- Query all transmuter pools, find unique tokens across them and return X by-liq

- Choose X tokens for which we know, there is a PCL pool - ASTRO

- Query all PCL pools, find unique tokens across them and return X by-liq

## Testing

This PR implements the helpers and provides a `main.py` script for testing:

```
python3 tests/main.py
Transmuter  [['usdc', 'usdc']]
Astroport PCL  [['osmo', 'axl'], ['stars', 'osmo']]
Top Liquidity Token  ['osmo']
Top Volume Token  ['usdc']
2 Low Liquidity Tokens  ['gusdc', 'sikoba']
3 Low Volume Tokens  ['dym', 'ISLM', 'kuji']
```