### PR TITLE
test(e2e): reduce flakiness in candidate route and prices tests

### DIFF
--- a/router/usecase/router.go
+++ b/router/usecase/router.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"sort"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	cosmwasmpooltypes "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/types"
@@ -115,7 +116,7 @@ func sortPools(pools []sqsdomain.PoolI, transmuterCodeIDs map[uint64]struct{}, t
 
 		// rating += 1/ 100 of TVL of asset across all pools
 		// (Ignoring any pool with an error in TVL)
-		if pool.GetSQSPoolModel().PoolLiquidityCapError == noPoolLiquidityCapError {
+		if strings.TrimSpace(pool.GetSQSPoolModel().PoolLiquidityCapError) == noPoolLiquidityCapError {
 			rating += totalTVLFloat / 100
 		}
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -29,3 +29,8 @@ RT_THRESHOLD = 1
 
 ## Unsupported token count threshold
 UNSUPPORTED_TOKEN_COUNT_THRESHOLD = 10
+
+# Min liquidity in USD of each token in the transmuter pool
+# required to run the transmuter test. This is to avoid the flakiness
+# stemming from transmuter pool imbalance.
+TRANSMUTER_MIN_TOKEN_LIQ_USD = 15000

--- a/tests/sqs_service.py
+++ b/tests/sqs_service.py
@@ -1,6 +1,6 @@
 import requests
 
-SQS_STAGE = "http://localhost:9092"
+SQS_STAGE = "https://sqs.stage.osmosis.zone"
 SQS_PROD = "https://sqs.osmosis.zone"
 
 ROUTER_ROUTES_URL = "/router/routes"

--- a/tests/test_candidate_routes.py
+++ b/tests/test_candidate_routes.py
@@ -4,6 +4,7 @@ import pytest
 
 from sqs_service import *
 import constants
+import util
 from conftest import SERVICE_MAP
 
 # Arbitrary choice based on performance at the time of test writing
@@ -48,6 +49,8 @@ class TestCandidateRoutes:
         transmuter_pool_id = transmuter_token_data[0]
         tansmuter_token_pair = transmuter_token_data[1]
 
+        util.skip_imbalanced_pool_test(transmuter_token_data)
+
         config = sqs_service.get_config()
         expected_num_routes = config['Router']['MaxRoutes']
 
@@ -56,6 +59,11 @@ class TestCandidateRoutes:
         validate_pool_id_in_route(routes, [transmuter_pool_id])
     
     def test_astroport_tokens(self, environment_url):
+
+        # See:
+        # https://linear.app/osmosis/issue/DATA-191/[techdebt]-re-enable-astroport-integration-test-for-candidate-routes
+        pytest.skip("Skipping Astroport PCL candidate route test per DATA-191")
+
         sqs_service = SERVICE_MAP[environment_url]
 
         astroport_token_data = setup.astroport_token_pair[0]

--- a/tests/test_tokens_prices.py
+++ b/tests/test_tokens_prices.py
@@ -63,7 +63,7 @@ class TestTokensPrices:
     # NUM_TOKENS_DEFAULT mid volume tokens
     @pytest.mark.parametrize("token",setup.choose_tokens_volume_range(NUM_TOKENS_DEFAULT, MIN_VOL_FILTER_DEFAULT, MAX_VAL_MID_VOL_FILTER_DEFAULT))
     def test_mid_volume_token_prices(self, environment_url, token):
-        self.run_coingecko_comparison_test(environment_url, token, MID_PRICE_DIFF, allow_blank_coingecko_id=False)
+        self.run_coingecko_comparison_test(environment_url, token, MID_PRICE_DIFF, allow_blank_coingecko_id=True)
 
     # NUM_TOKENS_DEFAULT top by-volume tokens
     @pytest.mark.parametrize("token", setup.choose_tokens_volume_range(NUM_TOKENS_DEFAULT))

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,19 @@
+import setup
+import constants
+import pytest
+
+def skip_imbalanced_pool_test(token_data):
+    """
+    Skip the test if any of the tokens in the pool (token_data[0]) have less than TRANSMUTER_MIN_TOKEN_LIQ_USD liquidity.
+    See definition of TRANSMUTER_MIN_TOKEN_LIQ_USD for more information.
+
+    This is useful for skipping pools such as transmuter that tend to get out of balance, consisting
+    only of one token and causing the flakiness in our test suite.
+    """
+    pool_id = token_data[0]
+    pool_data = setup.pool_by_id_map.get(pool_id)
+    pool_tokens = pool_data.get("pool_tokens")
+    for token in pool_tokens:
+        if float(token.get("amount")) < constants.TRANSMUTER_MIN_TOKEN_LIQ_USD:
+            pytest.skip("Skipped test due to pool being imbalanced")
+            return


### PR DESCRIPTION
- Skip Transmuter pool candidate route tests if transmuter is imbalances
- Skip Astroport PCL tests per: https://github.com/osmosis-labs/sqs/issues/258
- Disable spot price validation in prices for mid-liq tokens since they caused flakiness (no coingecko ID found) 