### PR TITLE
fix: DYDX spot price bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+- Fix Astroport PCL spot price bug - failure to utilize token out denom for quote estimate in edge cases
+
 ## v0.17.10
 
 - /config-private endpoint, mask OTEL config in /config endpoint

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -705,7 +705,7 @@ func (r *routerUseCaseImpl) GetPoolSpotPrice(ctx context.Context, poolID uint64,
 		return osmomath.BigDec{}, fmt.Errorf("taker fee not found for pool %d, denom in (%s), denom out (%s)", poolID, quoteAsset, baseAsset)
 	}
 
-	spotPrice, err := r.poolsUsecase.GetPoolSpotPrice(ctx, poolID, poolTakerFee, baseAsset, quoteAsset)
+	spotPrice, err := r.poolsUsecase.GetPoolSpotPrice(ctx, poolID, poolTakerFee, quoteAsset, baseAsset)
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}

--- a/sqsdomain/routable_pool.go
+++ b/sqsdomain/routable_pool.go
@@ -33,9 +33,6 @@ type RoutablePool interface {
 	CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error)
 	ChargeTakerFeeExactIn(tokenIn sdk.Coin) (tokenInAfterFee sdk.Coin)
 
-	// SetTokenOutDenom sets the token out denom on the routable pool.
-	SetTokenOutDenom(tokenOutDenom string)
-
 	GetTakerFee() osmomath.Dec
 
 	GetSpreadFactor() osmomath.Dec

--- a/tokens/usecase/pricing/chain/pricing_chain.go
+++ b/tokens/usecase/pricing/chain/pricing_chain.go
@@ -221,8 +221,6 @@ func (c *chainPricing) computePrice(ctx context.Context, baseDenom string, quote
 	if useAlternativeMethod {
 		// Compute on-chain price for 1 unit of base denom and quote denom.
 		chainPrice = osmomath.NewBigDecFromBigInt(tenQuoteCoin.Amount.BigIntMut()).QuoMut(osmomath.NewBigDecFromBigInt(quote.GetAmountOut().BigIntMut()))
-	} else {
-		chainPrice = osmomath.OneBigDec().QuoMut(chainPrice)
 	}
 
 	if chainPrice.IsZero() {


### PR DESCRIPTION
Fixes this:
![image](https://github.com/osmosis-labs/sqs/assets/34196718/89397daf-537f-4c51-81d4-9fa786a957a1)

The core of the bug was that in edge cases the `TokenOutDenom` is not set by design. As a result, the quote-based spot price method for Astroport PCL pools would fail, falling back to the CW pool query that would return spot price that is already scaled.

That would result in falling back to querying the contract directly but the contract returns already descaled spot price (relative to denom precision by mistake)


## Testing

### Prod Prices

```

  "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C": {
    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4": "2164876635285.779993175913358528062425000000000000"
  },
  "ibc/B8C608CEE08C4F30A15A7955306F2EDAF4A02BB191CABC4185C1A57FD978DA1B": {
    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4": "0.095202519949110931378352595589401691"
  },
  "uosmo": {
    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4": "0.871430586109772434016678413411669181"
  }
}
```

This PR prices

```
{
  "ibc/831F0B1BBB1D08A2B75311892876D71565478C532967545476DF4C2D7492E48C": {
    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4": "2.167893220913947883791043000000000000"
  },
  "ibc/B8C608CEE08C4F30A15A7955306F2EDAF4A02BB191CABC4185C1A57FD978DA1B": {
    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4": "0.095391145246243553183855132539200743"
  },
  "uosmo": {
    "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4": "0.871361998916329797000000000000000000"
  }
}
```

⏫ Note that all prices are the same but DYDX is fixed