### PR TITLE
bugfix: PoolWrapper Validate panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 - [Dynamic Min Liquidity] new ingester methods for acquiring necessary metadata.
+- bugfix: PoolWrapper Validate panic
 
 ## v0.19.1
 

--- a/sqsdomain/pools.go
+++ b/sqsdomain/pools.go
@@ -149,9 +149,9 @@ func (p *PoolWrapper) Validate(minPoolLiquidityCapitalization osmomath.Int) erro
 
 	// Validate pool liquidity capitalization.
 	// If there is no pool liquidity capitalization error set and the pool liquidity capitalization is nil or zero, return an error. This implies
-	// That pool has no liqudiity.
+	// That pool has no liquidity.
 	poolLiquidityCapError := strings.TrimSpace(p.SQSModel.PoolLiquidityCapError)
-	if poolLiquidityCapError == "" && sqsModel.PoolLiquidityCap.IsZero() {
+	if poolLiquidityCapError == "" && (sqsModel.PoolLiquidityCap.IsNil() || sqsModel.PoolLiquidityCap.IsZero()) {
 		return fmt.Errorf("pool (%d) has no liquidity, minimum pool liquidity capitalization (%s)", p.GetId(), minPoolLiquidityCapitalization)
 	}
 


### PR DESCRIPTION
This pull request is a simple fix for `panic` I have encountered while working on other stuff. Is seems that not all pools during the block processing may have [SQSPool.PoolLiquidityCap](https://github.com/deividaspetraitis/sqs/blob/eb663f50a61224a6d8e2d73578ee5e4c327fec12/sqsdomain/pools.go#L55) initialized which leads to `panic`, for example: 

```json
{
  "total_value_locked_uosmo": "5469409",
  "total_value_locked_error": "error getting token precision ibc/A8C2D23A1E6F95DA4E48BA349667E322BD7A6C996D8A4AAE8BA72E190F3D1477",
  "balances": [
    {
      "denom": "ibc/A8C2D23A1E6F95DA4E48BA3496 67E322BD7A6C996D8A4AAE8BA72E190F3D1477",
      "amount": "183287"
    },
    {
      "denom": "uosmo",
      "amount": "5469409"
    }
  ],
  "pool_denoms": [
    "ibc/A8C2D23A1E6F95DA4E48BA349667E322BD7A6C996D8A4AAE8BA72E190F3D1477",
    "uosmo"
  ],
  "spread_factor": "0 .001000000000000000"
}
```



```dlv
(dlv) p poolResultData.SQSModel
github.com/osmosis-labs/sqs/sqsdomain.SQSPool {
        PoolLiquidityCap: cosmossdk.io/math.Int {
                i: *math/big.Int nil,},
        PoolLiquidityCapError: "",
        Balances: github.com/cosmos/cosmos-sdk/types.Coins len: 2, cap: 2, [
                (*"github.com/cosmos/cosmos-sdk/types.Coin")(0xc001778120),
                (*"github.com/cosmos/cosmos-sdk/types.Coin")(0xc001778138),
        ],
        PoolDenoms: []string len: 2, cap: 2, [
                "ibc/A8C2D23A1E6F95DA4E48BA349667E322BD7A6C996D8A4AAE8BA72E190F3D1477",
                "uosmo",
        ],
        SpreadFactor: cosmossdk.io/math.LegacyDec {
                i: *(*"math/big.Int")(0xc001648c20),},
        CosmWasmPoolModel: *github.com/osmosis-labs/sqs/sqsdomain.CosmWasmPoolModel nil,}
```