### PR TITLE
feat: /config-private endpoint, mask otel in /config endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+- /config-private endpoint, mask OTEL config in /config endpoint
+
 ## v0.17.8
 
 - Rebuild image from new dockerfile

--- a/system/delivery/http/system_http_handler.go
+++ b/system/delivery/http/system_http_handler.go
@@ -40,7 +40,7 @@ type JsonResponse struct {
 	} `json:"result"`
 }
 
-// ConfigResponse defines the response for the /config-private endpoint
+// ConfigPrivateResponse defines the response for the /config-private endpoint
 type ConfigPrivateResponse struct {
 	OTEL *domain.OTELConfig `json:"otel"`
 }

--- a/system/delivery/http/system_http_handler.go
+++ b/system/delivery/http/system_http_handler.go
@@ -40,6 +40,11 @@ type JsonResponse struct {
 	} `json:"result"`
 }
 
+// ConfigResponse defines the response for the /config-private endpoint
+type ConfigPrivateResponse struct {
+	OTEL *domain.OTELConfig `json:"otel"`
+}
+
 const (
 	heightTolerance       = 10
 	versionPlaceholder    = "version="
@@ -70,6 +75,7 @@ func NewSystemHandler(e *echo.Echo, config domain.Config, logger log.Logger, us 
 
 	e.GET("/healthcheck", handler.GetHealthStatus)
 	e.GET("/config", handler.GetConfig)
+	e.GET("/config-private", handler.GetConfigPrivate)
 	e.GET("/version", handler.GetVersion)
 	e.GET("/metrics", echo.WrapHandler(promhttp.Handler()))
 	e.GET("/swagger/*", echoSwagger.EchoWrapHandler(echoSwagger.URL("docs/swagger.json"), echoSwagger.URL("swagger.yaml")))
@@ -77,7 +83,20 @@ func NewSystemHandler(e *echo.Echo, config domain.Config, logger log.Logger, us 
 
 // GetConfig returns the config for the SQS service
 func (h *SystemHandler) GetConfig(c echo.Context) error {
+	// Mask OTEL config since it containts sensitive information
+	// Fode debugging, we expose a separate endpoint that we block in LB.
+	config := h.config
+	config.OTEL = nil
+
 	return c.JSON(http.StatusOK, h.config)
+}
+
+// GetConfigPrivate returns the OTEL config that containts
+// sensitive information. This endpoint is meant to be blocked in the LB.
+func (h *SystemHandler) GetConfigPrivate(c echo.Context) error {
+	return c.JSON(http.StatusOK, ConfigPrivateResponse{
+		OTEL: h.config.OTEL,
+	})
 }
 
 func (h *SystemHandler) GetVersion(c echo.Context) error {

--- a/system/delivery/http/system_http_handler.go
+++ b/system/delivery/http/system_http_handler.go
@@ -83,7 +83,7 @@ func NewSystemHandler(e *echo.Echo, config domain.Config, logger log.Logger, us 
 
 // GetConfig returns the config for the SQS service
 func (h *SystemHandler) GetConfig(c echo.Context) error {
-	// Mask OTEL config since it containts sensitive information
+	// Mask OTEL config since it contains sensitive information
 	// Fode debugging, we expose a separate endpoint that we block in LB.
 	config := h.config
 	config.OTEL = nil
@@ -91,7 +91,7 @@ func (h *SystemHandler) GetConfig(c echo.Context) error {
 	return c.JSON(http.StatusOK, h.config)
 }
 
-// GetConfigPrivate returns the OTEL config that containts
+// GetConfigPrivate returns the OTEL config that contains
 // sensitive information. This endpoint is meant to be blocked in the LB.
 func (h *SystemHandler) GetConfigPrivate(c echo.Context) error {
 	return c.JSON(http.StatusOK, ConfigPrivateResponse{


### PR DESCRIPTION
We block /config endpoint in stage and production because it contains sensitive information

However, it is useful to have it.

As a solution, we expose a separate `/config-private` endpoint with the sensitive config that we can block in LB.

For `/config`, we overwrite the sensitive information, allowing us to unblock it.