### PR TITLE
feat: Implement CandidateRouteSearchDataWorker

### DIFF
--- a/domain/mocks/pool_liquidity_pricing_update_listenet_mock.go
+++ b/domain/mocks/pool_liquidity_pricing_update_listenet_mock.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"time"
 
 	"github.com/osmosis-labs/sqs/domain"
@@ -8,19 +9,19 @@ import (
 
 type PoolLiquidityPricingMock struct {
 	// represents the last height this mock was called with.
-	lastHeightCalled int64
+	lastHeightCalled uint64
 }
 
 var _ domain.PoolLiquidityComputeListener = &PoolLiquidityPricingMock{}
 
 // OnPoolLiquidityCompute implements domain.PoolLiquidityComputeListener.
-func (p *PoolLiquidityPricingMock) OnPoolLiquidityCompute(height int64) error {
+func (p *PoolLiquidityPricingMock) OnPoolLiquidityCompute(ctx context.Context, height uint64, blockPoolMetaData domain.BlockPoolMetadata) error {
 	p.lastHeightCalled = height
 	return nil
 }
 
 // GetLastHeightCalled returns the last heigh when this mock was executed.
-func (p *PoolLiquidityPricingMock) GetLastHeightCalled() int64 {
+func (p *PoolLiquidityPricingMock) GetLastHeightCalled() uint64 {
 	return p.lastHeightCalled
 }
 

--- a/domain/mvc/chainInfo.go
+++ b/domain/mvc/chainInfo.go
@@ -22,4 +22,12 @@ type ChainInfoUsecase interface {
 	// - 50 heights have passed since the last update
 	// - The initial pool liquidity update has not been received
 	ValidatePoolLiquidityUpdates() error
+
+	// ValidateCandidateRouteSearchDataUpdates validates the candidate route search data updates
+	// Returns nil if the candidate route search data updates are valid
+	// Returns error otherwise.
+	// Candidate route search data updates can be invalid if:
+	// - 50 heights have passed since the last update
+	// - The initial candidate route search data update has not been received
+	ValidateCandidateRouteSearchDataUpdates() error
 }

--- a/domain/mvc/router.go
+++ b/domain/mvc/router.go
@@ -10,8 +10,19 @@ import (
 	"github.com/osmosis-labs/sqs/sqsdomain"
 )
 
+// CandidateRouteSearchDataUpdateListener is the interface for the candidate route search data holder.
+type CandidateRouteSearchDataHolder interface {
+	// SetCandidateRouteSearchData sets the candidate route search data on the holder
+	SetCandidateRouteSearchData(candidateRouteSearchData map[string][]sqsdomain.PoolI)
+
+	// GetCandidateRouteSearchData gets the candidate route search data from the holder
+	GetCandidateRouteSearchData() map[string][]sqsdomain.PoolI
+}
+
 // RouterUsecase represent the router's usecases
 type RouterUsecase interface {
+	CandidateRouteSearchDataHolder
+
 	// GetOptimalQuote returns the optimal quote for the given tokenIn and tokenOutDenom.
 	GetOptimalQuote(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, opts ...domain.RouterOption) (domain.Quote, error)
 	// GetCustomDirectQuote returns the custom direct quote for the given tokenIn, tokenOutDenom and poolID.

--- a/domain/pricing.go
+++ b/domain/pricing.go
@@ -205,7 +205,7 @@ type LiquidityPricer interface {
 // It is used to notify the listeners of the pool liquidity compute worker that the computation
 // for a given height is completed.
 type PoolLiquidityComputeListener interface {
-	OnPoolLiquidityCompute(height int64) error
+	OnPoolLiquidityCompute(ctx context.Context, height uint64, blockPoolMetaData BlockPoolMetadata) error
 }
 
 // PricesResult defines the result of the prices.

--- a/domain/router.go
+++ b/domain/router.go
@@ -190,3 +190,21 @@ func WithIsPricingWorkerPrecompute(isPricingWorkerPrecompute bool) RouterOption 
 		o.IsPricingWorkerPrecompute = isPricingWorkerPrecompute
 	}
 }
+
+// CandidateRouteSearchDataWorker defines the interface for the candidate route search data worker.
+// It pre-computes data necessary for efficiently computing candidate routes.
+type CandidateRouteSearchDataWorker interface {
+	// UpdatePrices updates prices for the tokens from the unique block pool metadata
+	// that contains information about changed denoms and pools within a block.
+	// Propagates the results to the listeners.
+	ComputeSearchData(ctx context.Context, height uint64, uniqueBlockPoolMetaData BlockPoolMetadata) error
+
+	// RegisterListener registers a listener for candidate route data updates.
+	RegisterListener(listener CandidateRouteSearchDataUpdateListener)
+}
+
+// PricingUpdateListener defines the interface for the candidate route search data listener.
+type CandidateRouteSearchDataUpdateListener interface {
+	// OnSearchDataUpdate notifies the listener of the candidate route data update.
+	OnSearchDataUpdate(ctx context.Context, height uint64) error
+}

--- a/router/usecase/worker/candidate_route_search_data_worker.go
+++ b/router/usecase/worker/candidate_route_search_data_worker.go
@@ -1,0 +1,65 @@
+package worker
+
+import (
+	"context"
+
+	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/domain/mvc"
+	"github.com/osmosis-labs/sqs/log"
+	"github.com/osmosis-labs/sqs/sqsdomain"
+)
+
+type candidateRouteSearchDataWorker struct {
+	listeners                []domain.CandidateRouteSearchDataUpdateListener
+	poolsHandler             mvc.PoolHandler
+	candidateRouteDataHolder mvc.CandidateRouteSearchDataHolder
+	logger                   log.Logger
+}
+
+var (
+	_ domain.CandidateRouteSearchDataWorker = &candidateRouteSearchDataWorker{}
+	_ domain.PoolLiquidityComputeListener   = &candidateRouteSearchDataWorker{}
+)
+
+func NewCandidateRouteSearchDataWorker(poolHandler mvc.PoolHandler, candidateRouteDataHolder mvc.CandidateRouteSearchDataHolder, logger log.Logger) *candidateRouteSearchDataWorker {
+	return &candidateRouteSearchDataWorker{
+		listeners:                []domain.CandidateRouteSearchDataUpdateListener{},
+		poolsHandler:             poolHandler,
+		candidateRouteDataHolder: candidateRouteDataHolder,
+		logger:                   logger,
+	}
+}
+
+// OnPoolLiquidityCompute implements domain.PoolLiquidityComputeListener.
+func (c *candidateRouteSearchDataWorker) OnPoolLiquidityCompute(ctx context.Context, height uint64, blockPoolMetaData domain.BlockPoolMetadata) error {
+
+	// Compute search data and propagate error up the chain to fail the health check.
+	if err := c.ComputeSearchData(ctx, height, blockPoolMetaData); err != nil {
+		return err
+	}
+
+	// Notify listeners
+	for _, listener := range c.listeners {
+		_ = listener.OnSearchDataUpdate(ctx, height)
+	}
+
+	return nil
+}
+
+// ComputeSearchData implements domain.CandidateRouteSearchDataWorker.
+func (c *candidateRouteSearchDataWorker) ComputeSearchData(ctx context.Context, height uint64, blockPoolMetaData domain.BlockPoolMetadata) error {
+
+	// TODO: implement
+	// https://linear.app/osmosis/issue/DATA-248/[candidaterouteopt]-implement-and-test-core-pre-computation-logic
+
+	candidateRouteData := map[string][]sqsdomain.PoolI{}
+
+	c.candidateRouteDataHolder.SetCandidateRouteSearchData(candidateRouteData)
+
+	return nil
+}
+
+// RegisterListener implements domain.CandidateRouteSearchDataWorker.
+func (c *candidateRouteSearchDataWorker) RegisterListener(listener domain.CandidateRouteSearchDataUpdateListener) {
+	c.listeners = append(c.listeners, listener)
+}

--- a/router/usecase/worker/candidate_route_search_data_worker.go
+++ b/router/usecase/worker/candidate_route_search_data_worker.go
@@ -32,7 +32,6 @@ func NewCandidateRouteSearchDataWorker(poolHandler mvc.PoolHandler, candidateRou
 
 // OnPoolLiquidityCompute implements domain.PoolLiquidityComputeListener.
 func (c *candidateRouteSearchDataWorker) OnPoolLiquidityCompute(ctx context.Context, height uint64, blockPoolMetaData domain.BlockPoolMetadata) error {
-
 	// Compute search data and propagate error up the chain to fail the health check.
 	if err := c.ComputeSearchData(ctx, height, blockPoolMetaData); err != nil {
 		return err
@@ -48,7 +47,6 @@ func (c *candidateRouteSearchDataWorker) OnPoolLiquidityCompute(ctx context.Cont
 
 // ComputeSearchData implements domain.CandidateRouteSearchDataWorker.
 func (c *candidateRouteSearchDataWorker) ComputeSearchData(ctx context.Context, height uint64, blockPoolMetaData domain.BlockPoolMetadata) error {
-
 	// TODO: implement
 	// https://linear.app/osmosis/issue/DATA-248/[candidaterouteopt]-implement-and-test-core-pre-computation-logic
 

--- a/system/delivery/http/system_http_handler.go
+++ b/system/delivery/http/system_http_handler.go
@@ -202,6 +202,11 @@ func (h *SystemHandler) GetHealthStatus(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, err.Error())
 	}
 
+	// Validate candidate route search data updates
+	if err := h.CIUsecase.ValidateCandidateRouteSearchDataUpdates(); err != nil {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, err.Error())
+	}
+
 	// Return combined status
 	return c.JSON(http.StatusOK, map[string]string{
 		"grpc_gateway_status": "running",

--- a/tokens/usecase/pricing/worker/pool_liquidity_pricer_worker.go
+++ b/tokens/usecase/pricing/worker/pool_liquidity_pricer_worker.go
@@ -94,7 +94,7 @@ func (p *poolLiquidityPricerWorker) OnPricingUpdate(ctx context.Context, height 
 	// Notify listeners.
 	for _, listener := range p.updateListeners {
 		// Avoid checking error since we want to execute all listeners.
-		_ = listener.OnPoolLiquidityCompute(int64(height))
+		_ = listener.OnPoolLiquidityCompute(ctx, height, blockPoolMetadata)
 	}
 
 	return nil

--- a/tokens/usecase/pricing/worker/pool_liquidity_pricer_worket_test.go
+++ b/tokens/usecase/pricing/worker/pool_liquidity_pricer_worket_test.go
@@ -163,7 +163,7 @@ func (s *PoolLiquidityComputeWorkerSuite) TestOnPricingUpdate() {
 
 	// Validate that the listener mock was called with the relevant height.
 	lastHeightCalled := mockListener.GetLastHeightCalled()
-	s.Require().Equal(int64(defaultHeight), lastHeightCalled)
+	s.Require().Equal(defaultHeight, lastHeightCalled)
 
 	// Validate that the pool liquidity handler mock was called with the relevant pool IDs.
 	s.validateLiquidityCapPools(map[uint64]liquidityResult{

--- a/tokens/usecase/pricing/worker/pricing_worker_test.go
+++ b/tokens/usecase/pricing/worker/pricing_worker_test.go
@@ -21,7 +21,7 @@ type PricingWorkerTestSuite struct {
 }
 
 const (
-	defaultHeight = 1
+	defaultHeight uint64 = 1
 )
 
 var (


### PR DESCRIPTION
Docs: https://github.com/osmosis-labs/sqs/pull/355

Task: https://linear.app/osmosis/issue/DATA-247/[candidaterouteopt]-implement-candidateroutesearchdataworker

- implements barebones candidate route search data worker
- wires it up in the worker/listener pipeline
- wires it up to healthcheck
- wires it up to router use case to persist the pre-computed data for routing