### PR TITLE
Added labels on docker build and push

### DIFF
--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -43,6 +43,7 @@ jobs:
         SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-8)
         echo "DOCKER_IMAGE_TAG=${{ github.ref_name }}-${SHORT_SHA}" >> $GITHUB_ENV
         echo "DOCKER_IMAGE_TAG_WITH_DATE=${{ github.ref_name }}-${SHORT_SHA}-$(date +%s)" >> $GITHUB_ENV
+        echo "BUILD_DATE=$(date +%s)" >> $GITHUB_ENV
     -
       name: Build and Push Docker Images
       uses: docker/build-push-action@v5
@@ -56,10 +57,11 @@ jobs:
           ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG_WITH_DATE }}
         labels: |
           repository_full_name=${{ github.repository }}
-          branch: ${{ github.ref_name }}
-          commit_sha=${GITHUB_SHA} 
-          docker_image_tag: ${{ env.DOCKER_IMAGE_TAG }}
-          build_date=$(date +%s)
+          repository_docker=${{ env.DOCKER_REPOSITORY }}
+          ref_name=${{ github.ref_name }}
+          commit_sha=${{ env.GITHUB_SHA }} 
+          tag=${{ env.DOCKER_IMAGE_TAG }}
+          build_date=${{ env.BUILD_DATE }}
     - name: Get default branch name
       run: echo "The default branch is ${{ github.event.repository.default_branch }} and the actual branch is ${{ github.ref }}"
     - 

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -9,7 +9,6 @@
 name: Push Dev Images
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - "v[0-9]+.x"

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -9,6 +9,7 @@
 name: Push Dev Images
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "v[0-9]+.x"

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -54,6 +54,12 @@ jobs:
         tags: |
           ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}
           ${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG_WITH_DATE }}
+        labels: |
+          repository_full_name=${{ github.repository }}
+          branch: ${{ github.ref_name }}
+          commit_sha=${GITHUB_SHA} 
+          docker_image_tag: ${{ env.DOCKER_IMAGE_TAG }}
+          build_date=$(date +%s)
     - name: Get default branch name
       run: echo "The default branch is ${{ github.event.repository.default_branch }} and the actual branch is ${{ github.ref }}"
     - 

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -54,9 +54,9 @@ jobs:
               ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
               ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
           labels: |
-            repository_full_name=${{ github.repository }}
-            repository_docker=${{ env.DOCKER_REPOSITORY }}
-            ref_name=${{ github.ref_name }}
-            commit_sha=${{ env.GITHUB_SHA }} 
-            tag=${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
-            build_date=${{ env.BUILD_DATE }}
+              repository_full_name=${{ github.repository }}
+              repository_docker=${{ env.DOCKER_REPOSITORY }}
+              ref_name=${{ github.ref_name }}
+              commit_sha=${{ env.GITHUB_SHA }} 
+              tag=${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+              build_date=${{ env.BUILD_DATE }}

--- a/.github/workflows/push-docker-images.yml
+++ b/.github/workflows/push-docker-images.yml
@@ -53,3 +53,10 @@ jobs:
               ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}
               ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}
               ${{ env.DOCKER_REPOSITORY }}:${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+          labels: |
+            repository_full_name=${{ github.repository }}
+            repository_docker=${{ env.DOCKER_REPOSITORY }}
+            ref_name=${{ github.ref_name }}
+            commit_sha=${{ env.GITHUB_SHA }} 
+            tag=${{ env.MAJOR_VERSION }}.${{ env.MINOR_VERSION }}.${{ env.PATCH_VERSION }}
+            build_date=${{ env.BUILD_DATE }}


### PR DESCRIPTION
These changes aim to add labels to the Docker images in their respective workflows. 

This is needed to provide information about:
- Repository name
- Docker repository name
- GitHub ref name
- GitHub commit SHA
- GitHub tag
- Build date