### PR TITLE
refactor/test: append allUST to pool denoms and remove gamm share

### DIFF
--- a/domain/pricing.go
+++ b/domain/pricing.go
@@ -51,8 +51,6 @@ type PricingOptions struct {
 	RecomputePricesIsSpotPriceComputeMethod bool
 	// MinPoolLiquidityCap defines the minimum liquidity required to consider a pool for pricing.
 	MinPoolLiquidityCap uint64
-	// IsWorkerPrecomputePricing defines whether the pricing is precomputed by the worker.
-	IsWorkerPrecomputePricing bool
 }
 
 // PricingOption configures the pricing options.
@@ -80,13 +78,6 @@ func WithRecomputePricesQuoteBasedMethod() PricingOption {
 func WithMinPricingPoolLiquidityCap(minPoolLiquidityCap uint64) PricingOption {
 	return func(o *PricingOptions) {
 		o.MinPoolLiquidityCap = minPoolLiquidityCap
-	}
-}
-
-// WithIsWorkerPrecomputePricing configures the pricing options to be used for worker precompute.
-func WithIsWorkerPrecomputePricing() PricingOption {
-	return func(o *PricingOptions) {
-		o.IsWorkerPrecomputePricing = true
 	}
 }
 

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -40,3 +40,6 @@ type DenomPoolLiquidityData struct {
 	// in that pool
 	Pools map[uint64]osmomath.Int
 }
+
+// GAMMSharePrefix is the prefix for the GAMM share
+const GAMMSharePrefix = "gamm/pool"

--- a/ingest/usecase/export_test.go
+++ b/ingest/usecase/export_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/sqsdomain"
 )
 
 type (
@@ -15,4 +16,8 @@ func UpdateCurrentBlockLiquidityMapFromBalances(currentBlockLiquidityMap domain.
 
 func TransferDenomLiquidityMap(transferTo, transferFrom domain.DenomPoolLiquidityMap) domain.DenomPoolLiquidityMap {
 	return transferDenomLiquidityMap(transferTo, transferFrom)
+}
+
+func ProcessSQSModelMut(sqsModel *sqsdomain.SQSPool) error {
+	return processSQSModelMut(sqsModel)
 }

--- a/ingest/usecase/ingest_usecase_test.go
+++ b/ingest/usecase/ingest_usecase_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/ingest/usecase"
 	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
+	"github.com/osmosis-labs/sqs/sqsdomain"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -360,6 +362,138 @@ func (s *IngestUseCaseTestSuite) TestTransferDenomLiquidityMap() {
 
 			// Validation
 			s.Require().Equal(tc.expectedResult, result)
+		})
+	}
+}
+
+func (s *IngestUseCaseTestSuite) TestProcessSQSModelMut() {
+
+	var (
+		defaultModel = &sqsdomain.SQSPool{
+			PoolLiquidityCap:      osmomath.NewInt(1_000),
+			PoolLiquidityCapError: "",
+			Balances:              sdk.NewCoins(defaultUOSMOBalance, defaultUSDCBalance),
+			PoolDenoms:            []string{UOSMO, USDC},
+			SpreadFactor:          osmomath.NewDec(1),
+			CosmWasmPoolModel:     nil,
+		}
+
+		deepCopy = func(sqsPool *sqsdomain.SQSPool) *sqsdomain.SQSPool {
+			copy := *sqsPool
+
+			copy.PoolLiquidityCap = sqsPool.PoolLiquidityCap.ToLegacyDec().TruncateInt()
+			copy.PoolLiquidityCapError = sqsPool.PoolLiquidityCapError
+			copy.Balances = sdk.NewCoins(sqsPool.Balances...)
+			copy.PoolDenoms = append([]string(nil), sqsPool.PoolDenoms...)
+			copy.SpreadFactor = sqsPool.SpreadFactor.Clone()
+
+			// Not a deep copy because it is irrelevant for this test.
+			copy.CosmWasmPoolModel = sqsPool.CosmWasmPoolModel
+
+			return &copy
+		}
+
+		defaultCosmWasmModel = &cosmwasmpool.CosmWasmPoolModel{
+			ContractInfo: cosmwasmpool.ContractInfo{
+				Contract: cosmwasmpool.ALLOY_TRANSMUTER_CONTRACT_NAME,
+				Version:  cosmwasmpool.ALLOY_TRANSMUTER_MIN_CONTRACT_VERSION,
+			},
+			Data: cosmwasmpool.CosmWasmPoolData{
+				AlloyTransmuter: &cosmwasmpool.AlloyTransmuterData{
+					AlloyedDenom: routertesting.ALLUSDT,
+				},
+			},
+		}
+
+		invalidCosmWasmModel = &cosmwasmpool.CosmWasmPoolModel{
+			ContractInfo: cosmwasmpool.ContractInfo{
+				Contract: cosmwasmpool.ALLOY_TRANSMUTER_CONTRACT_NAME,
+				Version:  cosmwasmpool.ALLOY_TRANSMUTER_MIN_CONTRACT_VERSION,
+			},
+
+			// Note: data is missing
+		}
+
+		withCosmWasmModel = func(sqsPool *sqsdomain.SQSPool, cosmWasmModel *cosmwasmpool.CosmWasmPoolModel) *sqsdomain.SQSPool {
+			sqsPool = deepCopy(sqsPool)
+			sqsPool.CosmWasmPoolModel = cosmWasmModel
+			return sqsPool
+		}
+
+		withPoolDenoms = func(sqsPool *sqsdomain.SQSPool, denoms ...string) *sqsdomain.SQSPool {
+			sqsPool = deepCopy(sqsPool)
+			sqsPool.PoolDenoms = denoms
+			return sqsPool
+		}
+
+		withBalances = func(sqsPool *sqsdomain.SQSPool, balances sdk.Coins) *sqsdomain.SQSPool {
+			sqsPool = deepCopy(sqsPool)
+			sqsPool.Balances = balances
+			return sqsPool
+		}
+
+		modelWithCWModelSet = withCosmWasmModel(defaultModel, defaultCosmWasmModel)
+	)
+
+	tests := []struct {
+		name string
+
+		sqsModel *sqsdomain.SQSPool
+
+		expectedSQSModel *sqsdomain.SQSPool
+		expectedErr      bool
+	}{
+		{
+			name: "non-cosmwaspool model -> unchanged",
+
+			sqsModel: defaultModel,
+
+			expectedSQSModel: defaultModel,
+		},
+		{
+			name: "with gamm share in balance -> filtered",
+
+			sqsModel: withBalances(defaultModel, sdk.NewCoins(sdk.NewCoin(domain.GAMMSharePrefix, osmomath.OneInt())).Add(defaultModel.Balances...)),
+
+			expectedSQSModel: defaultModel,
+		},
+		{
+			name: "with gamm share in pool denoms -> filtered",
+
+			// Note: append wrangling is done to avoid mutation of defaultModel.
+			sqsModel: withPoolDenoms(defaultModel, append([]string{domain.GAMMSharePrefix}, defaultModel.PoolDenoms...)...),
+
+			expectedSQSModel: defaultModel,
+		},
+		{
+			name: "alloyed cosmwasm model -> added to pool denoms",
+
+			sqsModel: modelWithCWModelSet,
+
+			// Note: append wrangling is done to avoid mutation of defaultModel.
+			expectedSQSModel: withPoolDenoms(modelWithCWModelSet, append(append([]string{}, defaultModel.PoolDenoms...), routertesting.ALLUSDT)...),
+		},
+		{
+			name: "cosmwasm model not correctly set -> error",
+
+			sqsModel: withCosmWasmModel(defaultModel, invalidCosmWasmModel),
+
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		s.T().Run(tc.name, func(t *testing.T) {
+			// System under test
+			err := usecase.ProcessSQSModelMut(tc.sqsModel)
+
+			if tc.expectedErr {
+				s.Require().Error(err)
+			} else {
+				s.Require().NoError(err)
+				s.Require().Equal(tc.expectedSQSModel, tc.sqsModel)
+			}
 		})
 	}
 }

--- a/tokens/usecase/pricing/chain/pricing_chain.go
+++ b/tokens/usecase/pricing/chain/pricing_chain.go
@@ -110,7 +110,6 @@ func (c *chainPricing) GetPrice(ctx context.Context, baseDenom string, quoteDeno
 		MinPoolLiquidityCap:                     c.minPoolLiquidityCap,
 		RecomputePricesIsSpotPriceComputeMethod: defaultIsSpotPriceComputeMethod,
 		RecomputePrices:                         false,
-		IsWorkerPrecomputePricing:               false,
 	}
 
 	for _, opt := range opts {
@@ -120,7 +119,7 @@ func (c *chainPricing) GetPrice(ctx context.Context, baseDenom string, quoteDeno
 	// Recompute prices if desired by configuration.
 	// Otherwise, look into cache first.
 	if options.RecomputePrices {
-		return c.computePrice(ctx, baseDenom, quoteDenom, options.MinPoolLiquidityCap, options.RecomputePricesIsSpotPriceComputeMethod, options.IsWorkerPrecomputePricing)
+		return c.computePrice(ctx, baseDenom, quoteDenom, options.MinPoolLiquidityCap, options.RecomputePricesIsSpotPriceComputeMethod)
 	}
 
 	// equal base and quote yield the price of one
@@ -147,11 +146,11 @@ func (c *chainPricing) GetPrice(ctx context.Context, baseDenom string, quoteDeno
 	}
 
 	// If cache miss occurs, we compute the price.
-	return c.computePrice(ctx, baseDenom, quoteDenom, options.MinPoolLiquidityCap, options.RecomputePricesIsSpotPriceComputeMethod, options.IsWorkerPrecomputePricing)
+	return c.computePrice(ctx, baseDenom, quoteDenom, options.MinPoolLiquidityCap, options.RecomputePricesIsSpotPriceComputeMethod)
 }
 
 // computePrice computes the price for a given base and quote denom
-func (c *chainPricing) computePrice(ctx context.Context, baseDenom string, quoteDenom string, minPoolLiquidityCap uint64, isSpotPriceComputeMethod, isPricingWorkerPrecompute bool) (osmomath.BigDec, error) {
+func (c *chainPricing) computePrice(ctx context.Context, baseDenom string, quoteDenom string, minPoolLiquidityCap uint64, isSpotPriceComputeMethod bool) (osmomath.BigDec, error) {
 	cacheKey := domain.FormatPricingCacheKey(baseDenom, quoteDenom)
 
 	if baseDenom == quoteDenom {

--- a/tokens/usecase/pricing/worker/pricing_worker.go
+++ b/tokens/usecase/pricing/worker/pricing_worker.go
@@ -58,7 +58,7 @@ func (p *pricingWorker) updatePrices(height uint64, uniqueBlockPoolMetaData doma
 	// Note that we recompute prices entirely.
 	// Min osmo liquidity must be zero. The reason is that some pools have TVL incorrectly calculated as zero.
 	// For example, BRNCH / STRDST (1288). As a result, they are incorrectly excluded despite having appropriate liquidity.
-	prices, err := p.tokensUseCase.GetPrices(ctx, baseDenoms, []string{p.quoteDenom}, domain.ChainPricingSourceType, domain.WithRecomputePrices(), domain.WithMinPricingPoolLiquidityCap(p.minLiquidityCap), domain.WithIsWorkerPrecomputePricing())
+	prices, err := p.tokensUseCase.GetPrices(ctx, baseDenoms, []string{p.quoteDenom}, domain.ChainPricingSourceType, domain.WithRecomputePrices(), domain.WithMinPricingPoolLiquidityCap(p.minLiquidityCap))
 	if err != nil {
 		p.logger.Error("failed to pre-compute prices", zap.Error(err))
 


### PR DESCRIPTION
Some clean ups to pool balances:
- removing gamm shares from denoms and balances (cause failures in route search downstream)
- adding alloyed denom to pool denoms. This is helpful in route search downstream

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functionality for processing SQS model mutations, enhancing the system's capability to handle updated data models.

- **Bug Fixes**
	- Updated various components to ensure compatibility with new SQS model processing functions.

- **Refactor**
	- Removed the `IsWorkerPrecomputePricing` field and related function across multiple files, streamlining the pricing structure and improving code maintainability.

- **Tests**
	- Added comprehensive test cases to validate the processing of SQS models with various configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->