### PR TITLE
Alessandro/add commit sha integration test action

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.commit_sha || github.repository_default_branch }}
       
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,6 +11,10 @@ on:
           - stage
           - prod
         default: 'stage'
+      commit_sha:
+        description: 'Commit SHA (optional)'
+        required: false
+        default: ''
   schedule:
     - cron: '0 * * * *'
 

--- a/.github/workflows/push-dev-docker-images.yml
+++ b/.github/workflows/push-dev-docker-images.yml
@@ -70,7 +70,7 @@ jobs:
       if: ${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
       name: Send Webhook to deploy automatically to stage
       run: |
-        echo '{"sqsdockerversion":"${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}"}' > temp.json
+        echo '{"sqsdockerversion":"${{ env.DOCKER_REPOSITORY }}:${{ env.DOCKER_IMAGE_TAG }}", "commitsha":"${{ env.SHA }}"}' > temp.json
         jq -s '.[0] * .[1]' config.json temp.json > combined_config.json
         curl -H "Content-Type: application/json" -X POST -d @combined_config.json ${{ secrets.DEPLOY_URL }}
 


### PR DESCRIPTION
This PR introduces the following changes:

- Update to `.github/workflows/integration-test.yml`:

  - Added a new optional input `commit_sha` that has a default value an is optional.

- Update to `.github/workflows/push-dev-docker-images.yml`:
  - Modified the line that generates the `temp.json` file to include the `commitsha` field with the value of the commit id.
  
  This PR is to run automatically the Integration Test Suite after stage deploy