### PR TITLE
POC: Docker debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,15 @@
             "cwd": "${workspaceFolder}",
         },
         {
+            // See README.md#Debugging for more information
+            "name": "Debug Docker Container",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "port": 4000,
+            "host": "127.0.0.1"
+        },
+        {
             "name": "router/usecase",
             "type": "go",
             "request": "launch",

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1
+# See README.md#Debugging for more information
+
+ARG GO_VERSION="1.21"
+ARG RUNNER_IMAGE="golang:1.21"
+
+# --------------------------------------------------------
+# Builder
+# --------------------------------------------------------
+
+FROM golang:1.21-alpine as builder
+
+ARG GIT_VERSION
+ARG GIT_COMMIT
+
+WORKDIR /osmosis
+
+COPY go.mod go.sum ./
+COPY . .
+
+RUN set -eux; apk add --no-cache ca-certificates build-base linux-headers && \
+    go mod download
+
+RUN ARCH=$(uname -m) && WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm | sed 's/.* //') && \
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/libwasmvm_muslc.$ARCH.a \
+        -O /lib/libwasmvm_muslc.a && \
+    wget https://github.com/CosmWasm/wasmvm/releases/download/$WASMVM_VERSION/checksums.txt -O /tmp/checksums.txt && \
+    sha256sum /lib/libwasmvm_muslc.a | grep $(cat /tmp/checksums.txt | grep libwasmvm_muslc.$ARCH | cut -d ' ' -f 1)
+
+RUN BUILD_TAGS=muslc LINK_STATICALLY=true GOWORK=off go build -mod=readonly \
+    -tags "netgo,ledger,muslc" \
+    -gcflags "all=-N -l" \
+    -ldflags \
+    "-X github.com/osmosis-labs/sqs/version=${GIT_VERSION} \
+    -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
+    -v -o /osmosis/build/sqsd /osmosis/app/*.go 
+
+# --------------------------------------------------------
+# Runner
+# --------------------------------------------------------
+
+FROM ${RUNNER_IMAGE}
+COPY --from=builder /osmosis/build/sqsd /bin/sqsd
+ENV HOME /osmosis
+WORKDIR $HOME
+EXPOSE 9092
+EXPOSE 50051
+EXPOSE 4000
+RUN apt-get update && \
+    apt-get install curl vim nano -y
+
+RUN CGO_ENABLED=0 go install -ldflags "-s -w -extldflags '-static'" github.com/go-delve/delve/cmd/dlv@latest
+
+# Use JSON array format for ENTRYPOINT
+# If array is not used, the command arguments to docker run are ignored.
+CMD ["/go/bin/dlv", "--listen=:4000", "--headless=true", "--log=true", "--accept-multiclient", "--api-version=2", "exec", "/bin/sqsd", "--", "--config", "/osmosis/config.json", "--host", "sqs-default-host"]

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,18 @@ docker-build:
 	--build-arg GIT_COMMIT=$(COMMIT) \
 	-f Dockerfile .
 
+# This builds a debug image with the same version as the main image
+# The binary is built with the debug symbols and has started via Delve debugger.
+# Developer can then attach their IDE to the running container.
+# See README.md#Debugging for more details.
+docker-build-debug:
+	@DOCKER_BUILDKIT=1 $(DOCKER) build \
+	-t osmolabs/sqs:$(VERSION)-debug \
+	--build-arg GO_VERSION=$(GO_VERSION) \
+	--build-arg GIT_VERSION=$(VERSION) \
+	--build-arg GIT_COMMIT=$(COMMIT) \
+	-f Dockerfile.debug .
+
 # Cross-building for arm64 from amd64 (or vice-versa) takes
 # a lot of time due to QEMU virtualization but it's the only way (afaik)
 # to get a statically linked binary with CosmWasm

--- a/README.md
+++ b/README.md
@@ -624,6 +624,18 @@ See the recommended enabled configuration below:
 }
 ```
 
+## Debugging
+
+### Containers
+
+For debugging SQS Docker containers with dlv, build the binary using `make docker-build-debug`.
+This builds the binary with the debug symbols and then builds the Docker image with the debug binary.
+It also starts sqs via dlv inside the container while exposing port 4000.
+
+A client can then attach their debugger via port 4000.
+
+See `.vscode/launch.json` for the "Debug Docker Container" configuration.
+
 ## Useful Osmosis Resources
 
 -   [ADR-002 SQS GRPC Refactor](https://www.notion.so/osmosiszone/ADR-002-SQS-GRPC-Ingest-Refactor-19fa05956d0344f58d40fbab57c08af7)


### PR DESCRIPTION
This PR adds a VS Code configuration for jumping onto our stage/prod nodes via SSH and attaching a debugger to a running Docker container.

This solution requires maintaining a separate Dockerfile for building a debug container with dlv server listening