### PR TITLE
feat: Add fault tolerance in candidate route conversion when pools are breaking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 - [SQS-Routing] API to force quote over a given route
+- Add fault tolerance in candidate route conversion when pools are breaking.
 
 ## v25.0.0
 


### PR DESCRIPTION
We had a production incident earlier where a migrated code ID and long candidate route caching led to this component bubbling up an error in a single route up top, completely failing client requests when alternatives were available.

Instead, we should be skipping the violating routes silently in such cases.

## Testing

Added a unit test