### PR TITLE
refactor/test/fix: liquidity pricer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+- Fix bug of overapplying quote denom scaling factor in pool liquidity pricer.
+
 ## v25.1.1
 
 - Add fault tolerance in candidate route conversion when pools are breaking.

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -148,14 +148,9 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 			return nil, err
 		}
 
-		defaultQuoteDenomScalingFactor, err := tokensUseCase.GetChainScalingFactorByDenomMut(defaultQuoteDenom)
-		if err != nil {
-			return nil, err
-		}
-
 		quotePriceUpdateWorker := pricingWorker.New(tokensUseCase, defaultQuoteDenom, config.Pricing.WorkerMinPoolLiquidityCap, logger)
 
-		liquidityPricer := pricingWorker.NewLiquidityPricer(defaultQuoteDenom, defaultQuoteDenomScalingFactor)
+		liquidityPricer := pricingWorker.NewLiquidityPricer(defaultQuoteDenom, tokensUseCase.GetChainScalingFactorByDenomMut)
 
 		poolLiquidityComputeWorker := pricingWorker.NewPoolLiquidityWorker(tokensUseCase, liquidityPricer)
 

--- a/domain/mocks/scaling_factor_getter_cb_mock.go
+++ b/domain/mocks/scaling_factor_getter_cb_mock.go
@@ -1,0 +1,38 @@
+package mocks
+
+import (
+	"fmt"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/domain"
+)
+
+// setupMockScalingFactorCb configures a mock scaling factor callback to return the given
+// scaling factor and error.
+// It also validates that mock receives valid parameters as given by validDenom.
+// If validation does not pass, an error is returned rather than the mocked values.
+func SetupMockScalingFactorCb(validDenom string, mockScalingFactor osmomath.Dec, mockError error) domain.ScalingFactorGetterCb {
+	return func(denom string) (osmomath.Dec, error) {
+		// Validate denom s equl to the one set on mock.
+		if validDenom != denom {
+			return osmomath.Dec{}, fmt.Errorf("actual  denom (%s) is not equal to the one configured by mock (%s)", denom, validDenom)
+		}
+
+		if mockScalingFactor.IsNil() {
+			return osmomath.Dec{}, fmt.Errorf("scaling factor is nil for denom (%s)", validDenom)
+		}
+
+		return mockScalingFactor, mockError
+	}
+}
+
+func SetupMockScalingFactorCbFromMap(scalingFactorMap map[string]osmomath.Dec) domain.ScalingFactorGetterCb {
+	return func(denom string) (osmomath.Dec, error) {
+		scalingFactor, ok := scalingFactorMap[denom]
+		if !ok {
+			return osmomath.Dec{}, fmt.Errorf("scaling factor for denom (%s) not found", denom)
+		}
+
+		return scalingFactor, nil
+	}
+}

--- a/ingest/usecase/ingest_usecase_test.go
+++ b/ingest/usecase/ingest_usecase_test.go
@@ -205,6 +205,17 @@ func (s *IngestUseCaseTestSuite) TestUpdateCurrentBlockLiquidityMapFromBalances(
 				},
 			},
 		},
+		{
+			name: "Invalid token in balance -> skipped",
+
+			blockLiqMap: domain.DenomPoolLiquidityMap{},
+
+			balances: sdk.Coins{sdk.Coin{Denom: "[[]invalid[]]", Amount: osmomath.OneInt()}},
+
+			poolID: defaultPoolID + 1,
+
+			expectedBlockLiqMap: domain.DenomPoolLiquidityMap{},
+		},
 	}
 
 	for _, tc := range tests {

--- a/tokens/usecase/pricing/worker/export_test.go
+++ b/tokens/usecase/pricing/worker/export_test.go
@@ -2,6 +2,12 @@ package worker
 
 type PoolLiquidityPricerWorker = poolLiquidityPricerWorker
 
+var LiquidityCapErrorSeparator = liquidityCapErrorSeparator
+
 func (p *poolLiquidityPricerWorker) HasLaterUpdateThanHeight(denom string, height uint64) bool {
 	return p.hasLaterUpdateThanHeight(denom, height)
+}
+
+func FormatLiquidityCapErrorStr(denom string) string {
+	return formatLiquidityCapErrorStr(denom)
 }

--- a/tokens/usecase/pricing/worker/liquidity_pricer_test.go
+++ b/tokens/usecase/pricing/worker/liquidity_pricer_test.go
@@ -8,12 +8,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/domain/mocks"
 	"github.com/osmosis-labs/sqs/tokens/usecase/pricing/worker"
 )
 
 var (
-	// 10^6
-	defaultQuoteDenomScalingFactor = osmomath.MustNewDecFromStr("1000000")
 
 	// eth scaling factor 10^18
 	ethScalingFactor = osmomath.MustNewDecFromStr("1000000000000000000")
@@ -32,6 +31,9 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap() {
 		defaultAmount       = osmomath.NewInt(10)
 		doubleDefaultAmount = defaultAmount.Add(defaultAmount)
 
+		defaultResult       = defaultAmount.ToLegacyDec().Quo(defaultScalingFactor)
+		doubleDefaultResult = defaultResult.MulInt64(2)
+
 		zeroAmount = osmomath.ZeroInt()
 	)
 
@@ -48,30 +50,30 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap() {
 			coinAmount: defaultAmount,
 			baseDenomPriceInfo: domain.DenomPriceInfo{
 				Price:         priceOne,
-				ScalingFactor: defaultQuoteDenomScalingFactor,
+				ScalingFactor: defaultScalingFactor,
 			},
 
-			expectedLiquidityCap: defaultAmount.ToLegacyDec(),
+			expectedLiquidityCap: defaultResult,
 		},
 		{
 			name:       "double default amount, price one, equal scaling factors",
 			coinAmount: doubleDefaultAmount,
 			baseDenomPriceInfo: domain.DenomPriceInfo{
 				Price:         priceOne,
-				ScalingFactor: defaultQuoteDenomScalingFactor,
+				ScalingFactor: defaultScalingFactor,
 			},
 
-			expectedLiquidityCap: doubleDefaultAmount.ToLegacyDec(),
+			expectedLiquidityCap: doubleDefaultResult,
 		},
 		{
 			name:       "default amount, price two, equal scaling factors",
 			coinAmount: defaultAmount,
 			baseDenomPriceInfo: domain.DenomPriceInfo{
 				Price:         priceTwo,
-				ScalingFactor: defaultQuoteDenomScalingFactor,
+				ScalingFactor: defaultScalingFactor,
 			},
 
-			expectedLiquidityCap: osmomath.NewDecFromInt(doubleDefaultAmount),
+			expectedLiquidityCap: doubleDefaultResult,
 		},
 		{
 			name:       "default amount, price two, base scaling factor > quote scaling factor",
@@ -81,7 +83,7 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap() {
 				ScalingFactor: ethScalingFactor,
 			},
 
-			expectedLiquidityCap: osmomath.NewDecFromInt(doubleDefaultAmount).Mul(defaultQuoteDenomScalingFactor).Quo(ethScalingFactor),
+			expectedLiquidityCap: defaultAmount.ToLegacyDec().Quo(ethScalingFactor).Mul(priceTwo.Dec()),
 		},
 		{
 			name:       "default amount, price two, base scaling factor < quote scaling factor",
@@ -91,11 +93,11 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap() {
 				ScalingFactor: oneScalingFactor,
 			},
 
-			expectedLiquidityCap: osmomath.NewDecFromInt(doubleDefaultAmount).Mul(defaultQuoteDenomScalingFactor).Quo(oneScalingFactor),
+			expectedLiquidityCap: defaultAmount.MulRaw(2).ToLegacyDec(),
 		},
 
 		{
-			name:       "zero amount, price one, equal scaling factors",
+			name:       "zero amount, price one, one scaling factor",
 			coinAmount: zeroAmount,
 			baseDenomPriceInfo: domain.DenomPriceInfo{
 				Price:         priceOne,
@@ -146,11 +148,8 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap() {
 		s.T().Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Liquidity pricer
-			liquidityPricer := worker.NewLiquidityPricer(USDC, defaultQuoteDenomScalingFactor)
-
 			// System under test
-			usdcLiquidity, err := liquidityPricer.ComputeCoinCap(sdk.NewCoin(UOSMO, tt.coinAmount), tt.baseDenomPriceInfo)
+			usdcLiquidity, err := worker.ComputeCoinCap(sdk.NewCoin(UOSMO, tt.coinAmount), tt.baseDenomPriceInfo)
 			if tt.expectedError {
 				s.Require().Error(err)
 				return
@@ -168,7 +167,7 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap() {
 // This test is skipped by default but is kept for ease of debugging in case we start
 // having edge cases failures for some denom pairs. In that case, we can quickly
 // run this test and debug.
-func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap_AllCoin() {
+func (s *PoolLiquidityComputeWorkerSuite) TestPriceCoin_AllCoin() {
 	s.T().Parallel()
 	s.T().Skip("skipping long-running test by default. To be used in cases where we need to identify breakages across all coins")
 
@@ -197,8 +196,6 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap_AllCoin() {
 
 	errors := make([]errorData, 0)
 
-	liquidityPricer := worker.NewLiquidityPricer(USDC, defaultQuoteDenomScalingFactor)
-
 	s.Require().NotZero(len(tokenMetadata))
 	for chainDenom, token := range tokenMetadata {
 		chainAmount := osmomath.NewDec(10).PowerMut(uint64(token.Precision + 1)).TruncateInt()
@@ -218,7 +215,7 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap_AllCoin() {
 		}
 
 		// System under test
-		usdcLiquidity, err := liquidityPricer.ComputeCoinCap(sdk.NewCoin(chainDenom, chainAmount), baseDenomPriceInfo)
+		usdcLiquidity, err := worker.ComputeCoinCap(sdk.NewCoin(chainDenom, chainAmount), baseDenomPriceInfo)
 
 		if err != nil {
 			errors = append(errors, errorData{
@@ -235,5 +232,208 @@ func (s *PoolLiquidityComputeWorkerSuite) TestComputeCoinCap_AllCoin() {
 	fmt.Printf("\n\nErrors:\n")
 	for _, err := range errors {
 		fmt.Printf("denom: %s, error: %s\n", err.humanDenom, err.err.Error())
+	}
+}
+
+// TestPriceCoin tests the TestPriceCoin method by following the spec.
+func (s *PoolLiquidityComputeWorkerSuite) TestPriceCoin() {
+	var (
+		ethScaledLiquidity = ethScalingFactor.MulInt(defaultLiquidity).TruncateInt()
+
+		defaultPriceOne = osmomath.OneBigDec()
+	)
+
+	tests := []struct {
+		name string
+
+		preSetScalingFactorDenom string
+		preSetScalingFactorValue osmomath.Dec
+
+		denom          string
+		totalLiquidity osmomath.Int
+		price          osmomath.BigDec
+
+		expectedCapitalization osmomath.Int
+	}{
+		{
+			name: "scaling factor unset",
+
+			denom:          UOSMO,
+			totalLiquidity: defaultLiquidity,
+			price:          defaultPriceOne,
+
+			expectedCapitalization: zeroCapitalization,
+		},
+		{
+			name: "zero price -> produces zero capitalization",
+
+			preSetScalingFactorDenom: UOSMO,
+			preSetScalingFactorValue: defaultScalingFactor,
+
+			denom:          UOSMO,
+			totalLiquidity: defaultLiquidity,
+			price:          osmomath.ZeroBigDec(),
+
+			expectedCapitalization: zeroCapitalization,
+		},
+		{
+			name: "truncate -> produces zero capitalization",
+
+			// totalLiquidity * price / (quoteScalingFactor / baseScalingFactor)
+			// 1 * 10^-36 / 10^18 => below the precision of 36
+			preSetScalingFactorDenom: UOSMO,
+			preSetScalingFactorValue: ethScalingFactor,
+
+			denom:          UOSMO,
+			totalLiquidity: osmomath.OneInt(),
+			price:          osmomath.SmallestBigDec(),
+
+			expectedCapitalization: zeroCapitalization,
+		},
+		{
+			name: "happy path",
+
+			preSetScalingFactorDenom: UOSMO,
+			preSetScalingFactorValue: defaultScalingFactor,
+
+			denom:          UOSMO,
+			totalLiquidity: defaultLiquidity,
+			price:          defaultPriceOne,
+
+			// 10^6 / 10^6 = 1
+			expectedCapitalization: osmomath.OneInt(),
+		},
+		{
+			name: "happy path with different inputs",
+
+			preSetScalingFactorDenom: ATOM,
+			preSetScalingFactorValue: ethScalingFactor,
+
+			denom:          ATOM,
+			totalLiquidity: ethScaledLiquidity.MulRaw(2),
+			price:          osmomath.NewBigDec(2),
+
+			expectedCapitalization: ethScaledLiquidity.ToLegacyDec().QuoMut(ethScalingFactor).TruncateInt().MulRaw(4),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		s.T().Run(tt.name, func(t *testing.T) {
+
+			scalingFactorGetterCbMock := mocks.SetupMockScalingFactorCb(tt.denom, tt.preSetScalingFactorValue, nil)
+
+			// Create liquidity pricer
+			liquidityPricer := worker.NewLiquidityPricer(USDC, scalingFactorGetterCbMock)
+
+			// System under test
+			liquidityCapitalization := liquidityPricer.PriceCoin(sdk.NewCoin(tt.denom, tt.totalLiquidity), tt.price)
+
+			// Check the result
+			s.Require().Equal(tt.expectedCapitalization.String(), liquidityCapitalization.String())
+		})
+	}
+}
+
+// TestPriceBalances tests the TestPriceBalances method by following the spec.
+func (s *PoolLiquidityComputeWorkerSuite) TestPriceBalances() {
+	const (
+		noErrorStr = ""
+	)
+
+	var (
+		defaultCoin = sdk.NewCoin(UOSMO, defaultLiquidity)
+		secondCoin  = sdk.NewCoin(ATOM, defaultLiquidity)
+	)
+
+	tests := []struct {
+		name string
+
+		preSetScalingFactorMap map[string]osmomath.Dec
+
+		balances sdk.Coins
+		prices   domain.PricesResult
+
+		expectedLiquidityCap osmomath.Int
+		errorStr             string
+	}{
+		{
+			name: "single coin happy path",
+
+			preSetScalingFactorMap: defaultScalingFactorMap,
+			balances:               sdk.NewCoins(defaultCoin),
+
+			prices: defaultBlockPriceUpdates,
+
+			expectedLiquidityCap: defaultLiquidityCap,
+			errorStr:             noErrorStr,
+		},
+		{
+			name: "single coin no price -> error set",
+
+			preSetScalingFactorMap: defaultScalingFactorMap,
+			balances:               sdk.NewCoins(defaultCoin),
+
+			prices: domain.PricesResult{},
+
+			expectedLiquidityCap: osmomath.ZeroInt(),
+			errorStr:             worker.FormatLiquidityCapErrorStr(UOSMO),
+		},
+		{
+			name: "two coin happy path",
+
+			preSetScalingFactorMap: defaultScalingFactorMap,
+			balances:               sdk.NewCoins(defaultCoin, secondCoin),
+
+			prices: defaultBlockPriceUpdates,
+
+			expectedLiquidityCap: defaultLiquidityCap.Add(defaultLiquidityCap),
+			errorStr:             noErrorStr,
+		},
+		{
+			name: "one of the coins no price -> another coin still contributes, error set",
+
+			preSetScalingFactorMap: defaultScalingFactorMap,
+			balances:               sdk.NewCoins(defaultCoin, secondCoin),
+
+			// Note: no price for ATOM
+			prices: domain.PricesResult{
+				UOSMO: {
+					USDC: defaultPrice,
+				},
+			},
+
+			expectedLiquidityCap: defaultLiquidityCap,
+			errorStr:             worker.FormatLiquidityCapErrorStr(ATOM),
+		},
+		{
+			name: "two coin both error",
+
+			preSetScalingFactorMap: defaultScalingFactorMap,
+			balances:               sdk.NewCoins(defaultCoin, secondCoin),
+
+			// Note: no prices for both tokens
+			prices: domain.PricesResult{},
+
+			expectedLiquidityCap: zeroCapitalization,
+			errorStr:             worker.FormatLiquidityCapErrorStr(ATOM) + worker.LiquidityCapErrorSeparator + worker.FormatLiquidityCapErrorStr(UOSMO),
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		s.T().Run("", func(t *testing.T) {
+
+			scalingFactorGetterMock := mocks.SetupMockScalingFactorCbFromMap(tc.preSetScalingFactorMap)
+
+			// Create liquidity pricer
+			liquidityPricer := worker.NewLiquidityPricer(USDC, scalingFactorGetterMock)
+
+			liquidityCap, errStr := liquidityPricer.PriceBalances(tc.balances, tc.prices)
+
+			s.Require().Equal(tc.expectedLiquidityCap.String(), liquidityCap.String())
+			s.Require().Equal(tc.errorStr, errStr)
+		})
 	}
 }

--- a/tokens/usecase/pricing/worker/liquidity_pricer_test.go
+++ b/tokens/usecase/pricing/worker/liquidity_pricer_test.go
@@ -385,7 +385,14 @@ func (s *PoolLiquidityComputeWorkerSuite) TestPriceBalances() {
 			preSetScalingFactorMap: defaultScalingFactorMap,
 			balances:               sdk.NewCoins(defaultCoin, secondCoin),
 
-			prices: defaultBlockPriceUpdates,
+			prices: domain.PricesResult{
+				UOSMO: {
+					USDC: defaultPrice,
+				},
+				ATOM: {
+					USDC: defaultPrice,
+				},
+			},
 
 			expectedLiquidityCap: defaultLiquidityCap.Add(defaultLiquidityCap),
 			errorStr:             noErrorStr,

--- a/tokens/usecase/pricing/worker/pool_liquidity_pricer_worket_test.go
+++ b/tokens/usecase/pricing/worker/pool_liquidity_pricer_worket_test.go
@@ -79,7 +79,7 @@ func TestPoolLiquidityComputeWorkerSuite(t *testing.T) {
 func (s *PoolLiquidityComputeWorkerSuite) TestOnPricingUpdate() {
 
 	// Create liquidity pricer
-	liquidityPricer := worker.NewLiquidityPricer(USDC, defaultQuoteDenomScalingFactor)
+	liquidityPricer := worker.NewLiquidityPricer(USDC, mocks.SetupMockScalingFactorCbFromMap(defaultScalingFactorMap))
 
 	// Set up the tokens pool liquidity mock handler
 	poolLiquidityHandlerMock := mocks.TokensPoolLiquidityHandlerMock{
@@ -119,7 +119,7 @@ func (s *PoolLiquidityComputeWorkerSuite) TestOnPricingUpdate() {
 	// Assert on specific values.
 	s.Require().Equal(result.Price, defaultPrice)
 	s.Require().Equal(result.TotalLiquidity, defaultLiquidity)
-	s.Require().Equal(result.TotalLiquidityCap, defaultLiquidityCap)
+	s.Require().Equal(result.TotalLiquidityCap.String(), defaultLiquidityCap.String())
 
 	// Validate that the listener mock was called with the relevant height.
 	lastHeightCalled := mockListener.GetLastHeightCalled()
@@ -235,117 +235,6 @@ func (s *PoolLiquidityComputeWorkerSuite) TestHasLaterUpdateThanHeight() {
 
 			// Check the result.
 			s.Require().Equal(tt.expected, actual)
-		})
-	}
-}
-
-// TestStoreHeightForDenom tests the StoreHeightForDenom method by following the spec.
-func (s *PoolLiquidityComputeWorkerSuite) TestComputeLiquidityCapitalization() {
-	var (
-		defaultScalingFactorMap = map[string]osmomath.Dec{
-			UOSMO: defaultScalingFactor,
-		}
-
-		defaultLiqidity = osmomath.NewInt(1_000_000)
-
-		ethScaledLiquidity = ethScalingFactor.MulInt(defaultLiqidity).TruncateInt()
-
-		defaultPriceOne = osmomath.OneBigDec()
-	)
-
-	tests := []struct {
-		name string
-
-		preSetScalingFactorMap map[string]osmomath.Dec
-
-		denom          string
-		totalLiquidity osmomath.Int
-		price          osmomath.BigDec
-
-		expectedCapitalization osmomath.Int
-	}{
-		{
-			name: "scaling factor unset",
-
-			preSetScalingFactorMap: map[string]osmomath.Dec{},
-
-			denom:          UOSMO,
-			totalLiquidity: defaultLiqidity,
-			price:          defaultPriceOne,
-
-			expectedCapitalization: zeroCapitalization,
-		},
-		{
-			name: "zero price -> produces zero capitalization",
-
-			preSetScalingFactorMap: defaultScalingFactorMap,
-
-			denom:          UOSMO,
-			totalLiquidity: defaultLiqidity,
-			price:          osmomath.ZeroBigDec(),
-
-			expectedCapitalization: zeroCapitalization,
-		},
-		{
-			name: "truncate -> produces zero capitalization",
-
-			// totalLiquidity * price / (quoteScalingFactor / baseScalingFactor)
-			// 1 * 10^-36 / 10^12 => below the precision of 36
-			preSetScalingFactorMap: map[string]osmomath.Dec{
-				UOSMO: ethScalingFactor,
-			},
-
-			denom:          UOSMO,
-			totalLiquidity: osmomath.OneInt(),
-			price:          osmomath.SmallestBigDec(),
-
-			expectedCapitalization: zeroCapitalization,
-		},
-		{
-			name: "happy path",
-
-			preSetScalingFactorMap: defaultScalingFactorMap,
-
-			denom:          UOSMO,
-			totalLiquidity: defaultLiqidity,
-			price:          defaultPriceOne,
-
-			expectedCapitalization: defaultLiqidity,
-		},
-		{
-			name: "happy path with different inputs",
-
-			preSetScalingFactorMap: map[string]osmomath.Dec{
-				ATOM: ethScalingFactor,
-			},
-
-			denom:          ATOM,
-			totalLiquidity: ethScaledLiquidity.MulRaw(2),
-			price:          osmomath.NewBigDec(2),
-
-			expectedCapitalization: ethScaledLiquidity.ToLegacyDec().MulMut(defaultScalingFactor).QuoMut(ethScalingFactor).TruncateInt().MulRaw(4),
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		s.T().Run(tt.name, func(t *testing.T) {
-			// Create liquidity pricer
-			liquidityPricer := worker.NewLiquidityPricer(USDC, defaultQuoteDenomScalingFactor)
-
-			// Set up the tokens pool liquidity mock handler
-			poolLiquidityHandlerMock := mocks.TokensPoolLiquidityHandlerMock{
-				DenomScalingFactorMap: tt.preSetScalingFactorMap,
-			}
-
-			// Create the worker
-			poolLiquidityPricerWorker := worker.NewPoolLiquidityWorker(&poolLiquidityHandlerMock, liquidityPricer)
-
-			// System under test
-			liquidityCapitalization := poolLiquidityPricerWorker.ComputeLiquidityCapitalization(tt.denom, tt.totalLiquidity, tt.price)
-
-			// Check the result
-			s.Require().Equal(tt.expectedCapitalization.String(), liquidityCapitalization.String())
 		})
 	}
 }
@@ -597,7 +486,7 @@ func (s *PoolLiquidityComputeWorkerSuite) TestRepriceDenomMetadata() {
 		s.T().Run(tt.name, func(t *testing.T) {
 
 			// Create liquidity pricer
-			liquidityPricer := worker.NewLiquidityPricer(USDC, defaultQuoteDenomScalingFactor)
+			liquidityPricer := worker.NewLiquidityPricer(USDC, mocks.SetupMockScalingFactorCbFromMap(defaultScalingFactorMap))
 
 			// Set up the tokens pool liquidity mock handler
 			poolLiquidityHandlerMock := mocks.TokensPoolLiquidityHandlerMock{

--- a/tokens/usecase/pricing/worker/pool_liquidity_pricer_worket_test.go
+++ b/tokens/usecase/pricing/worker/pool_liquidity_pricer_worket_test.go
@@ -37,7 +37,7 @@ var (
 	defaultPrice     = osmomath.NewBigDec(2)
 	defaultLiquidity = osmomath.NewInt(1_000_000)
 
-	defaultLiquidityCap = defaultLiquidity.MulRaw(2)
+	defaultLiquidityCap = defaultLiquidity.ToLegacyDec().Quo(defaultScalingFactor).MulMut(defaultPrice.Dec()).TruncateInt()
 
 	// Note: we are not testing the error handling of underlying methods.
 	// Those are unit-tested in their respective tests.


### PR DESCRIPTION
Refactor & progress towards pool liquidity capitalization/pricing

The core of the change focuses on creating better `PriceCoin` and `PriceBalances` APIs on the liquidity price and covering them with more tests.

Extracted from: https://github.com/osmosis-labs/sqs/pull/332 for ease of review.

As an outcome, identified and fixed an overapplying quote denom scaling factor bug in edge cases. It was unnoticed since this logic is not relied on in production yet.

Tested on the node