### PR TITLE
[Dynamic Min Liquidity] implement denom pool liquidity data transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- Ingester data transformations for dynamic min liquidity.
 - Optimize dynamic splits by caching repeated calls within callback.
 - Remove queue from pricing worker
 - Return single route quote if split quote fails

--- a/chaininfo/usecase/chain_info_usecase.go
+++ b/chaininfo/usecase/chain_info_usecase.go
@@ -89,10 +89,10 @@ func (p *chainInfoUseCase) StoreLatestHeight(height uint64) {
 }
 
 // OnPricingUpdate implements domain.PricingUpdateListener.
-func (p *chainInfoUseCase) OnPricingUpdate(ctx context.Context, height int64, pricesBaseQuoteDenomMap map[string]map[string]any, quoteDenom string) error {
+func (p *chainInfoUseCase) OnPricingUpdate(ctx context.Context, height uint64, blockMetadata domain.BlockPoolMetadata, pricesBaseQuoteDenomMap domain.PricesResult, quoteDenom string) error {
 	p.priceUpdateHeightMx.Lock()
 	defer p.priceUpdateHeightMx.Unlock()
-	p.latestPricesUpdateHeight = uint64(height)
+	p.latestPricesUpdateHeight = height
 
 	return nil
 }

--- a/domain/ingester.go
+++ b/domain/ingester.go
@@ -17,9 +17,9 @@ type GRPCIngesterConfig struct {
 // BlockPoolMetadata contains the metadata about unique pools
 // and denoms modified in a block.
 type BlockPoolMetadata struct {
-	// DenomMap is a map of denoms.
+	// DenomPoolLiquidityMap is a map of denoms to their liquidities across pools.
 	// These are constructed from the pool IDs updated within a block.
-	DenomMap DenomMap
+	DenomPoolLiquidityMap DenomPoolLiquidityMap
 	// PoolIDs are the IDs of all pools updated within a block.
 	PoolIDs map[uint64]struct{}
 }

--- a/domain/mocks/pricing_update_listener_mock.go
+++ b/domain/mocks/pricing_update_listener_mock.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"time"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 )
 
 type PricingUpdateListenerMock struct {
 	Height                 int
-	PricesBaseQuteDenomMap map[string]map[string]any
+	PricesBaseQuteDenomMap map[string]map[string]osmomath.BigDec
 	QuoteDenom             string
 
 	Done chan struct{}
@@ -22,7 +23,7 @@ type PricingUpdateListenerMock struct {
 func NewPricingListenerMock(timeout time.Duration) *PricingUpdateListenerMock {
 	return &PricingUpdateListenerMock{
 		Done:                   make(chan struct{}),
-		PricesBaseQuteDenomMap: make(map[string]map[string]any),
+		PricesBaseQuteDenomMap: make(map[string]map[string]osmomath.BigDec),
 		timeout:                timeout,
 	}
 }
@@ -30,7 +31,7 @@ func NewPricingListenerMock(timeout time.Duration) *PricingUpdateListenerMock {
 var _ domain.PricingUpdateListener = &PricingUpdateListenerMock{}
 
 // OnPricingUpdate implements worker.PricingUpdateListener.
-func (p *PricingUpdateListenerMock) OnPricingUpdate(ctx context.Context, height int64, pricesBaseQuoteDenomMap map[string]map[string]any, quoteDenom string) error {
+func (p *PricingUpdateListenerMock) OnPricingUpdate(ctx context.Context, height uint64, blockMetadata domain.BlockPoolMetadata, pricesBaseQuoteDenomMap domain.PricesResult, quoteDenom string) error {
 	p.Height = int(height)
 	p.QuoteDenom = quoteDenom
 

--- a/domain/mvc/tokens.go
+++ b/domain/mvc/tokens.go
@@ -34,7 +34,7 @@ type TokensUsecase interface {
 	// The outer map consists of base denoms as keys.
 	// The inner map consists of quote denoms as keys.
 	// The result of the inner map is prices of the outer base and inner quote.
-	GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (map[string]map[string]any, error)
+	GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error)
 
 	// RegisterPricingStrategy registers a pricing strategy for a given pricing source.
 	RegisterPricingStrategy(source domain.PricingSourceType, strategy domain.PricingSource)

--- a/domain/pricing.go
+++ b/domain/pricing.go
@@ -142,6 +142,15 @@ type PricingWorker interface {
 	RegisterListener(listener PricingUpdateListener)
 }
 
+// PricingUpdateListener defines the interface for the pricing update listener.
 type PricingUpdateListener interface {
-	OnPricingUpdate(ctx context.Context, height int64, pricesBaseQuoteDenomMap map[string]map[string]any, quoteDenom string) error
+	// OnPricingUpdate notifies the listener of the pricing update.
+	OnPricingUpdate(ctx context.Context, height uint64, blockMetaData BlockPoolMetadata, pricesBaseQuoteDenomMap PricesResult, quoteDenom string) error
 }
+
+// PricesResult defines the result of the prices.
+// [base denom][quote denom] => price
+// Note: BREAKING API - this type is API breaking as it is serialized to JSON.
+// from the /tokens/prices endpoint. Be mindful of changing it without
+// separating the API response for backward compatibility.
+type PricesResult map[string]map[string]osmomath.BigDec

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -1,5 +1,7 @@
 package domain
 
+import "github.com/osmosis-labs/osmosis/osmomath"
+
 // Token represents the token's domain model
 type Token struct {
 	// HumanDenom is the human readable denom.
@@ -11,5 +13,16 @@ type Token struct {
 	CoingeckoID string `json:"coingeckoId"`
 }
 
-// DenomMap is a map of denoms
-type DenomMap map[string]struct{}
+// DenomPoolLiquidityMap is a map of denoms to their pool liquidity data.
+type DenomPoolLiquidityMap map[string]DenomPoolLiquidityData
+
+// DenomPoolLiquidityData contains the pool liquidity data for a denom
+// It has the total liquidity for the denom as well as all the
+// pools with their individual contributions to the total.
+type DenomPoolLiquidityData struct {
+	// Total liquidity for this denom
+	TotalLiquidity osmomath.Int
+	// Mapping from pool ID to denom liquidity
+	// in that pool
+	Pools map[uint64]osmomath.Int
+}

--- a/ingest/usecase/export_test.go
+++ b/ingest/usecase/export_test.go
@@ -1,5 +1,18 @@
 package usecase
 
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/sqs/domain"
+)
+
 type (
 	IngestUseCaseImpl = ingestUseCase
 )
+
+func UpdateCurrentBlockLiquidityMapFromBalances(currentBlockLiquidityMap domain.DenomPoolLiquidityMap, currentPoolBalances sdk.Coins, poolID uint64) domain.DenomPoolLiquidityMap {
+	return updateCurrentBlockLiquidityMapFromBalances(currentBlockLiquidityMap, currentPoolBalances, poolID)
+}
+
+func TransferDenomLiquidityMap(transferTo, transferFrom domain.DenomPoolLiquidityMap) domain.DenomPoolLiquidityMap {
+	return transferDenomLiquidityMap(transferTo, transferFrom)
+}

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -7,6 +7,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"go.uber.org/zap"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
@@ -25,6 +28,8 @@ type ingestUseCase struct {
 	routerUsecase    mvc.RouterUsecase
 	chainInfoUseCase mvc.ChainInfoUsecase
 
+	denomLiquidityMap domain.DenomPoolLiquidityMap
+
 	// Worker that computes prices for all tokens with the default quote.
 	defaultQuotePriceUpdateWorker domain.PricingWorker
 
@@ -34,13 +39,6 @@ type ingestUseCase struct {
 type poolResult struct {
 	pool sqsdomain.PoolI
 	err  error
-}
-
-// UniqueBlockPoolMetaData contains the metadta about unique pools
-// and denoms modified in a block.
-type UniqueBlockPoolMetaData struct {
-	Denoms  map[string]struct{}
-	PoolIDs map[uint64]struct{}
 }
 
 var (
@@ -55,6 +53,8 @@ func NewIngestUsecase(poolsUseCase mvc.PoolsUsecase, routerUseCase mvc.RouterUse
 		chainInfoUseCase: chainInfoUseCase,
 		routerUsecase:    routerUseCase,
 		poolsUseCase:     poolsUseCase,
+
+		denomLiquidityMap: make(domain.DenomPoolLiquidityMap),
 
 		logger: logger,
 
@@ -92,12 +92,7 @@ func (p *ingestUseCase) ProcessBlockData(ctx context.Context, height uint64, tak
 
 	// Note: we must queue the update before we start updating prices as pool liquidity
 	// worker listens for the pricing updates at the same height.
-	p.defaultQuotePriceUpdateWorker.UpdatePricesAsync(height, domain.BlockPoolMetadata{
-		DenomMap: uniqueBlockPoolMetadata.Denoms,
-		// TODO: add in the future PR.
-		// Ref: https://github.com/osmosis-labs/sqs/pull/224
-		// PoolIDs: ,
-	})
+	p.defaultQuotePriceUpdateWorker.UpdatePricesAsync(height, uniqueBlockPoolMetadata)
 
 	// Store the latest ingested height.
 	p.chainInfoUseCase.StoreLatestHeight(height)
@@ -123,7 +118,7 @@ func (p *ingestUseCase) sortAndStorePools(pools []sqsdomain.PoolI) {
 }
 
 // parsePoolData parses the pool data and returns the pool objects.
-func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.PoolData) ([]sqsdomain.PoolI, UniqueBlockPoolMetaData, error) {
+func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.PoolData) ([]sqsdomain.PoolI, domain.BlockPoolMetadata, error) {
 	poolResultChan := make(chan poolResult, len(poolData))
 
 	// Parse the pools concurrently
@@ -140,10 +135,11 @@ func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.Poo
 
 	parsedPools := make([]sqsdomain.PoolI, 0, len(poolData))
 
-	uniqueData := UniqueBlockPoolMetaData{
-		Denoms:  make(map[string]struct{}),
+	uniqueData := domain.BlockPoolMetadata{
 		PoolIDs: make(map[uint64]struct{}, len(poolData)),
 	}
+
+	currentBlockLiquidityMap := domain.DenomPoolLiquidityMap{}
 
 	// Collect the parsed pools
 	for i := 0; i < len(poolData); i++ {
@@ -156,21 +152,110 @@ func (p *ingestUseCase) parsePoolData(ctx context.Context, poolData []*types.Poo
 				continue
 			}
 
-			// Update unique denoms
-			for _, balance := range poolResult.pool.GetSQSPoolModel().Balances {
-				uniqueData.Denoms[balance.Denom] = struct{}{}
-			}
+			// Get balances and pool ID.
+			currentPoolBalances := poolResult.pool.GetSQSPoolModel().Balances
+			poolID := poolResult.pool.GetId()
+
+			// Update block liquidity map.
+			currentBlockLiquidityMap = updateCurrentBlockLiquidityMapFromBalances(currentBlockLiquidityMap, currentPoolBalances, poolID)
 
 			// Update unique pools.
-			uniqueData.PoolIDs[poolResult.pool.GetId()] = struct{}{}
+			uniqueData.PoolIDs[poolID] = struct{}{}
 
 			parsedPools = append(parsedPools, poolResult.pool)
 		case <-ctx.Done():
-			return nil, UniqueBlockPoolMetaData{}, ctx.Err()
+			return nil, domain.BlockPoolMetadata{}, ctx.Err()
 		}
 	}
 
+	// Transfer the updated block denom liquidity data to the global map.
+	// Note, the updated liquidity data contains updates only for the pools updated
+	// in the current block. We need to merge this data with the holistic existing data.
+	p.denomLiquidityMap = transferDenomLiquidityMap(p.denomLiquidityMap, currentBlockLiquidityMap)
+
+	// Update unique denoms.
+	uniqueData.DenomPoolLiquidityMap = p.denomLiquidityMap
+
 	return parsedPools, uniqueData, nil
+}
+
+// updateCurrentBlockLiquidityMapFromBalances updates the current block liquidity map with the balance from the pool of the supplied ID.
+// For each denom, if there is pre-existent denom data, it is updated, if there is no denom dat, it is initialized to the given balances.
+// CONTRACT: if thehere is a liqudiity entry for a denom, it must have been previously initialized by calling this function.
+// Returns the updated map.
+func updateCurrentBlockLiquidityMapFromBalances(currentBlockLiquidityMap domain.DenomPoolLiquidityMap, currentPoolBalances sdk.Coins, poolID uint64) domain.DenomPoolLiquidityMap {
+	// For evey coin in balance
+	for _, coin := range currentPoolBalances {
+		// Get denom data for this denom
+		denomData, ok := currentBlockLiquidityMap[coin.Denom]
+		if !ok {
+			// Initialize if does not exist
+			denomData = domain.DenomPoolLiquidityData{
+				TotalLiquidity: osmomath.ZeroInt(),
+				Pools:          map[uint64]osmomath.Int{},
+			}
+		}
+
+		// Set the denom liquidity contribution from the given pool
+		denomData.Pools[poolID] = coin.Amount
+
+		// Update total liquidity
+		denomData.TotalLiquidity = denomData.TotalLiquidity.Add(coin.Amount)
+
+		// Update the block liquidity map
+		currentBlockLiquidityMap[coin.Denom] = denomData
+	}
+
+	// Return for idiomacy despite param mutation.
+	return currentBlockLiquidityMap
+}
+
+// transferDenomLiquidityMap transfer the updated block denom liquidity data from transferFrom to
+// transferTo map.
+//
+// Note, the updated liquidity data contains updates only for the pools updated
+// in the current block. We need to merge this data with the holistic existing data.
+//
+// Returns the updated map.
+//
+// Transfer process:
+// If there is an entry in transferFrom map that does not exist in transferTo, it is copied to the transferTo map.
+// If there is an entry for the same denom in both maps, it is merged from one map to the other.
+//
+// Merge process:
+// For all pools in the transfer from map, if there is an entry for that pool in the transferTo map, we subtract
+// that pools liquidity contribution from total in the transferTo map.
+//
+// We then simply add the transferFrom liquidity map to the total to reflect the new total.
+// the updated denom liquidity data is then set for that denom.
+func transferDenomLiquidityMap(transferTo, transferFrom domain.DenomPoolLiquidityMap) domain.DenomPoolLiquidityMap {
+	for denom, transferFromDenomLiquidityData := range transferFrom {
+		transferToLiquidityDataForDenom, ok := transferTo[denom]
+		if !ok {
+			transferTo[denom] = transferFromDenomLiquidityData
+			continue
+		}
+
+		// Transfer pools
+		for transferFromPoolID, transferFromLiquidity := range transferFromDenomLiquidityData.Pools {
+			// Current pool data
+			transferToPoolLiquidity, ok := transferToLiquidityDataForDenom.Pools[transferFromPoolID]
+			if ok {
+				// Subtract the existing liquidity from the total liquidity.
+				transferToLiquidityDataForDenom.TotalLiquidity = transferToLiquidityDataForDenom.TotalLiquidity.Sub(transferToPoolLiquidity)
+			}
+
+			// Add the new liquidity to the total liquidity.
+			transferToLiquidityDataForDenom.TotalLiquidity = transferToLiquidityDataForDenom.TotalLiquidity.Add(transferFromLiquidity)
+			// Overwrite liquidity for the pool or set it if it doesn't exist.
+			transferToLiquidityDataForDenom.Pools[transferFromPoolID] = transferFromLiquidity
+		}
+
+		// Update the global map with the updated data.
+		transferTo[denom] = transferToLiquidityDataForDenom
+	}
+
+	return transferTo
 }
 
 // parsePool parses the pool data and returns the pool object

--- a/ingest/usecase/ingest_usecase_test.go
+++ b/ingest/usecase/ingest_usecase_test.go
@@ -16,7 +16,7 @@ type IngestUseCaseTestSuite struct {
 }
 
 const (
-	defaltPoolID uint64 = 1
+	defaultPoolID uint64 = 1
 )
 
 var (
@@ -37,7 +37,7 @@ var (
 		UOSMO: domain.DenomPoolLiquidityData{
 			TotalLiquidity: defaultAmount,
 			Pools: map[uint64]osmomath.Int{
-				defaltPoolID: defaultAmount,
+				defaultPoolID: defaultAmount,
 			},
 		},
 	}
@@ -46,7 +46,7 @@ var (
 		USDC: domain.DenomPoolLiquidityData{
 			TotalLiquidity: defaultAmount.Add(defaultAmount),
 			Pools: map[uint64]osmomath.Int{
-				defaltPoolID + 1: defaultAmount.Add(defaultAmount),
+				defaultPoolID + 1: defaultAmount.Add(defaultAmount),
 			},
 		},
 	}
@@ -55,14 +55,14 @@ var (
 		UOSMO: domain.DenomPoolLiquidityData{
 			TotalLiquidity: defaultAmount,
 			Pools: map[uint64]osmomath.Int{
-				defaltPoolID: defaultAmount,
+				defaultPoolID: defaultAmount,
 			},
 		},
 
 		USDC: domain.DenomPoolLiquidityData{
 			TotalLiquidity: defaultUSDCBalance.Amount,
 			Pools: map[uint64]osmomath.Int{
-				defaltPoolID + 1: defaultUSDCBalance.Amount,
+				defaultPoolID + 1: defaultUSDCBalance.Amount,
 			},
 		},
 	}
@@ -90,7 +90,7 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 
 			blockLiqMap: emptyBlockLiqMap,
 
-			poolID: defaltPoolID,
+			poolID: defaultPoolID,
 
 			expectedBlockLiqMap: emptyBlockLiqMap,
 		},
@@ -106,7 +106,7 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 
 			balances: sdk.NewCoins(defaultUOSMOBalance),
 
-			poolID: defaltPoolID,
+			poolID: defaultPoolID,
 
 			expectedBlockLiqMap: domain.DenomPoolLiquidityMap{
 				UOSMO: domain.DenomPoolLiquidityData{
@@ -114,7 +114,7 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 					TotalLiquidity: defaultAmount.Add(defaultAmount),
 					Pools: map[uint64]osmomath.Int{
 						// Pool entry added
-						defaltPoolID: defaultAmount,
+						defaultPoolID: defaultAmount,
 					},
 				},
 			},
@@ -126,7 +126,7 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 
 			balances: sdk.NewCoins(defaultUSDCBalance),
 
-			poolID: defaltPoolID + 1,
+			poolID: defaultPoolID + 1,
 
 			expectedBlockLiqMap: mergedUOSMOandUSDCMap,
 		},
@@ -136,7 +136,7 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 			blockLiqMap: defaultMapUOSMOEntry,
 
 			balances: sdk.NewCoins(),
-			poolID:   defaltPoolID,
+			poolID:   defaultPoolID,
 
 			expectedBlockLiqMap: defaultMapUOSMOEntry,
 		},
@@ -147,7 +147,7 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 			blockLiqMap: emptyDenomLiquidityMap,
 
 			balances: sdk.NewCoins(),
-			poolID:   defaltPoolID,
+			poolID:   defaultPoolID,
 
 			expectedBlockLiqMap: emptyDenomLiquidityMap,
 		},
@@ -158,13 +158,13 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 				UOSMO: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultAmount,
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID: defaultAmount,
+						defaultPoolID: defaultAmount,
 					},
 				},
 				USDC: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultAmount,
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID: defaultAmount,
+						defaultPoolID: defaultAmount,
 					},
 				},
 			},
@@ -174,25 +174,25 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 				defaultUSDCBalance,
 				defaultATOMBalance,
 			),
-			poolID: defaltPoolID + 1,
+			poolID: defaultPoolID + 1,
 
 			expectedBlockLiqMap: domain.DenomPoolLiquidityMap{
 				UOSMO: domain.DenomPoolLiquidityData{
 					// Doubled
 					TotalLiquidity: defaultAmount.Add(defaultAmount),
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID: defaultAmount,
+						defaultPoolID: defaultAmount,
 						// Another pool entry created.
-						defaltPoolID + 1: defaultAmount,
+						defaultPoolID + 1: defaultAmount,
 					},
 				},
 				USDC: domain.DenomPoolLiquidityData{
 					// Doubled
 					TotalLiquidity: defaultAmount.Add(defaultUSDCBalance.Amount),
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID: defaultAmount,
+						defaultPoolID: defaultAmount,
 						// Another pool entry created.
-						defaltPoolID + 1: defaultUSDCBalance.Amount,
+						defaultPoolID + 1: defaultUSDCBalance.Amount,
 					},
 				},
 
@@ -200,7 +200,7 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 				ATOM: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultATOMBalance.Amount,
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID + 1: defaultATOMBalance.Amount,
+						defaultPoolID + 1: defaultATOMBalance.Amount,
 					},
 				},
 			},
@@ -277,8 +277,8 @@ func (s *IngestUseCaseTestSuite) TestTransferDenomLiquidityMap() {
 				UOSMO: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultAmount.Add(defaultAmount),
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID:     defaultAmount,
-						defaltPoolID + 1: defaultAmount,
+						defaultPoolID:     defaultAmount,
+						defaultPoolID + 1: defaultAmount,
 					},
 				},
 			},
@@ -287,8 +287,8 @@ func (s *IngestUseCaseTestSuite) TestTransferDenomLiquidityMap() {
 				UOSMO: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultAmount.Add(defaultAmount),
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID:     defaultAmount,
-						defaltPoolID + 1: defaultAmount,
+						defaultPoolID:     defaultAmount,
+						defaultPoolID + 1: defaultAmount,
 					},
 				},
 			},
@@ -304,7 +304,7 @@ func (s *IngestUseCaseTestSuite) TestTransferDenomLiquidityMap() {
 				ATOM: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultAmount,
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID: defaultAmount,
+						defaultPoolID: defaultAmount,
 					},
 				},
 			},
@@ -314,14 +314,14 @@ func (s *IngestUseCaseTestSuite) TestTransferDenomLiquidityMap() {
 				UOSMO: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultUOSMOBalance.Amount,
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID: defaultUOSMOBalance.Amount,
+						defaultPoolID: defaultUOSMOBalance.Amount,
 					},
 				},
 				// Double USDC
 				USDC: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultUSDCBalance.Amount,
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID + 1: defaultUSDCBalance.Amount,
+						defaultPoolID + 1: defaultUSDCBalance.Amount,
 					},
 				},
 
@@ -329,7 +329,7 @@ func (s *IngestUseCaseTestSuite) TestTransferDenomLiquidityMap() {
 				ATOM: domain.DenomPoolLiquidityData{
 					TotalLiquidity: defaultAmount,
 					Pools: map[uint64]osmomath.Int{
-						defaltPoolID: defaultAmount,
+						defaultPoolID: defaultAmount,
 					},
 				},
 			},

--- a/ingest/usecase/ingest_usecase_test.go
+++ b/ingest/usecase/ingest_usecase_test.go
@@ -1,1 +1,369 @@
 package usecase_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/ingest/usecase"
+	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
+	"github.com/stretchr/testify/suite"
+)
+
+type IngestUseCaseTestSuite struct {
+	routertesting.RouterTestHelper
+}
+
+const (
+	defaltPoolID uint64 = 1
+)
+
+var (
+	emptyBlockLiqMap = domain.DenomPoolLiquidityMap{}
+	defaultAmount    = osmomath.NewInt(1_000)
+
+	UOSMO = routertesting.UOSMO
+	USDC  = routertesting.USDC
+	ATOM  = routertesting.ATOM
+
+	defaultUOSMOBalance = sdk.NewCoin(UOSMO, defaultAmount)
+
+	defaultUSDCBalance = sdk.NewCoin(USDC, defaultAmount.Add(defaultAmount))
+
+	defaultATOMBalance = sdk.NewCoin(ATOM, defaultAmount)
+
+	defaultMapUOSMOEntry = domain.DenomPoolLiquidityMap{
+		UOSMO: domain.DenomPoolLiquidityData{
+			TotalLiquidity: defaultAmount,
+			Pools: map[uint64]osmomath.Int{
+				defaltPoolID: defaultAmount,
+			},
+		},
+	}
+
+	defaultUSDCLiquidityMapEntry = domain.DenomPoolLiquidityMap{
+		USDC: domain.DenomPoolLiquidityData{
+			TotalLiquidity: defaultAmount.Add(defaultAmount),
+			Pools: map[uint64]osmomath.Int{
+				defaltPoolID + 1: defaultAmount.Add(defaultAmount),
+			},
+		},
+	}
+
+	mergedUOSMOandUSDCMap = domain.DenomPoolLiquidityMap{
+		UOSMO: domain.DenomPoolLiquidityData{
+			TotalLiquidity: defaultAmount,
+			Pools: map[uint64]osmomath.Int{
+				defaltPoolID: defaultAmount,
+			},
+		},
+
+		USDC: domain.DenomPoolLiquidityData{
+			TotalLiquidity: defaultUSDCBalance.Amount,
+			Pools: map[uint64]osmomath.Int{
+				defaltPoolID + 1: defaultUSDCBalance.Amount,
+			},
+		},
+	}
+
+	emptyDenomLiquidityMap = domain.DenomPoolLiquidityMap{}
+)
+
+func TestIngestUseCaseTestSuite(t *testing.T) {
+	suite.Run(t, new(IngestUseCaseTestSuite))
+}
+
+// Validates updateCurrentBlockLiquidityMapFromBalances per the spec.
+func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances() {
+	tests := []struct {
+		name string
+
+		blockLiqMap domain.DenomPoolLiquidityMap
+		balances    sdk.Coins
+		poolID      uint64
+
+		expectedBlockLiqMap domain.DenomPoolLiquidityMap
+	}{
+		{
+			name: "Empty map, empty balance, pool ID",
+
+			blockLiqMap: emptyBlockLiqMap,
+
+			poolID: defaltPoolID,
+
+			expectedBlockLiqMap: emptyBlockLiqMap,
+		},
+		{
+			name: "Token in map, one token in balance no pools pre-existing -> updated the token in map & added pool",
+
+			blockLiqMap: domain.DenomPoolLiquidityMap{
+				UOSMO: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultAmount,
+					Pools:          map[uint64]osmomath.Int{},
+				},
+			},
+
+			balances: sdk.NewCoins(defaultUOSMOBalance),
+
+			poolID: defaltPoolID,
+
+			expectedBlockLiqMap: domain.DenomPoolLiquidityMap{
+				UOSMO: domain.DenomPoolLiquidityData{
+					// 2x original amount
+					TotalLiquidity: defaultAmount.Add(defaultAmount),
+					Pools: map[uint64]osmomath.Int{
+						// Pool entry added
+						defaltPoolID: defaultAmount,
+					},
+				},
+			},
+		},
+		{
+			name: "One token in map, unrelated token in balance -> created separate entry",
+
+			blockLiqMap: defaultMapUOSMOEntry,
+
+			balances: sdk.NewCoins(defaultUSDCBalance),
+
+			poolID: defaltPoolID + 1,
+
+			expectedBlockLiqMap: mergedUOSMOandUSDCMap,
+		},
+		{
+			name: "One token in map, zero tokens in balance -> no-op",
+
+			blockLiqMap: defaultMapUOSMOEntry,
+
+			balances: sdk.NewCoins(),
+			poolID:   defaltPoolID,
+
+			expectedBlockLiqMap: defaultMapUOSMOEntry,
+		},
+
+		{
+			name: "Zero tokens in balance, none in map -> no-op",
+
+			blockLiqMap: emptyDenomLiquidityMap,
+
+			balances: sdk.NewCoins(),
+			poolID:   defaltPoolID,
+
+			expectedBlockLiqMap: emptyDenomLiquidityMap,
+		},
+		{
+			name: "Some tokens in map, some tokens in balance -> updates as expected",
+
+			blockLiqMap: domain.DenomPoolLiquidityMap{
+				UOSMO: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultAmount,
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID: defaultAmount,
+					},
+				},
+				USDC: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultAmount,
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID: defaultAmount,
+					},
+				},
+			},
+
+			balances: sdk.NewCoins(
+				defaultUOSMOBalance,
+				defaultUSDCBalance,
+				defaultATOMBalance,
+			),
+			poolID: defaltPoolID + 1,
+
+			expectedBlockLiqMap: domain.DenomPoolLiquidityMap{
+				UOSMO: domain.DenomPoolLiquidityData{
+					// Doubled
+					TotalLiquidity: defaultAmount.Add(defaultAmount),
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID: defaultAmount,
+						// Another pool entry created.
+						defaltPoolID + 1: defaultAmount,
+					},
+				},
+				USDC: domain.DenomPoolLiquidityData{
+					// Doubled
+					TotalLiquidity: defaultAmount.Add(defaultUSDCBalance.Amount),
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID: defaultAmount,
+						// Another pool entry created.
+						defaltPoolID + 1: defaultUSDCBalance.Amount,
+					},
+				},
+
+				// New entry for atom created.
+				ATOM: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultATOMBalance.Amount,
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID + 1: defaultATOMBalance.Amount,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		s.T().Run(tc.name, func(t *testing.T) {
+			// Note that the transferTo parameter is mutated, so we need to copy it
+			// to avoid flakiness across tests.
+			blockLiqMapCopy := deepCopyDenomLiquidityMap(tc.blockLiqMap)
+
+			// System under test.
+			actualBlockLiqMap := usecase.UpdateCurrentBlockLiquidityMapFromBalances(blockLiqMapCopy, tc.balances, tc.poolID)
+
+			// Validate.
+			s.Require().Equal(tc.expectedBlockLiqMap, actualBlockLiqMap)
+		})
+	}
+}
+
+// Validates transferDenomLiquidityMap per the spec.
+func (s *IngestUseCaseTestSuite) TestTransferDenomLiquidityMap() {
+	tests := []struct {
+		name string
+
+		transferTo   domain.DenomPoolLiquidityMap
+		transferFrom domain.DenomPoolLiquidityMap
+
+		expectedResult domain.DenomPoolLiquidityMap
+	}{
+		{
+			name: "both empty -> no-op",
+
+			transferTo:   emptyDenomLiquidityMap,
+			transferFrom: emptyDenomLiquidityMap,
+
+			expectedResult: emptyDenomLiquidityMap,
+		},
+
+		{
+			name: "transferTo empty -> transferred over",
+
+			transferTo:   emptyDenomLiquidityMap,
+			transferFrom: defaultMapUOSMOEntry,
+
+			expectedResult: defaultMapUOSMOEntry,
+		},
+
+		{
+			name: "transferFrom empty -> no-op",
+
+			transferTo:   defaultMapUOSMOEntry,
+			transferFrom: emptyBlockLiqMap,
+
+			expectedResult: defaultMapUOSMOEntry,
+		},
+
+		{
+			name: "entry is in transferFrom but not transferTo -> copied over",
+
+			transferTo:   defaultMapUOSMOEntry,
+			transferFrom: defaultUSDCLiquidityMapEntry,
+
+			expectedResult: mergedUOSMOandUSDCMap,
+		},
+
+		{
+			name: "same entry is in transferTo and transferFrom -> overwritten",
+
+			transferTo: defaultMapUOSMOEntry,
+			transferFrom: domain.DenomPoolLiquidityMap{
+				UOSMO: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultAmount.Add(defaultAmount),
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID:     defaultAmount,
+						defaltPoolID + 1: defaultAmount,
+					},
+				},
+			},
+
+			expectedResult: domain.DenomPoolLiquidityMap{
+				UOSMO: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultAmount.Add(defaultAmount),
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID:     defaultAmount,
+						defaltPoolID + 1: defaultAmount,
+					},
+				},
+			},
+		},
+
+		{
+			name: "2 entries in transfer from, 3 exist in transfer to (1 copied, 1 updated, 1 untouched)",
+
+			transferTo: mergedUOSMOandUSDCMap,
+			transferFrom: domain.DenomPoolLiquidityMap{
+				UOSMO: defaultUSDCLiquidityMapEntry[UOSMO],
+				USDC:  defaultUSDCLiquidityMapEntry[USDC],
+				ATOM: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultAmount,
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID: defaultAmount,
+					},
+				},
+			},
+
+			expectedResult: domain.DenomPoolLiquidityMap{
+				// Double UOSMO
+				UOSMO: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultUOSMOBalance.Amount,
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID: defaultUOSMOBalance.Amount,
+					},
+				},
+				// Double USDC
+				USDC: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultUSDCBalance.Amount,
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID + 1: defaultUSDCBalance.Amount,
+					},
+				},
+
+				// ATOM unchanged.
+				ATOM: domain.DenomPoolLiquidityData{
+					TotalLiquidity: defaultAmount,
+					Pools: map[uint64]osmomath.Int{
+						defaltPoolID: defaultAmount,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		s.T().Run(tc.name, func(t *testing.T) {
+			// Note that the transferTo parameter is mutated, so we need to copy it
+			// to avoid flakiness across tests.
+			transferToCopy := deepCopyDenomLiquidityMap(tc.transferTo)
+
+			// System under test
+			result := usecase.TransferDenomLiquidityMap(transferToCopy, tc.transferFrom)
+
+			// Validation
+			s.Require().Equal(tc.expectedResult, result)
+		})
+	}
+}
+
+// deepCopyDenomLiquidityMap is a helper function to deep copy a DenomLiquidityMap.
+func deepCopyDenomLiquidityMap(m domain.DenomPoolLiquidityMap) domain.DenomPoolLiquidityMap {
+	copy := make(domain.DenomPoolLiquidityMap, len(m))
+	for k, v := range m {
+		copy[k] = domain.DenomPoolLiquidityData{
+			TotalLiquidity: v.TotalLiquidity,
+			Pools:          make(map[uint64]osmomath.Int, len(v.Pools)),
+		}
+		for pk, pv := range v.Pools {
+			copy[k].Pools[pk] = pv
+		}
+	}
+	return copy
+}

--- a/tokens/usecase/pricing/worker/pricing_worker.go
+++ b/tokens/usecase/pricing/worker/pricing_worker.go
@@ -40,7 +40,7 @@ func (p *pricingWorker) UpdatePricesAsync(height uint64, uniqueBlockPoolMetaData
 }
 
 func (p *pricingWorker) updatePrices(height uint64, uniqueBlockPoolMetaData domain.BlockPoolMetadata) {
-	baseDenoms := keysFromMap(uniqueBlockPoolMetaData.DenomMap)
+	baseDenoms := keysFromMap(uniqueBlockPoolMetaData.DenomPoolLiquidityMap)
 
 	ctx, cancel := context.WithTimeout(context.Background(), priceUpdateTimeout)
 	start := time.Now()
@@ -67,7 +67,7 @@ func (p *pricingWorker) updatePrices(height uint64, uniqueBlockPoolMetaData doma
 	// Update listeners
 	for _, listener := range p.updateListeners {
 		// Ignore errors
-		_ = listener.OnPricingUpdate(ctx, int64(height), prices, p.quoteDenom)
+		_ = listener.OnPricingUpdate(ctx, height, uniqueBlockPoolMetaData, prices, p.quoteDenom)
 	}
 
 	// Measure duration

--- a/tokens/usecase/pricing/worker/pricing_worker_test.go
+++ b/tokens/usecase/pricing/worker/pricing_worker_test.go
@@ -57,19 +57,21 @@ func (s *PricingWorkerTestSuite) TestUpdatePricesAsync() {
 		{
 			name: "empty base denoms",
 			baseDenoms: domain.BlockPoolMetadata{
-				DenomMap: domain.DenomMap{},
+				DenomPoolLiquidityMap: domain.DenomPoolLiquidityMap{},
 			},
 		},
 		{
 			name: "one base denom",
 			baseDenoms: domain.BlockPoolMetadata{
-				DenomMap: domain.DenomMap{UOSMO: {}},
+				DenomPoolLiquidityMap: domain.DenomPoolLiquidityMap{UOSMO: {
+					TotalLiquidity: osmomath.OneInt(),
+				}},
 			},
 		},
 		{
 			name: "several base denoms",
 			baseDenoms: domain.BlockPoolMetadata{
-				DenomMap: domain.DenomMap{
+				DenomPoolLiquidityMap: domain.DenomPoolLiquidityMap{
 					UOSMO: {},
 					ATOM:  {},
 					USDC:  {},
@@ -79,7 +81,7 @@ func (s *PricingWorkerTestSuite) TestUpdatePricesAsync() {
 		{
 			name: "several base denoms with a queued base denom",
 			baseDenoms: domain.BlockPoolMetadata{
-				DenomMap: domain.DenomMap{
+				DenomPoolLiquidityMap: domain.DenomPoolLiquidityMap{
 					UOSMO: {},
 					USDC:  {},
 				},
@@ -118,10 +120,10 @@ func (s *PricingWorkerTestSuite) TestUpdatePricesAsync() {
 			s.Require().False(didTimeout)
 
 			// Ensure that the correct number of base denoms are set
-			s.Require().Equal(len(tc.baseDenoms.DenomMap), len(mockPricingUpdateListener.PricesBaseQuteDenomMap))
+			s.Require().Equal(len(tc.baseDenoms.DenomPoolLiquidityMap), len(mockPricingUpdateListener.PricesBaseQuteDenomMap))
 
 			// Ensure that non-zero prices are set for each base denom
-			s.ValidatePrices(tc.baseDenoms.DenomMap, defaultQuoteDenom, mockPricingUpdateListener.PricesBaseQuteDenomMap)
+			s.ValidatePrices(tc.baseDenoms.DenomPoolLiquidityMap, defaultQuoteDenom, mockPricingUpdateListener.PricesBaseQuteDenomMap)
 		})
 	}
 }
@@ -164,10 +166,10 @@ func (s *PricingWorkerTestSuite) TestGetPrices_Chain_FindUnsupportedTokens() {
 
 	// Populate base denoms with all possible chain denoms
 	baseDenoms := domain.BlockPoolMetadata{
-		DenomMap: domain.DenomMap{},
+		DenomPoolLiquidityMap: domain.DenomPoolLiquidityMap{},
 	}
 	for chainDenom := range tokenMetadata {
-		baseDenoms.DenomMap[chainDenom] = struct{}{}
+		baseDenoms.DenomPoolLiquidityMap[chainDenom] = domain.DenomPoolLiquidityData{}
 	}
 
 	// Test for empty base denoms
@@ -223,7 +225,7 @@ func (s *PricingWorkerTestSuite) TestGetPrices_Chain_FindUnsupportedTokens() {
 	s.Require().Equal(20, zeroPriceCounter)
 }
 
-func (s *PricingWorkerTestSuite) ValidatePrices(initialDenoms map[string]struct{}, expectedQuoteDenom string, prices map[string]map[string]any) {
+func (s *PricingWorkerTestSuite) ValidatePrices(initialDenoms domain.DenomPoolLiquidityMap, expectedQuoteDenom string, prices map[string]map[string]osmomath.BigDec) {
 	for baseDenom := range initialDenoms {
 		quoteMap, ok := prices[baseDenom]
 		s.Require().True(ok)

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -55,7 +55,7 @@ type priceResult struct {
 // Define a result struct to hold the base denom and prices for each possible quote denom or error
 type priceResults struct {
 	baseDenom string
-	prices    map[string]any
+	prices    map[string]osmomath.BigDec
 	err       error
 }
 
@@ -167,8 +167,8 @@ func (t *tokensUseCase) GetChainScalingFactorByDenomMut(denom string) (osmomath.
 }
 
 // GetPrices implements pricing.PricingStrategy.
-func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (map[string]map[string]any, error) {
-	byBaseDenomResult := make(map[string]map[string]any, len(baseDenoms))
+func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error) {
+	byBaseDenomResult := make(map[string]map[string]osmomath.BigDec, len(baseDenoms))
 
 	// Create a channel to communicate the results
 	resultsChan := make(chan priceResults, len(quoteDenoms))
@@ -215,8 +215,8 @@ func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quot
 // Returns a map with keys as quotes and values as prices or error, if any.
 // Returns error if base denom is not found in the token metadata.
 // Sets the price to zero in case of failing to compute the price between base and quote but these being valid tokens.
-func (t *tokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, pricingOptions ...domain.PricingOption) (map[string]any, error) {
-	byQuoteDenomForGivenBaseResult := make(map[string]any, len(quoteDenoms))
+func (t *tokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, pricingOptions ...domain.PricingOption) (map[string]osmomath.BigDec, error) {
+	byQuoteDenomForGivenBaseResult := make(map[string]osmomath.BigDec, len(quoteDenoms))
 	// Validate base denom is a valid denom
 	// Return zeroes for all quotes if base denom is not found
 	_, err := t.GetMetadataByChainDenom(baseDenom)


### PR DESCRIPTION
Ref: https://linear.app/osmosis/issue/DATA-199/[dynamic-min-liquidity-filter]-implement-and-test-new-ingester-data

Separated from https://github.com/osmosis-labs/sqs/pull/224 for ease of review.

To compute dynamic min liquidity based on the liquidity of each denom across all pools, we must transform the pool data into a mapping between denoms and their corresponding liquidity.

This PR implements the necessary helpers infrastructure to achieve this, propagating the data into a pricing worker for further usage.

See #224 for the end result of this feature.

## Testing

- #224 has already been tested on node
- The new logic in this PR is covered by unit tests