### PR TITLE
Hotfix for Alloyed pool swaps failing due to not having LP share in balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - [SQS-Routing] API to force quote over a given route
 - Add fault tolerance in candidate route conversion when pools are breaking.
+- Hotfix for Alloyed pool swaps failing due to not having LP share in balances. 
 
 ## v25.0.0
 

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -86,7 +86,12 @@ func GetCandidateRoutes(pools []sqsdomain.PoolI, tokenIn sdk.Coin, tokenOutDenom
 			if len(currentRoute) == 0 {
 				currentTokenInAmount := pool.SQSModel.Balances.AmountOf(currenTokenInDenom)
 
-				if currentTokenInAmount.LT(tokenIn.Amount) {
+				// HACK: alloyed LP share is not contained in balances.
+				// TODO: remove the hack and ingest the LP share balance on the Osmosis side.
+				// https://linear.app/osmosis/issue/DATA-236/bug-alloyed-lp-share-is-not-present-in-balances
+				isAlloyed := pool.SQSModel.CosmWasmPoolModel != nil && pool.SQSModel.CosmWasmPoolModel.IsAlloyTransmuter()
+
+				if currentTokenInAmount.LT(tokenIn.Amount) && !isAlloyed {
 					visited[i] = true
 					// Not enough tokenIn to swap.
 					continue


### PR DESCRIPTION
The alloyed LP share is not present in the balances, causing a routing bug below.

Longer term we should solve this by ingesting the LP share balance for the alloyed pool but this is a quick hot fix for now.

![image](https://github.com/osmosis-labs/sqs/assets/34196718/b6044f93-3b26-43fb-9148-18ee8c96bc27)
