### PR TITLE
POC: local mcap (progress towards dynamic min liquidity)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,20 @@
             ],
         },
         {
+            "name": "ingest/usecase",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/ingest/usecase",
+            "args": [
+                "-test.timeout",
+                "30m",
+                "-test.run",
+                "TestIngestUseCaseTestSuite/TestUpdateUniqueDenomData",
+                "-test.v"
+            ],
+        },
+        {
             "name": "tokens/usecase",
             "type": "go",
             "request": "launch",
@@ -37,7 +51,7 @@
                 "-test.timeout",
                 "30m",
                 "-test.run",
-                "TestTokensUseCaseTestSuite/TestGetPrices_Chain_PricingOptions",
+                "TestTokensUseCaseTestSuite/TestPoolDenomMetadata",
                 "-test.v"
             ],
         },

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -142,9 +142,14 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 
 		quotePriceUpdateWorker := pricingWorker.New(tokensUseCase, defaultQuoteDenom, logger)
 
+		poolLiquidityComputeWorker := pricingWorker.NewPoolLiquidityWorker(tokensUseCase, poolsUseCase)
+
 		// chain info use case acts as the healthcheck. It receives updates from the pricing worker.
 		// It then passes the healthcheck as long as updates are received at the appropriate intervals.
 		quotePriceUpdateWorker.RegisterListener(chainInfoUseCase)
+
+		// pool liquidity compute worker listens to the quote price update worker.
+		quotePriceUpdateWorker.RegisterListener(poolLiquidityComputeWorker)
 
 		// Initialize ingest handler and usecase
 		ingestUseCase, err := ingestusecase.NewIngestUsecase(poolsUseCase, routerUsecase, tokensUseCase, chainInfoUseCase, appCodec, quotePriceUpdateWorker, logger)

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -147,7 +147,7 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 		quotePriceUpdateWorker.RegisterListener(chainInfoUseCase)
 
 		// Initialize ingest handler and usecase
-		ingestUseCase, err := ingestusecase.NewIngestUsecase(poolsUseCase, routerUsecase, chainInfoUseCase, appCodec, quotePriceUpdateWorker, logger)
+		ingestUseCase, err := ingestusecase.NewIngestUsecase(poolsUseCase, routerUsecase, tokensUseCase, chainInfoUseCase, appCodec, quotePriceUpdateWorker, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/chaininfo/usecase/chain_info_usecase.go
+++ b/chaininfo/usecase/chain_info_usecase.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	chaininforepo "github.com/osmosis-labs/sqs/chaininfo/repository"
 	"github.com/osmosis-labs/sqs/domain"
 
@@ -89,7 +90,7 @@ func (p *chainInfoUseCase) StoreLatestHeight(height uint64) {
 }
 
 // OnPricingUpdate implements domain.PricingUpdateListener.
-func (p *chainInfoUseCase) OnPricingUpdate(ctx context.Context, height int64, pricesBaseQuoteDenomMap map[string]map[string]any, quoteDenom string) error {
+func (p *chainInfoUseCase) OnPricingUpdate(ctx context.Context, height int64, blockMetadata domain.BlockPoolMetadata, pricesBaseQuoteDenomMap map[string]map[string]osmomath.BigDec, quoteDenom string) error {
 	p.priceUpdateHeightMx.Lock()
 	defer p.priceUpdateHeightMx.Unlock()
 	p.latestPricesUpdateHeight = uint64(height)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -166,6 +166,32 @@ const docTemplate = `{
                 }
             }
         },
+        "/tokens/pool-metadata": {
+            "get": {
+                "description": "returns pool denom metadata. As of today, this metadata is represented by the local market cap of the token computed over all Osmosis pools.\nFor testnet, uses osmo-test-5 asset list. For mainnet, uses osmosis-1 asset list.\nSee ` + "`" + `config.json` + "`" + ` and ` + "`" + `config-testnet.json` + "`" + ` in root for details.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Pool Denom Metadata",
+                "operationId": "get-pool-denom-metadata",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "List of denoms where each can either be a human denom or a chain denom",
+                        "name": "denoms",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Boolean flag indicating whether the given denoms are human readable or not. Human denoms get converted to chain internally",
+                        "name": "humanDenoms",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
         "/tokens/prices": {
             "get": {
                 "description": "Given a list of base denominations, returns the spot price with a system-configured quote denomination.",
@@ -215,6 +241,10 @@ const docTemplate = `{
                 "human_denom": {
                     "description": "HumanDenom is the human readable denom.",
                     "type": "string"
+                },
+                "is_unlisted": {
+                    "description": "IsUnlisted is true if the token is unlisted.",
+                    "type": "boolean"
                 },
                 "precision": {
                     "description": "Precision is the precision of the token.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -157,6 +157,32 @@
                 }
             }
         },
+        "/tokens/pool-metadata": {
+            "get": {
+                "description": "returns pool denom metadata. As of today, this metadata is represented by the local market cap of the token computed over all Osmosis pools.\nFor testnet, uses osmo-test-5 asset list. For mainnet, uses osmosis-1 asset list.\nSee `config.json` and `config-testnet.json` in root for details.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Pool Denom Metadata",
+                "operationId": "get-pool-denom-metadata",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "List of denoms where each can either be a human denom or a chain denom",
+                        "name": "denoms",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Boolean flag indicating whether the given denoms are human readable or not. Human denoms get converted to chain internally",
+                        "name": "humanDenoms",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {}
+            }
+        },
         "/tokens/prices": {
             "get": {
                 "description": "Given a list of base denominations, returns the spot price with a system-configured quote denomination.",
@@ -206,6 +232,10 @@
                 "human_denom": {
                     "description": "HumanDenom is the human readable denom.",
                     "type": "string"
+                },
+                "is_unlisted": {
+                    "description": "IsUnlisted is true if the token is unlisted.",
+                    "type": "boolean"
                 },
                 "precision": {
                     "description": "Precision is the precision of the token.",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4,6 +4,9 @@ definitions:
       human_denom:
         description: HumanDenom is the human readable denom.
         type: string
+      is_unlisted:
+        description: IsUnlisted is true if the token is unlisted.
+        type: boolean
       precision:
         description: Precision is the precision of the token.
         type: integer
@@ -152,6 +155,29 @@ paths:
               $ref: '#/definitions/domain.Token'
             type: object
       summary: Token Metadata
+  /tokens/pool-metadata:
+    get:
+      description: |-
+        returns pool denom metadata. As of today, this metadata is represented by the local market cap of the token computed over all Osmosis pools.
+        For testnet, uses osmo-test-5 asset list. For mainnet, uses osmosis-1 asset list.
+        See `config.json` and `config-testnet.json` in root for details.
+      operationId: get-pool-denom-metadata
+      parameters:
+      - description: List of denoms where each can either be a human denom or a chain
+          denom
+        in: query
+        name: denoms
+        type: string
+      - description: Boolean flag indicating whether the given denoms are human readable
+          or not. Human denoms get converted to chain internally
+        in: query
+        name: humanDenoms
+        required: true
+        type: boolean
+      produces:
+      - application/json
+      responses: {}
+      summary: Pool Denom Metadata
   /tokens/prices:
     get:
       consumes:

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -166,3 +166,11 @@ type StaleHeightError struct {
 func (e StaleHeightError) Error() string {
 	return fmt.Sprintf("stored height (%d) is stale, time since last update (%d), max allowed seconds (%d)", e.StoredHeight, e.TimeSinceLastUpdate, e.MaxAllowedTimeDeltaSecs)
 }
+
+type PoolDenomMetaDataNotPresentError struct {
+	ChainDenom string
+}
+
+func (e PoolDenomMetaDataNotPresentError) Error() string {
+	return fmt.Sprintf("pool denom metadata for denom (%s) is not found", e.ChainDenom)
+}

--- a/domain/mocks/pricing_update_listener_mock.go
+++ b/domain/mocks/pricing_update_listener_mock.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 )
 
 type PricingUpdateListenerMock struct {
 	Height                 int
-	PricesBaseQuteDenomMap map[string]map[string]any
+	PricesBaseQuteDenomMap map[string]map[string]osmomath.BigDec
 	QuoteDenom             string
 
 	Done chan struct{}
@@ -22,7 +23,7 @@ type PricingUpdateListenerMock struct {
 func NewPricingListenerMock(timeout time.Duration) *PricingUpdateListenerMock {
 	return &PricingUpdateListenerMock{
 		Done:                   make(chan struct{}),
-		PricesBaseQuteDenomMap: make(map[string]map[string]any),
+		PricesBaseQuteDenomMap: make(map[string]map[string]osmomath.BigDec),
 		timeout:                timeout,
 	}
 }
@@ -30,7 +31,7 @@ func NewPricingListenerMock(timeout time.Duration) *PricingUpdateListenerMock {
 var _ domain.PricingUpdateListener = &PricingUpdateListenerMock{}
 
 // OnPricingUpdate implements worker.PricingUpdateListener.
-func (p *PricingUpdateListenerMock) OnPricingUpdate(ctx context.Context, height int64, pricesBaseQuoteDenomMap map[string]map[string]any, quoteDenom string) error {
+func (p *PricingUpdateListenerMock) OnPricingUpdate(ctx context.Context, height int64, blockMetadata domain.BlockPoolMetadata, pricesBaseQuoteDenomMap map[string]map[string]osmomath.BigDec, quoteDenom string) error {
 	p.Height = int(height)
 	p.QuoteDenom = quoteDenom
 

--- a/domain/mvc/tokens.go
+++ b/domain/mvc/tokens.go
@@ -2,7 +2,10 @@ package mvc
 
 import (
 	"context"
+	"fmt"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/labstack/echo/v4"
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 )
@@ -36,8 +39,79 @@ type TokensUsecase interface {
 	// The result of the inner map is prices of the outer base and inner quote.
 	GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (map[string]map[string]any, error)
 
+	// UpdatePoolDenomMetadata updates the pool denom metadata, completely overwriting any previous
+	// denom results stored internally, if any. The denoms metadata that is present internally
+	// but not in the provided map will be left unchanged.
+	UpdatePoolDenomMetadata(tokensMetadata map[string]domain.PoolDenomMetaData)
+
+	// GetPoolDenomMetadata returns the pool denom metadata of a pool denom.
+	// This metadata is accumulated from all pools.
+	GetPoolDenomMetadata(chainDenom string) (domain.PoolDenomMetaData, error)
+
+	// GetPoolLiquidityCap returns the pool liquidity market cap for a given chain denom.
+	// This value is accumulated from all Osmosis pools.
+	GetPoolLiquidityCap(chainDenom string) (osmomath.Int, error)
+
+	// GetPoolDenomsMetadata returns the pool denom metadata for the given chain denoms.
+	// These values are accumulated from all Osmosis pools.
+	GetPoolDenomsMetadata(chainDenoms []string) map[string]domain.PoolDenomMetaData
+
+	// GetFullPoolDenomMetadata returns the local market caps for all chain denoms.
+	// For any valid (per the asset list) denom, if there is no metadata, it will be set to empty
+	// and all values such as local market cap will be set to zero.
+	GetFullPoolDenomMetadata() map[string]domain.PoolDenomMetaData
+
 	// RegisterPricingStrategy registers a pricing strategy for a given pricing source.
 	RegisterPricingStrategy(source domain.PricingSourceType, strategy domain.PricingSource)
 
 	IsValidChainDenom(chainDenom string) bool
+}
+
+// ValidateChainDenomQueryParam validates the chain denom query parameter.
+// If isHumanDenoms is true, it converts the human denom to chain denom.
+// If isHumanDenoms is false, it validates the chain denom.
+// Returns the chain denom and an error if any.
+func ValidateChainDenomQueryParam(tokensUsecase TokensUsecase, denom string, isHumanDenoms bool) (string, error) {
+	// Note that sdk.Coins initialization
+	// auto-converts base denom from human
+	// to IBC notation.
+	// As a result, we avoid attempting the
+	// to convert a denom that is already changed.
+	baseDenom, err := sdk.GetBaseDenom()
+	if err != nil {
+		return "", nil
+	}
+
+	if isHumanDenoms {
+		// Convert human denom to chain denom.
+		// See definition of baseDenom.
+		if denom != baseDenom {
+			return tokensUsecase.GetChainDenom(denom)
+		}
+	} else {
+		if !tokensUsecase.IsValidChainDenom(denom) {
+			return "", fmt.Errorf("denom is not a valid chain denom (%s)", denom)
+		}
+	}
+
+	// Valid chain denom
+	return denom, nil
+}
+
+// ValidateChainDenomsQueryParam validates the chain denom query parameters.
+func ValidateChainDenomsQueryParam(c echo.Context, tokensUsecase TokensUsecase, denoms []string) ([]string, error) {
+	isHumanDenoms, err := domain.GetIsHumanDenomsQueryParam(c)
+	if err != nil {
+		return nil, err
+	}
+
+	chainDenoms := make([]string, len(denoms))
+	for i, denom := range denoms {
+		chainDenom, err := ValidateChainDenomQueryParam(tokensUsecase, denom, isHumanDenoms)
+		if err != nil {
+			return nil, err
+		}
+		chainDenoms[i] = chainDenom
+	}
+	return chainDenoms, nil
 }

--- a/domain/mvc/tokens.go
+++ b/domain/mvc/tokens.go
@@ -37,7 +37,7 @@ type TokensUsecase interface {
 	// The outer map consists of base denoms as keys.
 	// The inner map consists of quote denoms as keys.
 	// The result of the inner map is prices of the outer base and inner quote.
-	GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (map[string]map[string]any, error)
+	GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (map[string]map[string]osmomath.BigDec, error)
 
 	// UpdatePoolDenomMetadata updates the pool denom metadata, completely overwriting any previous
 	// denom results stored internally, if any. The denoms metadata that is present internally

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -13,7 +13,7 @@ type CosmWasmPoolRouterConfig struct {
 // BlockPoolMetadata contains the metadata about unique pools
 // and denoms modified in a block.
 type BlockPoolMetadata struct {
-	UpdatedDenoms       map[string]struct{}
+	UpdatedDenoms     map[string]struct{}
 	DenomLiquidityMap map[string]PoolDenomMetaData
 	PoolIDs           map[uint64]struct{}
 }

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -9,3 +9,11 @@ type CosmWasmPoolRouterConfig struct {
 	// node URI
 	NodeURI string
 }
+
+// BlockPoolMetadata contains the metadata about unique pools
+// and denoms modified in a block.
+type BlockPoolMetadata struct {
+	UpdatedDenoms       map[string]struct{}
+	DenomLiquidityMap map[string]PoolDenomMetaData
+	PoolIDs           map[uint64]struct{}
+}

--- a/domain/pricing.go
+++ b/domain/pricing.go
@@ -123,7 +123,7 @@ type PricingWorker interface {
 	// UpdatePrices updates prices for the given base denoms asyncronously.
 	// Returns a channel that will be closed when the update is completed.
 	// Propagates the results to the listeners.
-	UpdatePricesAsync(height uint64, baseDenoms map[string]struct{})
+	UpdatePricesAsync(height uint64, baseDenoms map[string]PoolDenomMetaData)
 
 	// RegisterListener registers a listener for pricing updates.
 	RegisterListener(listener PricingUpdateListener)

--- a/domain/pricing.go
+++ b/domain/pricing.go
@@ -123,15 +123,15 @@ type PricingWorker interface {
 	// UpdatePrices updates prices for the given base denoms asyncronously.
 	// Returns a channel that will be closed when the update is completed.
 	// Propagates the results to the listeners.
-	UpdatePricesAsync(height uint64, baseDenoms map[string]PoolDenomMetaData)
+	UpdatePricesAsync(height uint64, uniqueBlockPoolMetaData BlockPoolMetadata)
 
 	// RegisterListener registers a listener for pricing updates.
 	RegisterListener(listener PricingUpdateListener)
+}
 
-	// IsProcessing returns true if the worker is processing a pricing update.
-	IsProcessing() bool
+type PoolLiquidityPricingWorker interface {
 }
 
 type PricingUpdateListener interface {
-	OnPricingUpdate(ctx context.Context, height int64, pricesBaseQuoteDenomMap map[string]map[string]any, quoteDenom string) error
+	OnPricingUpdate(ctx context.Context, height int64, blockMetaData BlockPoolMetadata, pricesBaseQuoteDenomMap map[string]map[string]osmomath.BigDec, quoteDenom string) error
 }

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -1,5 +1,7 @@
 package domain
 
+import "github.com/osmosis-labs/osmosis/osmomath"
+
 // Token represents the token's domain model
 type Token struct {
 	// HumanDenom is the human readable denom.
@@ -8,4 +10,11 @@ type Token struct {
 	Precision int `json:"precision"`
 	// IsUnlisted is true if the token is unlisted.
 	IsUnlisted bool `json:"is_unlisted"`
+}
+
+// PoolDenomMetaData contains the metadata about the denoms collected from the pools.
+type PoolDenomMetaData struct {
+	// LocalMCap represents the local market cap.
+	// @Type string
+	LocalMCap osmomath.Int `json:"local_mcap"`
 }

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -14,7 +14,11 @@ type Token struct {
 
 // PoolDenomMetaData contains the metadata about the denoms collected from the pools.
 type PoolDenomMetaData struct {
-	// LocalMCap represents the local market cap.
+	// TotalLiquidity represents the total liquidity across all pools.
 	// @Type string
-	LocalMCap osmomath.Int `json:"local_mcap"`
+	TotalLiquidity osmomath.Int `json:"total_liquidity"`
+	// TotalLiquidityUSDC represents the total liquidity in USDC across all pools.
+	// If it is set to zero, that there was a failure in fetching the price.
+	// @Type string
+	TotalLiquidityUSDC osmomath.Int `json:"total_liquidity_usdc"`
 }

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -22,3 +22,14 @@ type PoolDenomMetaData struct {
 	// @Type string
 	TotalLiquidityUSDC osmomath.Int `json:"total_liquidity_usdc"`
 }
+
+type DenomLiquidityMap map[string]DenomLiquidityData
+
+// DenomLiquidityData contains the liquidity data for a denom
+type DenomLiquidityData struct {
+	// Total liquidity for this denom
+	TotalLiquidity osmomath.Int
+	// Mapping from pool ID to denom liquidity
+	// in that pool
+	Pools map[uint64]osmomath.Int
+}

--- a/domain/url.go
+++ b/domain/url.go
@@ -3,6 +3,7 @@ package domain
 import (
 	"context"
 	"net/url"
+	"strconv"
 
 	"github.com/labstack/echo/v4"
 )
@@ -33,4 +34,17 @@ func GetURLPathFromContext(ctx context.Context) (string, error) {
 		requestPath = "unknown"
 	}
 	return requestPath, nil
+}
+
+// GetIsHumanDenomsQueryParam returns the value of the humanDenoms query parameter
+// If the query parameter is not present, it returns false
+// Errors if the value is not a valid boolean.
+func GetIsHumanDenomsQueryParam(c echo.Context) (bool, error) {
+	isHumanDenomsStr := c.QueryParam("humanDenoms")
+
+	if len(isHumanDenomsStr) > 0 {
+		return strconv.ParseBool(isHumanDenomsStr)
+	}
+
+	return false, nil
 }

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -5,3 +5,65 @@ This is a component that is responsible for ingesting and processing data.
 It exposes a GRPC API for Osmosis node clients to send data to be ingested.
 
 See [this ADR](https://www.notion.so/osmosiszone/ADR-006-Streaming-GRPC-SQS-Ingest-4e3b2ff7d23e43e2a1f3c43adc3c26bc) for details about the design.
+
+The node pushes only the pool data that is changed within a block.
+
+As a result, it is possible to see the following sequence of events:
+- Height X: All Osmosis pools are pushed
+- Height X+1: Only the pools that have changed within that height are pushed
+
+## Workers
+
+### Pricing
+
+The pricing worker is responsible for pre-computing prices for all assets and the default
+quote denom (USDC).
+
+It is triggerred by the ingester asyncrnously when the GRPC push is received.
+
+It looks at the unique denoms constructed from the pool data and computes the prices for each
+asset and the default quote denom.
+
+Once complete, it calls a hook to notify the subscribed listeners that the prices have been updated.
+
+#### Pricing Listeners
+
+- Healthcheck: The healthcheck listener is responsible for updating the healthcheck status
+  based on the last time the prices were updated. If the prices are not updated within a certain
+  time period, the healthcheck status will be updated to unhealthy.
+An example of a listener is the healtcheck component. Once it is notified of the price update, it
+- Pool Liquidity Pricing Worker: This worker is responsible for updating the pool liquidity capitalization
+based on the prices that are computed by the pricing worker.
+
+### Pool Liquidity Pricing
+
+The pool liquidity pricing worker is responsible for updating the pool liquidity capitalization.
+
+We need to know:
+1. Prices for all tokens
+2. Liquidity for all tokens in all pools
+
+Again, 2 cases:
+
+1. All pools are pushed
+2. Only the pools that have changed within that height are pushed
+
+Problem:
+- In the current system, When we push only a subset of pools, we do not need to read all ~1700 other pools.
+
+However, with the pool liquidity pricing in place, we might need to know all pools that are associated with
+a particular token.
+
+Therefore, we store the following data structure:
+
+```go
+map[denom]struct{
+    TotalLiquidity: sdk.Int
+    map[poolId]struct{
+        Liquidity: sdk.Int
+    }
+}
+```
+
+This would alow us to identify all pools that are associated with a particular token and read them only
+rather than reading all pools.

--- a/ingest/README.md
+++ b/ingest/README.md
@@ -67,3 +67,12 @@ map[denom]struct{
 
 This would alow us to identify all pools that are associated with a particular token and read them only
 rather than reading all pools.
+
+Plan:
+- 1. Constrcut the map
+- 2. Update the map when a pool is pushed
+
+Q:
+- Where to store? a) ingester 2) tokens
+- Separate indexes or not? A: Probably not because we need to access them together at ingest time
+   * Should the stuff for queries then be a separate index??? 

--- a/ingest/usecase/export_test.go
+++ b/ingest/usecase/export_test.go
@@ -1,6 +1,14 @@
 package usecase
 
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/sqs/domain"
+)
+
 type (
 	IngestUseCaseImpl = ingestUseCase
 )
 
+func UpdateUniqueDenomData(uniqueDenomData map[string]domain.PoolDenomMetaData, balances sdk.Coins) {
+	updateUniqueDenomData(uniqueDenomData, balances)
+}

--- a/ingest/usecase/export_test.go
+++ b/ingest/usecase/export_test.go
@@ -1,14 +1,5 @@
 package usecase
 
-import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/osmosis-labs/sqs/domain"
-)
-
 type (
 	IngestUseCaseImpl = ingestUseCase
 )
-
-func UpdateUniqueDenomData(uniqueDenomData map[string]domain.PoolDenomMetaData, balances sdk.Coins) {
-	updateUniqueDenomData(uniqueDenomData, balances)
-}

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -8,7 +8,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"go.uber.org/zap"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v24/x/poolmanager/types"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
@@ -31,19 +30,14 @@ type ingestUseCase struct {
 	// Worker that computes prices for all tokens with the default quote.
 	defaultQuotePriceUpdateWorker domain.PricingWorker
 
+	poolLiquidityPricingWorker domain.PoolLiquidityPricingWorker
+
 	logger log.Logger
 }
 
 type poolResult struct {
 	pool sqsdomain.PoolI
 	err  error
-}
-
-// UniqueBlockPoolMetaData contains the metadta about unique pools
-// and denoms modified in a block.
-type UniqueBlockPoolMetaData struct {
-	Denoms  map[string]domain.PoolDenomMetaData
-	PoolIDs map[uint64]struct{}
 }
 
 var (
@@ -92,15 +86,30 @@ func (p *ingestUseCase) ProcessBlockData(ctx context.Context, height uint64, tak
 
 	// Sort and store pools.
 	p.logger.Info("sorting pools", zap.Uint64("height", height), zap.Duration("duration_since_start", time.Since(startProcessingTime)))
-	p.sortAndStorePools(allPools)
+
+	// TODO: can this calculation be moved into the pool liquidity worker
+	poolDenomLiquidity := p.sortAndStorePools(allPools)
+
+	previousBlockDenomMetadata := p.tokensUsecase.GetFullPoolDenomMetadata()
+	for denom, updatedLiquidityMetadata := range poolDenomLiquidity {
+		poolDenomLiquidity[denom] = domain.PoolDenomMetaData{
+			// Note, we recompute the total liquidity across all pools
+			TotalLiquidity: updatedLiquidityMetadata.TotalLiquidity,
+			// For tokens that were not updated within this block, we keep the previous value
+			TotalLiquidityUSDC: previousBlockDenomMetadata[denom].TotalLiquidityUSDC,
+		}
+	}
+
+	// Update block pool denom metadata
+	uniqueBlockPoolMetadata.DenomLiquidityMap = poolDenomLiquidity
 
 	// Update pool denom metadata
-	p.logger.Info("updating pool denom metadata", zap.Uint64("height", height), zap.Int("denom_count", len(uniqueBlockPoolMetadata.Denoms)), zap.Duration("duration_since_start", time.Since(startProcessingTime)))
-	p.tokensUsecase.UpdatePoolDenomMetadata(uniqueBlockPoolMetadata.Denoms)
+	p.logger.Info("updating pool denom metadata", zap.Uint64("height", height), zap.Int("denom_count", len(uniqueBlockPoolMetadata.DenomLiquidityMap)), zap.Duration("duration_since_start", time.Since(startProcessingTime)))
+	p.tokensUsecase.UpdatePoolDenomMetadata(uniqueBlockPoolMetadata.DenomLiquidityMap)
 
 	// Note: we must queue the update before we start updating prices as pool liquidity
 	// worker listens for the pricing updates at the same height.
-	p.defaultQuotePriceUpdateWorker.UpdatePricesAsync(height, uniqueBlockPoolMetadata.Denoms)
+	p.defaultQuotePriceUpdateWorker.UpdatePricesAsync(height, uniqueBlockPoolMetadata)
 
 	// Store the latest ingested height.
 	p.chainInfoUseCase.StoreLatestHeight(height)
@@ -115,18 +124,20 @@ func (p *ingestUseCase) ProcessBlockData(ctx context.Context, height uint64, tak
 
 // sortAndStorePools sorts the pools and stores them in the router.
 // TODO: instead of resorting all pools every block, we should put the updated pools in the correct position
-func (p *ingestUseCase) sortAndStorePools(pools []sqsdomain.PoolI) {
+func (p *ingestUseCase) sortAndStorePools(pools []sqsdomain.PoolI) map[string]domain.PoolDenomMetaData {
 	cosmWasmPoolConfig := p.poolsUseCase.GetCosmWasmPoolConfig()
 	routerConfig := p.routerUsecase.GetConfig()
 
-	sortedPools := routerusecase.ValidateAndSortPools(pools, cosmWasmPoolConfig, routerConfig.PreferredPoolIDs, p.logger)
+	sortedPools, poolDenomLiquidity := routerusecase.ValidateAndSortPools(pools, cosmWasmPoolConfig, routerConfig.PreferredPoolIDs, p.logger)
 
 	// Sort the pools and store them in the router.
 	p.routerUsecase.SetSortedPools(sortedPools)
+
+	return poolDenomLiquidity
 }
 
 // parsePoolData parses the pool data and returns the pool objects.
-func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.PoolData) ([]sqsdomain.PoolI, UniqueBlockPoolMetaData, error) {
+func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.PoolData) ([]sqsdomain.PoolI, domain.BlockPoolMetadata, error) {
 	poolResultChan := make(chan poolResult, len(poolData))
 
 	// Parse the pools concurrently
@@ -143,9 +154,9 @@ func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.Poo
 
 	parsedPools := make([]sqsdomain.PoolI, 0, len(poolData))
 
-	uniqueData := UniqueBlockPoolMetaData{
-		Denoms:  make(map[string]domain.PoolDenomMetaData),
-		PoolIDs: make(map[uint64]struct{}, len(poolData)),
+	uniqueData := domain.BlockPoolMetadata{
+		UpdatedDenoms: make(map[string]struct{}, len(poolData)),
+		PoolIDs:       make(map[uint64]struct{}, len(poolData)),
 	}
 
 	// Collect the parsed pools
@@ -159,15 +170,17 @@ func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.Poo
 				continue
 			}
 
-			// Update unique denoms
-			updateUniqueDenomData(uniqueData.Denoms, poolResult.pool.GetSQSPoolModel().Balances)
+			// Update unique denoms.
+			for _, coin := range poolResult.pool.GetSQSPoolModel().Balances {
+				uniqueData.UpdatedDenoms[coin.Denom] = struct{}{}
+			}
 
 			// Update unique pools.
 			uniqueData.PoolIDs[poolResult.pool.GetId()] = struct{}{}
 
 			parsedPools = append(parsedPools, poolResult.pool)
 		case <-ctx.Done():
-			return nil, UniqueBlockPoolMetaData{}, ctx.Err()
+			return nil, domain.BlockPoolMetadata{}, ctx.Err()
 		}
 	}
 
@@ -195,22 +208,4 @@ func (p *ingestUseCase) parsePool(pool *types.PoolData) (sqsdomain.PoolI, error)
 	}
 
 	return &poolWrapper, nil
-}
-
-// updateUniqueDenomData updates the unique denom data with the given balances
-// mutates the uniqueDenomData map. If the denom is already present, it updates the liquidity
-func updateUniqueDenomData(uniqueDenomData map[string]domain.PoolDenomMetaData, balances sdk.Coins) {
-	for _, balance := range balances {
-		poolLiquidity, ok := uniqueDenomData[balance.Denom]
-		if ok {
-			// Update the pool liquidity
-			poolLiquidity.LocalMCap = poolLiquidity.LocalMCap.Add(balance.Amount)
-			uniqueDenomData[balance.Denom] = poolLiquidity
-		} else {
-			// Initialize the pool liquidity
-			uniqueDenomData[balance.Denom] = domain.PoolDenomMetaData{
-				LocalMCap: balance.Amount,
-			}
-		}
-	}
 }

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"go.uber.org/zap"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v24/x/poolmanager/types"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
@@ -26,6 +27,8 @@ type ingestUseCase struct {
 	routerUsecase    mvc.RouterUsecase
 	tokensUsecase    mvc.TokensUsecase
 	chainInfoUseCase mvc.ChainInfoUsecase
+
+	denomLiquidityMap domain.DenomLiquidityMap
 
 	// Worker that computes prices for all tokens with the default quote.
 	defaultQuotePriceUpdateWorker domain.PricingWorker
@@ -53,6 +56,8 @@ func NewIngestUsecase(poolsUseCase mvc.PoolsUsecase, routerUseCase mvc.RouterUse
 		routerUsecase:    routerUseCase,
 		tokensUsecase:    tokensUseCase,
 		poolsUseCase:     poolsUseCase,
+
+		denomLiquidityMap: make(domain.DenomLiquidityMap),
 
 		logger: logger,
 
@@ -155,7 +160,7 @@ func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.Poo
 	parsedPools := make([]sqsdomain.PoolI, 0, len(poolData))
 
 	uniqueData := domain.BlockPoolMetadata{
-		UpdatedDenoms: make(map[string]struct{}, len(poolData)),
+		UpdatedDenoms: make(map[string]struct{}),
 		PoolIDs:       make(map[uint64]struct{}, len(poolData)),
 	}
 
@@ -170,9 +175,31 @@ func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.Poo
 				continue
 			}
 
+			currentPoolBalances := poolResult.pool.GetSQSPoolModel().Balances
+			denomLiquidityMap := p.denomLiquidityMap
+
 			// Update unique denoms.
-			for _, coin := range poolResult.pool.GetSQSPoolModel().Balances {
-				uniqueData.UpdatedDenoms[coin.Denom] = struct{}{}
+			for _, coin := range currentPoolBalances {
+				denomData, ok := denomLiquidityMap[coin.Denom]
+
+				updatedLiquidity := osmomath.ZeroInt()
+				pools := map[uint64]osmomath.Int{}
+				if ok {
+					updatedLiquidity = denomData.TotalLiquidity
+					for k, v := range denomData.Pools {
+						pools[k] = v
+					}
+				}
+
+				// Update the current pool liquidity for the denom.
+				pools[poolResult.pool.GetId()] = coin.Amount
+				// Update the total liquidity for the denom.
+				updatedLiquidity = updatedLiquidity.Add(coin.Amount)
+
+				denomLiquidityMap[coin.Denom] = domain.DenomLiquidityData{
+					TotalLiquidity: updatedLiquidity,
+					Pools:          pools,
+				}
 			}
 
 			// Update unique pools.

--- a/ingest/usecase/ingest_usecase_test.go
+++ b/ingest/usecase/ingest_usecase_test.go
@@ -1,13 +1,8 @@
 package usecase_test
 
 import (
-	"reflect"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/sqs/domain"
-	"github.com/osmosis-labs/sqs/ingest/usecase"
 	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
 	"github.com/stretchr/testify/suite"
 )
@@ -23,58 +18,4 @@ type IngestUseCaseTestSuite struct {
 
 func TestIngestUseCaseTestSuite(t *testing.T) {
 	suite.Run(t, new(IngestUseCaseTestSuite))
-}
-
-// TestUpdateUniqueDenomData provides table-driven tests for the updateUniqueDenomData function
-func TestUpdateUniqueDenomData(t *testing.T) {
-	// Test case structure
-	type test struct {
-		name            string
-		uniqueDenomData map[string]domain.PoolDenomMetaData
-		balances        sdk.Coins
-		expected        map[string]domain.PoolDenomMetaData
-	}
-
-	var (
-		amountX     = osmomath.NewInt(100)
-		amountHalfX = osmomath.NewInt(50)
-
-		sumOfAmounts = amountX.Add(amountHalfX)
-	)
-
-	tests := []test{
-		{
-			name:            "Empty map, new entries added",
-			uniqueDenomData: map[string]domain.PoolDenomMetaData{},
-			balances:        []sdk.Coin{{Denom: UOSMO, Amount: amountX}, {Denom: USDC, Amount: amountHalfX}},
-			expected:        map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}, USDC: {LocalMCap: amountHalfX}},
-		},
-		{
-			name:            "Existing entries, updated correctly",
-			uniqueDenomData: map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}},
-			balances:        []sdk.Coin{{Denom: UOSMO, Amount: amountHalfX}},
-			expected:        map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX.Add(amountHalfX)}},
-		},
-		{
-			name:            "Mix of new and update entries",
-			uniqueDenomData: map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}},
-			balances:        []sdk.Coin{{Denom: UOSMO, Amount: amountHalfX}, {Denom: USDC, Amount: amountHalfX}},
-			expected:        map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: sumOfAmounts}, USDC: {LocalMCap: amountHalfX}},
-		},
-		{
-			name:            "No balances provided, map unchanged",
-			uniqueDenomData: map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}},
-			balances:        []sdk.Coin{},
-			expected:        map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			usecase.UpdateUniqueDenomData(tc.uniqueDenomData, tc.balances)
-			if !reflect.DeepEqual(tc.uniqueDenomData, tc.expected) {
-				t.Errorf("Unexpected result for '%s': got %v, want %v", tc.name, tc.uniqueDenomData, tc.expected)
-			}
-		})
-	}
 }

--- a/ingest/usecase/ingest_usecase_test.go
+++ b/ingest/usecase/ingest_usecase_test.go
@@ -1,1 +1,80 @@
 package usecase_test
+
+import (
+	"reflect"
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/ingest/usecase"
+	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
+	"github.com/stretchr/testify/suite"
+)
+
+var (
+	UOSMO = routertesting.UOSMO
+	USDC  = routertesting.USDC
+)
+
+type IngestUseCaseTestSuite struct {
+	routertesting.RouterTestHelper
+}
+
+func TestIngestUseCaseTestSuite(t *testing.T) {
+	suite.Run(t, new(IngestUseCaseTestSuite))
+}
+
+// TestUpdateUniqueDenomData provides table-driven tests for the updateUniqueDenomData function
+func TestUpdateUniqueDenomData(t *testing.T) {
+	// Test case structure
+	type test struct {
+		name            string
+		uniqueDenomData map[string]domain.PoolDenomMetaData
+		balances        sdk.Coins
+		expected        map[string]domain.PoolDenomMetaData
+	}
+
+	var (
+		amountX     = osmomath.NewInt(100)
+		amountHalfX = osmomath.NewInt(50)
+
+		sumOfAmounts = amountX.Add(amountHalfX)
+	)
+
+	tests := []test{
+		{
+			name:            "Empty map, new entries added",
+			uniqueDenomData: map[string]domain.PoolDenomMetaData{},
+			balances:        []sdk.Coin{{Denom: UOSMO, Amount: amountX}, {Denom: USDC, Amount: amountHalfX}},
+			expected:        map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}, USDC: {LocalMCap: amountHalfX}},
+		},
+		{
+			name:            "Existing entries, updated correctly",
+			uniqueDenomData: map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}},
+			balances:        []sdk.Coin{{Denom: UOSMO, Amount: amountHalfX}},
+			expected:        map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX.Add(amountHalfX)}},
+		},
+		{
+			name:            "Mix of new and update entries",
+			uniqueDenomData: map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}},
+			balances:        []sdk.Coin{{Denom: UOSMO, Amount: amountHalfX}, {Denom: USDC, Amount: amountHalfX}},
+			expected:        map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: sumOfAmounts}, USDC: {LocalMCap: amountHalfX}},
+		},
+		{
+			name:            "No balances provided, map unchanged",
+			uniqueDenomData: map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}},
+			balances:        []sdk.Coin{},
+			expected:        map[string]domain.PoolDenomMetaData{UOSMO: {LocalMCap: amountX}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			usecase.UpdateUniqueDenomData(tc.uniqueDenomData, tc.balances)
+			if !reflect.DeepEqual(tc.uniqueDenomData, tc.expected) {
+				t.Errorf("Unexpected result for '%s': got %v, want %v", tc.name, tc.uniqueDenomData, tc.expected)
+			}
+		})
+	}
+}

--- a/router/usecase/export_test.go
+++ b/router/usecase/export_test.go
@@ -63,3 +63,7 @@ func SortPools(pools []sqsdomain.PoolI, transmuterCodeIDs map[uint64]struct{}, t
 func GetSplitQuote(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Coin) (domain.Quote, error) {
 	return getSplitQuote(ctx, routes, tokenIn)
 }
+
+func UpdateUniqueDenomData(uniqueDenomData map[string]domain.PoolDenomMetaData, balances sdk.Coins) {
+	updateUniqueDenomData(uniqueDenomData, balances)
+}

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -245,7 +245,7 @@ func (s *RouterTestSuite) TestHandleRoutes() {
 			}, emptyCosmWasmPoolsRouterConfig, &log.NoOpLogger{}, cache.New(), candidateRouteCache)
 
 			// Validate and sort pools
-			sortedPools := usecase.ValidateAndSortPools(tc.repositoryPools, emptyCosmWasmPoolsRouterConfig, []uint64{}, noOpLogger)
+			sortedPools, _ := usecase.ValidateAndSortPools(tc.repositoryPools, emptyCosmWasmPoolsRouterConfig, []uint64{}, noOpLogger)
 
 			// Filter pools by min liquidity
 			sortedPools = usecase.FilterPoolsByMinLiquidity(sortedPools, minOsmoLiquidity)
@@ -759,7 +759,7 @@ func (s *RouterTestSuite) TestSortPools() {
 	s.Require().NoError(err)
 
 	// Validate and sort pools
-	sortedPools := usecase.ValidateAndSortPools(pools, emptyCosmWasmPoolsRouterConfig, []uint64{}, noOpLogger)
+	sortedPools, _ := usecase.ValidateAndSortPools(pools, emptyCosmWasmPoolsRouterConfig, []uint64{}, noOpLogger)
 
 	// Filter pools by min liquidity
 	sortedPools = usecase.FilterPoolsByMinLiquidity(sortedPools, defaultRouterConfig.MinOSMOLiquidity)

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -348,7 +348,7 @@ func (s *RouterTestHelper) SetupRouterAndPoolsUsecase(mainnetState MockMainnetSt
 
 	encCfg := app.MakeEncodingConfig()
 
-	ingestUsecase, err := ingestusecase.NewIngestUsecase(poolsUsecase, routerUsecase, nil, encCfg.Marshaler, nil, logger)
+	ingestUsecase, err := ingestusecase.NewIngestUsecase(poolsUsecase, routerUsecase, tokensUsecase, nil, encCfg.Marshaler, nil, logger)
 	if err != nil {
 		panic(err)
 	}

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -332,7 +332,7 @@ func (s *RouterTestHelper) SetupRouterAndPoolsUsecase(mainnetState MockMainnetSt
 	routerUsecase := routerusecase.NewRouterUsecase(routerRepositoryMock, poolsUsecase, options.RouterConfig, poolsUsecase.GetCosmWasmPoolConfig(), logger, options.RankedRoutes, options.CandidateRoutes)
 
 	// Validate and sort pools
-	sortedPools := routerusecase.ValidateAndSortPools(mainnetState.Pools, poolsUsecase.GetCosmWasmPoolConfig(), options.RouterConfig.PreferredPoolIDs, logger)
+	sortedPools, _ := routerusecase.ValidateAndSortPools(mainnetState.Pools, poolsUsecase.GetCosmWasmPoolConfig(), options.RouterConfig.PreferredPoolIDs, logger)
 
 	routerUsecase.SetSortedPools(sortedPools)
 
@@ -370,7 +370,7 @@ func (s *RouterTestHelper) ConvertAnyToBigDec(any any) osmomath.BigDec {
 
 // PrepareValidSortedRouterPools prepares a list of valid router pools above min liquidity
 func PrepareValidSortedRouterPools(pools []sqsdomain.PoolI, minOsmoLiquidity int) []sqsdomain.PoolI {
-	sortedPools := routerusecase.ValidateAndSortPools(pools, emptyCosmwasmPoolRouterConfig, []uint64{}, &log.NoOpLogger{})
+	sortedPools, _ := routerusecase.ValidateAndSortPools(pools, emptyCosmwasmPoolRouterConfig, []uint64{}, &log.NoOpLogger{})
 
 	// Sort pools
 	poolsAboveMinLiquidity := routerusecase.FilterPoolsByMinLiquidity(sortedPools, minOsmoLiquidity)

--- a/tokens/delivery/http/tokens_delivery.go
+++ b/tokens/delivery/http/tokens_delivery.go
@@ -55,6 +55,7 @@ func NewTokensHandler(e *echo.Echo, pricingConfig domain.PricingConfig, ts mvc.T
 	}
 
 	e.GET(formatTokensResource("/metadata"), handler.GetMetadata)
+	e.GET(formatTokensResource("/pool-metadata"), handler.GetPoolDenomMetadata)
 	e.GET(formatTokensResource("/prices"), handler.GetPrices)
 	e.GET(formatTokensResource("/usd-price-test"), handler.GetUSDPriceTest)
 	e.POST(formatTokensResource("/store-state"), handler.StoreTokensStateInFiles)
@@ -120,6 +121,34 @@ func (a *TokensHandler) GetMetadata(c echo.Context) (err error) {
 	}
 
 	return c.JSON(http.StatusOK, tokenMetadataResult)
+}
+
+// @Summary Pool Denom Metadata
+// @Description returns pool denom metadata. As of today, this metadata is represented by the local market cap of the token computed over all Osmosis pools.
+// @Description For testnet, uses osmo-test-5 asset list. For mainnet, uses osmosis-1 asset list.
+// @Description See `config.json` and `config-testnet.json` in root for details.
+// @ID get-pool-denom-metadata
+// @Produce  json
+// @Param  denoms  query  string  false  "List of denoms where each can either be a human denom or a chain denom"
+// @Param humanDenoms query bool true "Boolean flag indicating whether the given denoms are human readable or not. Human denoms get converted to chain internally"
+// @Router /tokens/pool-metadata [get]
+func (a *TokensHandler) GetPoolDenomMetadata(c echo.Context) (err error) {
+	denomsStr := c.QueryParam("denoms")
+	if len(denomsStr) == 0 {
+		// Return all pool denom metadata
+		result := a.TUsecase.GetFullPoolDenomMetadata()
+		return c.JSON(http.StatusOK, result)
+	}
+
+	denoms := strings.Split(denomsStr, ",")
+	// Validate denom parameters and convert to chain denoms if necessary.
+	chainDenoms, err := mvc.ValidateChainDenomsQueryParam(c, a.TUsecase, denoms)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
+	}
+
+	result := a.TUsecase.GetPoolDenomsMetadata(chainDenoms)
+	return c.JSON(http.StatusOK, result)
 }
 
 // @Summary Get prices

--- a/tokens/usecase/pricing/worker/pool_liquidity_compute_worker.go
+++ b/tokens/usecase/pricing/worker/pool_liquidity_compute_worker.go
@@ -1,0 +1,187 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/domain/mvc"
+)
+
+type PoolLiquidityComputeListener interface {
+	OnPoolLiquidityCompute(height int64, updatedPoolIDs []uint64) error
+}
+
+var (
+	_ domain.PricingUpdateListener = &poolLiquidityComputeWorker{}
+)
+
+type poolLiquidityComputeWorker struct {
+	poolsUseCase  mvc.PoolsUsecase
+	tokensUseCase mvc.TokensUsecase
+
+	latestHeightForDenom sync.Map
+}
+
+type DenomPriceInfo struct {
+	Price         osmomath.BigDec
+	ScalingFactor osmomath.Dec
+}
+
+var (
+	poolLiquidityComputeWorkerInstance domain.PricingUpdateListener = &poolLiquidityComputeWorker{}
+)
+
+func NewPoolLiquidityWorker(tokensUseCase mvc.TokensUsecase, poolsUseCase mvc.PoolsUsecase) domain.PricingUpdateListener {
+	return &poolLiquidityComputeWorker{
+
+		poolsUseCase:  poolsUseCase,
+		tokensUseCase: tokensUseCase,
+
+		latestHeightForDenom: sync.Map{},
+	}
+}
+
+// OnPricingUpdate implements worker.PricingUpdateListener.
+// CONTRACT: QueuePoolLiquidityCompute with the same height must be called prior to this.
+func (p *poolLiquidityComputeWorker) OnPricingUpdate(ctx context.Context, height int64, blockPoolMetadata domain.BlockPoolMetadata, baseDenomPriceUpdates map[string]map[string]osmomath.BigDec, quoteDenom string) error {
+
+	// Compute the scaling factors for the base denoms.
+	baseDenomPriceData := make(map[string]DenomPriceInfo, len(baseDenomPriceUpdates))
+	for baseDenom, quotesPrices := range baseDenomPriceUpdates {
+
+		price, ok := quotesPrices[quoteDenom]
+		if !ok {
+			return fmt.Errorf("no price update for %s when computing pool TVL", quoteDenom)
+		}
+
+		baseScalingFactor, err := p.tokensUseCase.GetChainScalingFactorByDenomMut(baseDenom)
+		if err != nil {
+			return err
+		}
+
+		baseDenomPriceData[baseDenom] = DenomPriceInfo{
+			Price:         price,
+			ScalingFactor: baseScalingFactor,
+		}
+	}
+
+	for denom := range blockPoolMetadata.UpdatedDenoms {
+
+		latestHeightForDenom, ok := p.latestHeightForDenom.Load(denom)
+		// Skip if the height is not the latest.
+		if ok && height < latestHeightForDenom.(int64) {
+			continue
+		}
+
+		poolDenomMetaData, ok := blockPoolMetadata.DenomLiquidityMap[denom]
+		if !ok {
+			// If no denom liquidity metadata available, set the total liquidity to zero.
+			blockPoolMetadata.DenomLiquidityMap[denom] = domain.PoolDenomMetaData{
+				TotalLiquidity:     osmomath.ZeroInt(),
+				TotalLiquidityUSDC: osmomath.ZeroInt(),
+			}
+		}
+
+		price, ok := baseDenomPriceData[denom]
+		if !ok {
+			// If no price is available, set the total liquidity to zero.
+			blockPoolMetadata.DenomLiquidityMap[denom] = domain.PoolDenomMetaData{
+				TotalLiquidity:     poolDenomMetaData.TotalLiquidity,
+				TotalLiquidityUSDC: osmomath.ZeroInt(),
+			}
+		} else {
+			usdcLiquidityValue, err := computeCoinTVL(sdk.NewCoin(denom, poolDenomMetaData.TotalLiquidity), price)
+			if err != nil {
+				// If there is an error, set the total liquidity to zero.
+				blockPoolMetadata.DenomLiquidityMap[denom] = domain.PoolDenomMetaData{
+					TotalLiquidity:     poolDenomMetaData.TotalLiquidity,
+					TotalLiquidityUSDC: osmomath.ZeroInt(),
+				}
+			} else {
+				// Set the total liquidity in USDC.
+				blockPoolMetadata.DenomLiquidityMap[denom] = domain.PoolDenomMetaData{
+					TotalLiquidity:     poolDenomMetaData.TotalLiquidity,
+					TotalLiquidityUSDC: usdcLiquidityValue.TruncateInt(),
+				}
+			}
+		}
+
+		p.latestHeightForDenom.Store(denom, height)
+	}
+
+	p.tokensUseCase.UpdatePoolDenomMetadata(blockPoolMetadata.DenomLiquidityMap)
+
+	return nil
+}
+
+func computeBalanceTVL(balance sdk.Coins, baseDenomPriceData map[string]DenomPriceInfo) (osmomath.Int, string) {
+	usdcTVL := osmomath.ZeroDec()
+
+	tvlError := ""
+
+	for _, balance := range balance {
+		// // TODO: for some reason we halt on these (potentially no routes)
+		// if balance.Denom == "ibc/E610B83FD5544E00A8A1967A2EB3BEF25F1A8CFE8650FE247A8BD4ECA9DC9222" || balance.Denom == "ibc/B2BD584CD2A0A9CE53D4449667E26160C7D44A9C41AF50F602C201E5B3CCA46C" {
+		// 	continue
+		// }
+
+		// Skip gamm shares
+		if strings.Contains(balance.Denom, "gamm/pool") {
+			continue
+		}
+
+		baseDenomPrice, ok := baseDenomPriceData[balance.Denom]
+		if !ok {
+			tvlError += fmt.Sprintf(" %s", fmt.Errorf("no price update for %s when computing pool TVL", balance.Denom))
+			continue
+		}
+
+		currentTokenTVL, err := computeCoinTVL(balance, baseDenomPrice)
+		if err != nil {
+			// Silenly skip.
+			// Append tvl error but continue to the next token
+			tvlError += fmt.Sprintf(" %s", err)
+			continue
+		}
+
+		usdcTVL = usdcTVL.AddMut(currentTokenTVL)
+	}
+
+	return usdcTVL.TruncateInt(), tvlError
+}
+
+// computeCoinTVl computes the equivalent of the given coin in the desired quote denom that is set on ingester
+func computeCoinTVL(coin sdk.Coin, baseDenomPriceData DenomPriceInfo) (osmomath.Dec, error) {
+	if baseDenomPriceData.Price.IsZero() {
+		return osmomath.Dec{}, fmt.Errorf("price for %s is zero", coin.Denom)
+	}
+	if baseDenomPriceData.ScalingFactor.IsZero() {
+		return osmomath.Dec{}, fmt.Errorf("scaling factor for %s is zero", coin.Denom)
+	}
+
+	currentTokenTVL := osmomath.NewBigDecFromBigInt(coin.Amount.BigIntMut()).MulMut(baseDenomPriceData.Price)
+	isOriginalAmountZero := coin.Amount.IsZero()
+
+	// Truncation in intermediary operation - return error.
+	if currentTokenTVL.IsZero() && !isOriginalAmountZero {
+		return osmomath.Dec{}, fmt.Errorf("truncation occurred when multiplying coin (%s) by price %s", coin, baseDenomPriceData.Price)
+	}
+
+	// Truncation in intermediary operation - return error.
+	currentTokenTVL = currentTokenTVL.QuoMut(osmomath.BigDecFromDec(baseDenomPriceData.ScalingFactor))
+	if currentTokenTVL.IsZero() && !isOriginalAmountZero {
+		return osmomath.Dec{}, fmt.Errorf("truncation occurred when multiplying (%s) of denom (%s) by the scaling factor (%s)", currentTokenTVL, coin.Denom, baseDenomPriceData.ScalingFactor)
+	}
+
+	if currentTokenTVL.IsZero() {
+		fmt.Println("currentTokenTVL is zero ", coin, " ", baseDenomPriceData.Price, " ", baseDenomPriceData.ScalingFactor)
+	}
+
+	return currentTokenTVL.Dec(), nil
+}

--- a/tokens/usecase/pricing/worker/pricing_worker.go
+++ b/tokens/usecase/pricing/worker/pricing_worker.go
@@ -47,7 +47,7 @@ func New(tokensUseCase mvc.TokensUsecase, quoteDenom string, logger log.Logger) 
 }
 
 // UpdatePrices implements PricingWorker.
-func (p *pricingWorker) UpdatePricesAsync(height uint64, baseDenoms map[string]struct{}) {
+func (p *pricingWorker) UpdatePricesAsync(height uint64, baseDenoms map[string]domain.PoolDenomMetaData) {
 	// Queue pricing updates
 	for baseDenom := range baseDenoms {
 		p.priceUpdateBaseDenomMap[baseDenom] = struct{}{}

--- a/tokens/usecase/pricing/worker/pricing_worker.go
+++ b/tokens/usecase/pricing/worker/pricing_worker.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"github.com/osmosis-labs/sqs/domain"
@@ -15,13 +14,6 @@ import (
 type pricingWorker struct {
 	updateListeners []domain.PricingUpdateListener
 	quoteDenom      string
-
-	// We use this flag to avoid running multiple price updates concurrently
-	// as it may cause high load on the system.
-	// If an update is missed, cache eviction will trigger it to be recomputed anyways.
-	isProcessing atomic.Bool
-
-	priceUpdateBaseDenomMap map[string]struct{}
 
 	tokensUseCase mvc.TokensUsecase
 
@@ -38,46 +30,22 @@ func New(tokensUseCase mvc.TokensUsecase, quoteDenom string, logger log.Logger) 
 		quoteDenom:      quoteDenom,
 		tokensUseCase:   tokensUseCase,
 
-		isProcessing: atomic.Bool{},
-
-		priceUpdateBaseDenomMap: make(map[string]struct{}),
-
 		logger: logger,
 	}
 }
 
 // UpdatePrices implements PricingWorker.
-func (p *pricingWorker) UpdatePricesAsync(height uint64, baseDenoms map[string]domain.PoolDenomMetaData) {
-	// Queue pricing updates
-	for baseDenom := range baseDenoms {
-		p.priceUpdateBaseDenomMap[baseDenom] = struct{}{}
-	}
-
-	if p.isProcessing.Load() {
-		p.logger.Info("pricing update queued", zap.Uint64("height", height))
-
-		return
-	}
-
-	p.isProcessing.Store(true)
-
-	// Get all tokens from the queue map
-
-	baseDenomsSlice := keysFromMap(p.priceUpdateBaseDenomMap)
-
-	// Empty the queue
-	p.priceUpdateBaseDenomMap = make(map[string]struct{})
-
-	go p.updatePrices(height, baseDenomsSlice)
+func (p *pricingWorker) UpdatePricesAsync(height uint64, uniqueBlockPoolMetaData domain.BlockPoolMetadata) {
+	go p.updatePrices(height, uniqueBlockPoolMetaData)
 }
 
-func (p *pricingWorker) updatePrices(height uint64, baseDenoms []string) {
+func (p *pricingWorker) updatePrices(height uint64, uniqueBlockPoolMetaData domain.BlockPoolMetadata) {
+
+	baseDenoms := keysFromMap(uniqueBlockPoolMetaData.UpdatedDenoms)
+
 	ctx, cancel := context.WithTimeout(context.Background(), priceUpdateTimeout)
 	start := time.Now()
 	defer func() {
-		// Reset the processing flag
-		p.isProcessing.Store(false)
-
 		// Cancel the context
 		cancel()
 
@@ -100,7 +68,7 @@ func (p *pricingWorker) updatePrices(height uint64, baseDenoms []string) {
 	// Update listeners
 	for _, listener := range p.updateListeners {
 		// Ignore errors
-		_ = listener.OnPricingUpdate(ctx, int64(height), prices, p.quoteDenom)
+		_ = listener.OnPricingUpdate(ctx, int64(height), uniqueBlockPoolMetaData, prices, p.quoteDenom)
 	}
 
 	// Measure duration
@@ -110,11 +78,6 @@ func (p *pricingWorker) updatePrices(height uint64, baseDenoms []string) {
 // RegisterListener implements PricingWorker.
 func (p *pricingWorker) RegisterListener(listener domain.PricingUpdateListener) {
 	p.updateListeners = append(p.updateListeners, listener)
-}
-
-// IsProcessing implements PricingWorker.
-func (p *pricingWorker) IsProcessing() bool {
-	return p.isProcessing.Load()
 }
 
 // Generic function to extract keys from any map.

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -67,7 +67,7 @@ type priceResult struct {
 // Define a result struct to hold the base denom and prices for each possible quote denom or error
 type priceResults struct {
 	baseDenom string
-	prices    map[string]any
+	prices    map[string]osmomath.BigDec
 	err       error
 }
 
@@ -139,7 +139,7 @@ func (t *tokensUseCase) GetPoolLiquidityCap(chainDenom string) (osmomath.Int, er
 	if err != nil {
 		return osmomath.Int{}, err
 	}
-	return poolDenomMetadata.LocalMCap, nil
+	return poolDenomMetadata.TotalLiquidity, nil
 }
 
 // GetPoolDenomMetadata implements mvc.TokensUsecase.
@@ -170,7 +170,7 @@ func (t *tokensUseCase) GetPoolDenomsMetadata(chainDenoms []string) map[string]d
 		// Instead of failing the entire request, we just set the local mcap to zero.
 		if err != nil {
 			result[chainDenom] = domain.PoolDenomMetaData{
-				LocalMCap: osmomath.ZeroInt(),
+				TotalLiquidity: osmomath.ZeroInt(),
 			}
 		} else {
 			result[chainDenom] = poolDenomMetadata
@@ -239,8 +239,8 @@ func (t *tokensUseCase) GetChainScalingFactorByDenomMut(denom string) (osmomath.
 }
 
 // GetPrices implements pricing.PricingStrategy.
-func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (map[string]map[string]any, error) {
-	byBaseDenomResult := make(map[string]map[string]any, len(baseDenoms))
+func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (map[string]map[string]osmomath.BigDec, error) {
+	byBaseDenomResult := make(map[string]map[string]osmomath.BigDec, len(baseDenoms))
 
 	// Create a channel to communicate the results
 	resultsChan := make(chan priceResults, len(quoteDenoms))
@@ -287,8 +287,8 @@ func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quot
 // Returns a map with keys as quotes and values as prices or error, if any.
 // Returns error if base denom is not found in the token metadata.
 // Sets the price to zero in case of failing to compute the price between base and quote but these being valid tokens.
-func (t *tokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, pricingOptions ...domain.PricingOption) (map[string]any, error) {
-	byQuoteDenomForGivenBaseResult := make(map[string]any, len(quoteDenoms))
+func (t *tokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, pricingOptions ...domain.PricingOption) (map[string]osmomath.BigDec, error) {
+	byQuoteDenomForGivenBaseResult := make(map[string]osmomath.BigDec, len(quoteDenoms))
 	// Validate base denom is a valid denom
 	// Return zeroes for all quotes if base denom is not found
 	_, err := t.GetMetadataByChainDenom(baseDenom)

--- a/tokens/usecase/tokens_usecase_test.go
+++ b/tokens/usecase/tokens_usecase_test.go
@@ -350,11 +350,11 @@ func (s *TokensUseCaseTestSuite) TestPoolDenomMetadata() {
 
 	// Update the pool denom metadata for ATOM and OSMO
 	atomPoolDenomMetadata := domain.PoolDenomMetaData{
-		LocalMCap: xAmount,
+		TotalLiquidity: xAmount,
 	}
 
 	osmoPoolDenomMetadata := domain.PoolDenomMetaData{
-		LocalMCap: doubleXAmount,
+		TotalLiquidity: doubleXAmount,
 	}
 
 	mainnetUsecase.Tokens.UpdatePoolDenomMetadata(map[string]domain.PoolDenomMetaData{
@@ -367,14 +367,14 @@ func (s *TokensUseCaseTestSuite) TestPoolDenomMetadata() {
 	s.Require().NoError(err)
 
 	// Check if the liquidity is updated.
-	s.Require().Equal(atomPoolDenomMetadata.LocalMCap.String(), atomLiquidityUpdated.String())
+	s.Require().Equal(atomPoolDenomMetadata.TotalLiquidity.String(), atomLiquidityUpdated.String())
 
 	// Get the liquidity of OSMO
 	osmoLiquidityUpdated, err := mainnetUsecase.Tokens.GetPoolLiquidityCap(UOSMO)
 	s.Require().NoError(err)
 
 	// Check if the liquidity is updated.
-	s.Require().Equal(osmoPoolDenomMetadata.LocalMCap.String(), osmoLiquidityUpdated.String())
+	s.Require().Equal(osmoPoolDenomMetadata.TotalLiquidity.String(), osmoLiquidityUpdated.String())
 
 	// Fail to get the liquidity of another token
 	_, err = mainnetUsecase.Tokens.GetPoolLiquidityCap(UION)
@@ -385,7 +385,7 @@ func (s *TokensUseCaseTestSuite) TestPoolDenomMetadata() {
 
 	// Now, update only the OSMO liquidity
 	osmoPoolDenomMetadataUpdated := domain.PoolDenomMetaData{
-		LocalMCap: xAmount,
+		TotalLiquidity: xAmount,
 	}
 	mainnetUsecase.Tokens.UpdatePoolDenomMetadata(map[string]domain.PoolDenomMetaData{
 		UOSMO: osmoPoolDenomMetadataUpdated,
@@ -404,7 +404,7 @@ func (s *TokensUseCaseTestSuite) TestPoolDenomMetadata() {
 			s.Require().Equal(osmoPoolDenomMetadataUpdated, metadata)
 		case UION:
 			// Validate UION is not present and is nullified without erroring.
-			s.Require().Equal(osmomath.ZeroInt().String(), metadata.LocalMCap.String())
+			s.Require().Equal(osmomath.ZeroInt().String(), metadata.TotalLiquidity.String())
 		}
 	}
 }


### PR DESCRIPTION
ref: https://linear.app/osmosis/issue/STABI-150/dynamic-min-liquidity-filter-to-solve-flashing-routes-problem

Returns local mcap denominated in the denom.

Next, need to add pre-computation logic for pricing it in USDC.

The final goal is to compute the min liquidity value dynamically based on the token input by utilizing these local mcap values.

The query is only exposed for convenience.