### PR TITLE
fix: return single route quote if split quote fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- Return single route quote if split quote fails
 - CoinGecko pricing source support
 - Consistently rename min liqudity filter across pool models & configs to min pool liquidity capitalization (cap)
 - Validate token in and out in /router quote endpoints to ensure that they are not equal to each other & clean up tokens/prices

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -196,7 +196,9 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 	// Compute split route quote
 	topSplitQuote, err := getSplitQuote(ctx, rankedRoutes, tokenIn)
 	if err != nil {
-		return nil, err
+		// If error occurs in splits, return the single route quote
+		// rather than failing.
+		return topSingleRouteQuote, nil
 	}
 
 	finalQuote := topSingleRouteQuote


### PR DESCRIPTION
https://linear.app/osmosis/issue/DATA-196/error-in-getting-quote-to-swap-pepe-against-usdc

If split quote fails, we should return the best single route quote.