### PR TITLE
 bugfix: Fix /version endpoint and let it work in containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - [Dynamic Min Liquidity] new ingester methods for acquiring necessary metadata.
 - bugfix: PoolWrapper Validate panic
+- SQS: Fix /version endpoint and let it work in containers
 
 ## v0.19.1
 

--- a/system/delivery/http/system_http_handler.go
+++ b/system/delivery/http/system_http_handler.go
@@ -131,11 +131,9 @@ func extractVersion(ldGlagsValueStr string) (string, error) {
 	// Extract the substring after github.com/osmosis-labs/sqs/version=
 	substring := ldGlagsValueStr[index+len(versionPlaceholder):]
 
-	strings.Index(ldGlagsValueStr, " ")
-
 	index = strings.Index(substring, whiteSpacePlaceholder)
 	if index == -1 {
-		return "", fmt.Errorf("Failed to find end of version string")
+		return substring, nil
 	}
 
 	return substring[:index], nil

--- a/system/delivery/http/system_http_handler_test.go
+++ b/system/delivery/http/system_http_handler_test.go
@@ -8,14 +8,46 @@ import (
 )
 
 func TestExtractVersion(t *testing.T) {
-	const (
-		ldFlagsValue = "-X github.com/osmosis-labs/sqs/version=0.1.2-4-g79c82c8     -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'"
 
-		expectedVersion = "0.1.2-4-g79c82c8"
-	)
+	// Test cases
+	testCases := []struct {
+		name            string
+		ldFlagsValue    string
+		expectedVersion string
+	}{
+		{
+			name:         "version is specified first in the ldFlagsValue",
+			ldFlagsValue: "-X github.com/osmosis-labs/sqs/version=0.1.2-4-g79c82c8     -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'",
 
-	result, err := http.ExtractVersion(ldFlagsValue)
-	require.NoError(t, err)
+			expectedVersion: "0.1.2-4-g79c82c8",
+		},
+		{
+			name:         "version is specified in the end of ldFlagsValue",
+			ldFlagsValue: "-w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static' -X github.com/osmosis-labs/sqs/version=0.1.2-4-g79c82c8",
 
-	require.Equal(t, expectedVersion, result)
+			expectedVersion: "0.1.2-4-g79c82c8",
+		},
+		{
+			name:         "version is specified in the middle of ldFlagsValue",
+			ldFlagsValue: "-extldflags '-Wl,-z,muldefs -static' -X github.com/osmosis-labs/sqs/version=0.1.2-4-g79c82c8 -w -s -linkmode=external",
+
+			expectedVersion: "0.1.2-4-g79c82c8",
+		},
+		{
+			name:         "ldFlagsValue only version",
+			ldFlagsValue: "-X github.com/osmosis-labs/sqs/version=0.1.2-4-g79c82c8",
+
+			expectedVersion: "0.1.2-4-g79c82c8",
+		},
+	}
+
+	// Run tests
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := http.ExtractVersion(tc.ldFlagsValue)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expectedVersion, result)
+		})
+	}
 }


### PR DESCRIPTION
# General 

This PR fixes `/version` endpoind, for more information please see #141 

# Testing

- Added several test cases
- Tested in docker container:
```
docker run -p 9092:9092 -p 26657:26657 -v ~/go/src/github.com/deividaspetraitis/sqs/config-testnet.json:/osmosis/config.json --net host --rm -it --entrypoint /bin/sh osmolabs/sqs:0.19.1-14-g994c27f
```