### PR TITLE
fix: taker fee not charged on transmuter pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 - Clean up chain pricing
+- Charge taker fee for transmuter pools
 
 ## v0.17.11
 

--- a/router/usecase/pools/routable_cw_transmuter_pool.go
+++ b/router/usecase/pools/routable_cw_transmuter_pool.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	cwpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
+	"github.com/osmosis-labs/osmosis/v25/x/poolmanager"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
 )
 
@@ -84,9 +85,9 @@ func (r *routableTransmuterPoolImpl) String() string {
 }
 
 // ChargeTakerFeeExactIn implements sqsdomain.RoutablePool.
-// Returns tokenInAmount and does not charge any fee for transmuter pools.
 func (r *routableTransmuterPoolImpl) ChargeTakerFeeExactIn(tokenIn sdk.Coin) (inAmountAfterFee sdk.Coin) {
-	return tokenIn
+	tokenInAfterTakerFee, _ := poolmanager.CalcTakerFeeExactIn(tokenIn, r.GetTakerFee())
+	return tokenInAfterTakerFee
 }
 
 // validateBalance validates that the balance of the denom to validate is greater than the token in amount.


### PR DESCRIPTION
Fixes the bug where taker fee is not charged on transmuter pools:
https://osmosis-network.slack.com/archives/C03JT90769K/p1713416922562079

When SQS was implemented, transmuter pools did not charge the taker fee. Later that was changed but the update here was never made.

When the original issue was reported, I suspected that its scope was more general around the token out fiat value. However, that ended up not being the case.

Additionally, this [FE PR](https://github.com/osmosis-labs/osmosis-frontend/pull/3156/files) assumed that the taker fee issue is more broad which is also not true.

Instead, we should revert https://github.com/osmosis-labs/osmosis-frontend/pull/3156/files and deploy this SQS transmuter taker fee charge from this PR.

## Testing

- Tested by doing a USDC / USDC.axl quote over swagger locally