### PR TITLE
fix: remove token in check in candidate route search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+- Remove token in check in candidate route search
+
 ## v25.1.1
 
 - Add fault tolerance in candidate route conversion when pools are breaking.

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -82,22 +82,6 @@ func GetCandidateRoutes(pools []sqsdomain.PoolI, tokenIn sdk.Coin, tokenOutDenom
 				continue
 			}
 
-			// Microptimization for the first pool in the route.
-			if len(currentRoute) == 0 {
-				currentTokenInAmount := pool.SQSModel.Balances.AmountOf(currenTokenInDenom)
-
-				// HACK: alloyed LP share is not contained in balances.
-				// TODO: remove the hack and ingest the LP share balance on the Osmosis side.
-				// https://linear.app/osmosis/issue/DATA-236/bug-alloyed-lp-share-is-not-present-in-balances
-				isAlloyed := pool.SQSModel.CosmWasmPoolModel != nil && pool.SQSModel.CosmWasmPoolModel.IsAlloyTransmuter()
-
-				if currentTokenInAmount.LT(tokenIn.Amount) && !isAlloyed {
-					visited[i] = true
-					// Not enough tokenIn to swap.
-					continue
-				}
-			}
-
 			currentPoolID := poolID
 			for _, denom := range poolDenoms {
 				if denom == currenTokenInDenom {


### PR DESCRIPTION
Discussed with @iboss-ptk 

This check is redundant and can be removed.