### PR TITLE
Canonical orderbook API

### DIFF
--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -122,7 +122,7 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 	}
 
 	// Initialize pools repository, usecase and HTTP handler
-	poolsUseCase := poolsUseCase.NewPoolsUsecase(config.Pools, config.ChainGRPCGatewayEndpoint, routerRepository, tokensUseCase.GetChainScalingFactorByDenomMut)
+	poolsUseCase := poolsUseCase.NewPoolsUsecase(config.Pools, config.ChainGRPCGatewayEndpoint, routerRepository, tokensUseCase.GetChainScalingFactorByDenomMut, logger)
 
 	// Initialize candidate route searcher
 	candidateRouteSearcher := routerUseCase.NewCandidateRouteFinder(routerRepository, logger)

--- a/docs/architecture/introduction.md
+++ b/docs/architecture/introduction.md
@@ -11,6 +11,8 @@ to group the code by separate "Functional Components" .
 
 This is a component that deals with liqudiity pools and their operations.
 
+See [docs/architecture/pools.md](docs/architecture/pools.md) for more details.
+
 ### Router Usecase
 
 This is the routing & quoting component.

--- a/docs/architecture/introduction.md
+++ b/docs/architecture/introduction.md
@@ -11,7 +11,7 @@ to group the code by separate "Functional Components" .
 
 This is a component that deals with liqudiity pools and their operations.
 
-See [docs/architecture/pools.md](docs/architecture/pools.md) for more details.
+See [docs/architecture/pools.md](https://github.com/osmosis-labs/sqs/blob/v25.x/docs/architecture/pools.md) for more details.
 
 ### Router Usecase
 

--- a/docs/architecture/pools.md
+++ b/docs/architecture/pools.md
@@ -1,0 +1,11 @@
+# Pools
+
+## Canonical Orderbooks
+
+The pools use case provides functionality for identifying the canonical orderbook pools among all orderbook-type pools.
+
+The canonical orderbook is defined as the orderbook with the highest liquidity for a given token pair.
+
+During the ingestion process, as the system stores pools, it processes the orderbook pools to determine the canonical orderbook for each token pair.
+
+The system then exposes an API that allows querying the canonical orderbook for a specific token pair as well as retrieving all canonical orderbooks for all token pairs.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -77,7 +77,7 @@ const docTemplate = `{
         },
         "/pools/canonical-orderbooks": {
             "get": {
-                "description": "Returns the list of canonical orderbook pool ID entries for the given base and quote.",
+                "description": "Returns the list of canonical orderbook pool ID entries for all possible base and quote combinations.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -75,6 +75,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/pools/canonical-orderbooks": {
+            "get": {
+                "description": "Returns the list of canonical orderbook pool ID entries for the given base and quote.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Get entries for all supported orderbook base and quote denoms.",
+                "responses": {
+                    "200": {
+                        "description": "List of canonical orderbook ool ID entries for all base and quotes",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.CanonicalOrderBooksResult"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/router/custom-direct-quote": {
             "get": {
                 "description": "Call does not search for the route rather directly computes the quote for the given poolID.",
@@ -322,6 +342,20 @@ const docTemplate = `{
         }
     },
     "definitions": {
+        "domain.CanonicalOrderBooksResult": {
+            "type": "object",
+            "properties": {
+                "base": {
+                    "type": "string"
+                },
+                "pool_id": {
+                    "type": "integer"
+                },
+                "quote": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Token": {
             "type": "object",
             "properties": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -42,6 +42,39 @@ const docTemplate = `{
                 }
             }
         },
+        "/pools/canonical-orderbook": {
+            "get": {
+                "description": "Returns the canonical orderbook pool ID for the given base and quote.\nif the pool ID is not found for the given pair, it returns an error.\nif the base or quote denom are not provided, it returns an error.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Get canonical orderbook pool ID for the given base and quote.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Base denom",
+                        "name": "base",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Quote denom",
+                        "name": "quote",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Canonical Orderbook Pool ID for the given base and quote",
+                        "schema": {
+                            "type": "uint64"
+                        }
+                    }
+                }
+            }
+        },
         "/router/custom-direct-quote": {
             "get": {
                 "description": "Call does not search for the route rather directly computes the quote for the given poolID.",
@@ -294,10 +327,6 @@ const docTemplate = `{
             "properties": {
                 "coingeckoId": {
                     "type": "string"
-                },
-                "is_unlisted": {
-                    "description": "IsUnlisted is true if the token is unlisted.",
-                    "type": "boolean"
                 },
                 "decimals": {
                     "description": "Precision is the precision of the token.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -68,7 +68,7 @@
         },
         "/pools/canonical-orderbooks": {
             "get": {
-                "description": "Returns the list of canonical orderbook pool ID entries for the given base and quote.",
+                "description": "Returns the list of canonical orderbook pool ID entries for all possible base and quote combinations.",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -66,6 +66,26 @@
                 }
             }
         },
+        "/pools/canonical-orderbooks": {
+            "get": {
+                "description": "Returns the list of canonical orderbook pool ID entries for the given base and quote.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Get entries for all supported orderbook base and quote denoms.",
+                "responses": {
+                    "200": {
+                        "description": "List of canonical orderbook ool ID entries for all base and quotes",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.CanonicalOrderBooksResult"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/router/custom-direct-quote": {
             "get": {
                 "description": "Call does not search for the route rather directly computes the quote for the given poolID.",
@@ -313,6 +333,20 @@
         }
     },
     "definitions": {
+        "domain.CanonicalOrderBooksResult": {
+            "type": "object",
+            "properties": {
+                "base": {
+                    "type": "string"
+                },
+                "pool_id": {
+                    "type": "integer"
+                },
+                "quote": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Token": {
             "type": "object",
             "properties": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -33,6 +33,39 @@
                 }
             }
         },
+        "/pools/canonical-orderbook": {
+            "get": {
+                "description": "Returns the canonical orderbook pool ID for the given base and quote.\nif the pool ID is not found for the given pair, it returns an error.\nif the base or quote denom are not provided, it returns an error.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Get canonical orderbook pool ID for the given base and quote.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Base denom",
+                        "name": "base",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Quote denom",
+                        "name": "quote",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Canonical Orderbook Pool ID for the given base and quote",
+                        "schema": {
+                            "type": "uint64"
+                        }
+                    }
+                }
+            }
+        },
         "/router/custom-direct-quote": {
             "get": {
                 "description": "Call does not search for the route rather directly computes the quote for the given poolID.",
@@ -285,10 +318,6 @@
             "properties": {
                 "coingeckoId": {
                     "type": "string"
-                },
-                "is_unlisted": {
-                    "description": "IsUnlisted is true if the token is unlisted.",
-                    "type": "boolean"
                 },
                 "decimals": {
                     "description": "Precision is the precision of the token.",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,4 +1,13 @@
 definitions:
+  domain.CanonicalOrderBooksResult:
+    properties:
+      base:
+        type: string
+      pool_id:
+        type: integer
+      quote:
+        type: string
+    type: object
   domain.Token:
     properties:
       coingeckoId:
@@ -88,6 +97,21 @@ paths:
           schema:
             type: uint64
       summary: Get canonical orderbook pool ID for the given base and quote.
+  /pools/canonical-orderbooks:
+    get:
+      description: Returns the list of canonical orderbook pool ID entries for the
+        given base and quote.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of canonical orderbook ool ID entries for all base and
+            quotes
+          schema:
+            items:
+              $ref: '#/definitions/domain.CanonicalOrderBooksResult'
+            type: array
+      summary: Get entries for all supported orderbook base and quote denoms.
   /router/custom-direct-quote:
     get:
       description: Call does not search for the route rather directly computes the

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,9 +3,6 @@ definitions:
     properties:
       coingeckoId:
         type: string
-      is_unlisted:
-        description: IsUnlisted is true if the token is unlisted.
-        type: boolean
       decimals:
         description: Precision is the precision of the token.
         type: integer
@@ -66,6 +63,31 @@ paths:
             items: {}
             type: array
       summary: Get pool(s) information
+  /pools/canonical-orderbook:
+    get:
+      description: |-
+        Returns the canonical orderbook pool ID for the given base and quote.
+        if the pool ID is not found for the given pair, it returns an error.
+        if the base or quote denom are not provided, it returns an error.
+      parameters:
+      - description: Base denom
+        in: query
+        name: base
+        required: true
+        type: string
+      - description: Quote denom
+        in: query
+        name: quote
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Canonical Orderbook Pool ID for the given base and quote
+          schema:
+            type: uint64
+      summary: Get canonical orderbook pool ID for the given base and quote.
   /router/custom-direct-quote:
     get:
       description: Call does not search for the route rather directly computes the

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -99,8 +99,8 @@ paths:
       summary: Get canonical orderbook pool ID for the given base and quote.
   /pools/canonical-orderbooks:
     get:
-      description: Returns the list of canonical orderbook pool ID entries for the
-        given base and quote.
+      description: Returns the list of canonical orderbook pool ID entries for all
+        possible base and quote combinations.
       produces:
       - application/json
       responses:

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -290,3 +290,11 @@ type PriceNotFoundForPoolLiquidityCapError struct {
 func (e PriceNotFoundForPoolLiquidityCapError) Error() string {
 	return fmt.Sprintf("price not found (zero) for denom %s", e.Denom)
 }
+
+type FailCastCanonicalOrderbookEntryError struct {
+	BaseQuoteKey string
+}
+
+func (e FailCastCanonicalOrderbookEntryError) Error() string {
+	return fmt.Sprintf("failed to cast orderbook entry for key (%s)", e.BaseQuoteKey)
+}

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -298,3 +298,19 @@ type FailCastCanonicalOrderbookEntryError struct {
 func (e FailCastCanonicalOrderbookEntryError) Error() string {
 	return fmt.Sprintf("failed to cast orderbook entry for key (%s)", e.BaseQuoteKey)
 }
+
+type FailSplitCanonicalOrderBookKeyError struct {
+	BaseQuoteKey string
+}
+
+func (e FailSplitCanonicalOrderBookKeyError) Error() string {
+	return fmt.Sprintf("failed to split base and quote denom from key %s", e.BaseQuoteKey)
+}
+
+type FailCastCanonicalOrderbookKeyError struct {
+	BaseQuoteKey string
+}
+
+func (e FailCastCanonicalOrderbookKeyError) Error() string {
+	return fmt.Sprintf("failed to cast key with value %v, expected string", e.BaseQuoteKey)
+}

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -30,6 +30,11 @@ type PoolsUsecaseMock struct {
 	TickModelMap map[uint64]*sqsdomain.TickModel
 }
 
+// GetCanonicalOrdrbookPoolID implements mvc.PoolsUsecase.
+func (pm *PoolsUsecaseMock) GetCanonicalOrdrbookPoolID(baseDenom string, quoteDenom string) (uint64, error) {
+	panic("unimplemented")
+}
+
 // StorePools implements mvc.PoolsUsecase.
 func (pm *PoolsUsecaseMock) StorePools(pools []sqsdomain.PoolI) error {
 	if pm.StorePoolsFunc != nil {

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -30,6 +30,16 @@ type PoolsUsecaseMock struct {
 	TickModelMap map[uint64]*sqsdomain.TickModel
 }
 
+// GetAllCanonicalOrderbookPoolIDs implements mvc.PoolsUsecase.
+func (pm *PoolsUsecaseMock) GetAllCanonicalOrderbookPoolIDs() ([]domain.CanonicalOrderBooksResult, error) {
+	panic("unimplemented")
+}
+
+// GetCanonicalOrderbookPoolID implements mvc.PoolsUsecase.
+func (pm *PoolsUsecaseMock) GetCanonicalOrderbookPoolID(baseDenom string, quoteDenom string) (uint64, error) {
+	panic("unimplemented")
+}
+
 // GetCanonicalOrdrbookPoolID implements mvc.PoolsUsecase.
 func (pm *PoolsUsecaseMock) GetCanonicalOrdrbookPoolID(baseDenom string, quoteDenom string) (uint64, error) {
 	panic("unimplemented")

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -40,11 +40,6 @@ func (pm *PoolsUsecaseMock) GetCanonicalOrderbookPoolID(baseDenom string, quoteD
 	panic("unimplemented")
 }
 
-// GetCanonicalOrdrbookPoolID implements mvc.PoolsUsecase.
-func (pm *PoolsUsecaseMock) GetCanonicalOrdrbookPoolID(baseDenom string, quoteDenom string) (uint64, error) {
-	panic("unimplemented")
-}
-
 // StorePools implements mvc.PoolsUsecase.
 func (pm *PoolsUsecaseMock) StorePools(pools []sqsdomain.PoolI) error {
 	if pm.StorePoolsFunc != nil {

--- a/domain/mvc/pools.go
+++ b/domain/mvc/pools.go
@@ -27,6 +27,8 @@ type PoolsUsecase interface {
 	GetPoolSpotPrice(ctx context.Context, poolID uint64, takerFee osmomath.Dec, quoteAsset, baseAsset string) (osmomath.BigDec, error)
 
 	GetCosmWasmPoolConfig() domain.CosmWasmPoolRouterConfig
+
+	GetCanonicalOrdrbookPoolID(baseDenom, quoteDenom string) (uint64, error)
 }
 
 type PoolHandler interface {

--- a/domain/mvc/pools.go
+++ b/domain/mvc/pools.go
@@ -34,6 +34,7 @@ type PoolsUsecase interface {
 
 	// GetAllCanonicalOrderbookPoolIDs returns all the canonical orderbook results
 	// where each base/quote denom is associated with a default pool ID.
+	// Sorts the results by pool ID.
 	GetAllCanonicalOrderbookPoolIDs() ([]domain.CanonicalOrderBooksResult, error)
 }
 

--- a/domain/mvc/pools.go
+++ b/domain/mvc/pools.go
@@ -28,7 +28,13 @@ type PoolsUsecase interface {
 
 	GetCosmWasmPoolConfig() domain.CosmWasmPoolRouterConfig
 
-	GetCanonicalOrdrbookPoolID(baseDenom, quoteDenom string) (uint64, error)
+	// GetCanonicalOrderbookPoolID returns the canonical orderbook pool ID for the given base and quote denoms.
+	// Returns error if the pool ID is not found for the given pair.
+	GetCanonicalOrderbookPoolID(baseDenom, quoteDenom string) (uint64, error)
+
+	// GetAllCanonicalOrderbookPoolIDs returns all the canonical orderbook results
+	// where each base/quote denom is associated with a default pool ID.
+	GetAllCanonicalOrderbookPoolIDs() ([]domain.CanonicalOrderBooksResult, error)
 }
 
 type PoolHandler interface {

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -58,3 +58,10 @@ var UnsetScalingFactorGetterCb ScalingFactorGetterCb = func(denom string) (osmom
 	// getter callback (defined on the tokens use case)
 	panic("scaling factor getter cb is unset")
 }
+
+// CanonicalOrderBooksResult is a structure for serializing canonical orderbook result returned to clients.
+type CanonicalOrderBooksResult struct {
+	Base   string `json:"base"`
+	Quote  string `json:"quote"`
+	PoolID uint64 `json:"pool_id"`
+}

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -52,8 +52,8 @@ func NewPoolsHandler(e *echo.Echo, us mvc.PoolsUsecase) {
 	}
 
 	e.GET(formatPoolsResource("/ticks/:id"), handler.GetConcentratedPoolTicks)
-	e.GET(formatPoolsResource("/canonical-orderbook"), handler.GetCanonicalOrderbooks)
-	e.GET(formatPoolsResource("/canonical-orderbooks"), handler.GetCanonicalOrderbooks)
+	e.GET(formatPoolsResource("/canonical-orderbook"), handler.GetCanonicalOrderbook)
+	e.GET(formatPoolsResource("/all-canonical-orderbooks"), handler.GetCanonicalOrderbooks)
 	e.GET(formatPoolsResource(""), handler.GetPools)
 }
 

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -140,7 +140,6 @@ func getStatusCode(err error) int {
 }
 
 func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
-
 	base := c.QueryParam("base")
 	quote := c.QueryParam("quote")
 	if base == "" || quote == "" {
@@ -156,7 +155,6 @@ func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 }
 
 func (a *PoolsHandler) GetCanonicalOrderbooks(c echo.Context) error {
-
 	orderbookData, err := a.PUsecase.GetAllCanonicalOrderbookPoolIDs()
 	if err != nil {
 		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -53,7 +53,7 @@ func NewPoolsHandler(e *echo.Echo, us mvc.PoolsUsecase) {
 
 	e.GET(formatPoolsResource("/ticks/:id"), handler.GetConcentratedPoolTicks)
 	e.GET(formatPoolsResource("/canonical-orderbook"), handler.GetCanonicalOrderbook)
-	e.GET(formatPoolsResource("/all-canonical-orderbooks"), handler.GetCanonicalOrderbooks)
+	e.GET(formatPoolsResource("/canonical-orderbooks"), handler.GetCanonicalOrderbooks)
 	e.GET(formatPoolsResource(""), handler.GetPools)
 }
 

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"fmt"
 	"net/http"
 	"strconv"
 
@@ -139,11 +138,24 @@ func getStatusCode(err error) int {
 	}
 }
 
+// @Summary Get canonical orderbook pool ID for the given base and quote.
+// @Description Returns the canonical orderbook pool ID for the given base and quote.
+// @Description if the pool ID is not found for the given pair, it returns an error.
+// @Description if the base or quote denom are not provided, it returns an error.
+// @Produce  json
+// @Param  base  query  string  true  "Base denom"
+// @Param  quote  query  string  true  "Quote denom"
+// @Success 200  uint64  "Canonical Orderbook Pool ID for the given base and quote"
+// @Router /pools/canonical-orderbook [get]
 func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 	base := c.QueryParam("base")
+	if base == "" {
+		return c.JSON(http.StatusBadRequest, ResponseError{Message: "base must be provided"})
+	}
+
 	quote := c.QueryParam("quote")
-	if base == "" || quote == "" {
-		return c.JSON(http.StatusBadRequest, ResponseError{Message: fmt.Sprintf("either both base and quote must be provided or none, had base (%s), quote (%s)", base, quote)})
+	if quote == "" {
+		return c.JSON(http.StatusBadRequest, ResponseError{Message: "quote must be provided"})
 	}
 
 	poolID, err := a.PUsecase.GetCanonicalOrderbookPoolID(base, quote)

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -166,6 +166,11 @@ func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 	return c.JSON(http.StatusOK, poolID)
 }
 
+// @Summary Get entries for all supported orderbook base and quote denoms.
+// @Description Returns the list of canonical orderbook pool ID entries for the given base and quote.
+// @Produce  json
+// @Success 200  {array}  domain.CanonicalOrderBooksResult  "List of canonical orderbook ool ID entries for all base and quotes"
+// @Router /pools/canonical-orderbooks [get]
 func (a *PoolsHandler) GetCanonicalOrderbooks(c echo.Context) error {
 	orderbookData, err := a.PUsecase.GetAllCanonicalOrderbookPoolIDs()
 	if err != nil {

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -136,6 +136,26 @@ func getStatusCode(err error) int {
 	}
 }
 
+func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
+
+	base := c.Param("base")
+	if base == "" {
+		return c.JSON(http.StatusBadRequest, ResponseError{Message: "base asset is required"})
+	}
+
+	quote := c.Param("quote")
+	if quote == "" {
+		return c.JSON(http.StatusBadRequest, ResponseError{Message: "quote asset is required"})
+	}
+
+	poolID, err := a.PUsecase.GetCanonicalOrdrbookPoolID(base, quote)
+	if err != nil {
+		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, poolID)
+}
+
 // convertPoolToResponse convertes a given pool to the appropriate response type.
 func convertPoolToResponse(pool sqsdomain.PoolI) PoolResponse {
 	return PoolResponse{

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -52,6 +52,7 @@ func NewPoolsHandler(e *echo.Echo, us mvc.PoolsUsecase) {
 	}
 
 	e.GET(formatPoolsResource("/ticks/:id"), handler.GetConcentratedPoolTicks)
+	e.GET(formatPoolsResource("/canonical-orderbook"), handler.GetCanonicalOrderbook)
 	e.GET(formatPoolsResource(""), handler.GetPools)
 }
 

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -139,12 +139,12 @@ func getStatusCode(err error) int {
 
 func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 
-	base := c.Param("base")
+	base := c.QueryParam("base")
 	if base == "" {
 		return c.JSON(http.StatusBadRequest, ResponseError{Message: "base asset is required"})
 	}
 
-	quote := c.Param("quote")
+	quote := c.QueryParam("quote")
 	if quote == "" {
 		return c.JSON(http.StatusBadRequest, ResponseError{Message: "quote asset is required"})
 	}

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -167,7 +167,7 @@ func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 }
 
 // @Summary Get entries for all supported orderbook base and quote denoms.
-// @Description Returns the list of canonical orderbook pool ID entries for the given base and quote.
+// @Description Returns the list of canonical orderbook pool ID entries for all possible base and quote combinations.
 // @Produce  json
 // @Success 200  {array}  domain.CanonicalOrderBooksResult  "List of canonical orderbook ool ID entries for all base and quotes"
 // @Router /pools/canonical-orderbooks [get]

--- a/pools/usecase/export_test.go
+++ b/pools/usecase/export_test.go
@@ -1,7 +1,25 @@
 package usecase
 
-import "github.com/osmosis-labs/osmosis/osmomath"
+import (
+	"github.com/osmosis-labs/osmosis/osmomath"
+)
+
+type OrderBookEntry = orderBookEntry
 
 func (p *poolsUseCase) ProcessOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom string, poolID uint64, poolLiquidityCapitalization osmomath.Int) (updatedBool bool, err error) {
 	return p.processOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom, poolID, poolLiquidityCapitalization)
+}
+
+// WARNING: this method is only meant for setting up tests. Do not move out of exporte_test.go
+func (p *poolsUseCase) StoreValidOrdeBookEntry(baseDenom, quoteDenom string, poolID uint64, poolLiquidityCapitalization osmomath.Int) {
+	p.canonicalOrderBookForBaseQuoteDenom.Store(formatBaseQuoteDenom(baseDenom, quoteDenom), orderBookEntry{
+		PoolID:       poolID,
+		LiquidityCap: poolLiquidityCapitalization,
+	})
+}
+
+// WARNING: this method is only meant for setting up tests. Do not move out of exporte_test.go
+func (p *poolsUseCase) StoreInvalidOrdeBookEntry(baseDenom, quoteDenom string) {
+	const invalidEntryType = 1
+	p.canonicalOrderBookForBaseQuoteDenom.Store(formatBaseQuoteDenom(baseDenom, quoteDenom), invalidEntryType)
 }

--- a/pools/usecase/export_test.go
+++ b/pools/usecase/export_test.go
@@ -13,7 +13,7 @@ func (p *poolsUseCase) ProcessOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom 
 	return p.processOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom, poolID, poolLiquidityCapitalization)
 }
 
-// WARNING: this method is only meant for setting up tests. Do not move out of exporte_test.go
+// WARNING: this method is only meant for setting up tests. Do not move out of export_test.go
 func (p *poolsUseCase) StoreValidOrdeBookEntry(baseDenom, quoteDenom string, poolID uint64, poolLiquidityCapitalization osmomath.Int) {
 	p.canonicalOrderBookForBaseQuoteDenom.Store(formatBaseQuoteDenom(baseDenom, quoteDenom), orderBookEntry{
 		PoolID:       poolID,
@@ -21,7 +21,7 @@ func (p *poolsUseCase) StoreValidOrdeBookEntry(baseDenom, quoteDenom string, poo
 	})
 }
 
-// WARNING: this method is only meant for setting up tests. Do not move out of exporte_test.go
+// WARNING: this method is only meant for setting up tests. Do not move out of export_test.go
 func (p *poolsUseCase) StoreInvalidOrdeBookEntry(baseDenom, quoteDenom string) {
 	const invalidEntryType = 1
 	p.canonicalOrderBookForBaseQuoteDenom.Store(formatBaseQuoteDenom(baseDenom, quoteDenom), invalidEntryType)

--- a/pools/usecase/export_test.go
+++ b/pools/usecase/export_test.go
@@ -4,7 +4,10 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
-type OrderBookEntry = orderBookEntry
+type (
+	OrderBookEntry = orderBookEntry
+	PoolsUsecase   = poolsUseCase
+)
 
 func (p *poolsUseCase) ProcessOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom string, poolID uint64, poolLiquidityCapitalization osmomath.Int) (updatedBool bool, err error) {
 	return p.processOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom, poolID, poolLiquidityCapitalization)

--- a/pools/usecase/export_test.go
+++ b/pools/usecase/export_test.go
@@ -22,7 +22,7 @@ func (p *poolsUseCase) StoreValidOrdeBookEntry(baseDenom, quoteDenom string, poo
 }
 
 // WARNING: this method is only meant for setting up tests. Do not move out of export_test.go
-func (p *poolsUseCase) StoreInvalidOrdeBookEntry(baseDenom, quoteDenom string) {
+func (p *poolsUseCase) StoreInvalidOrderBookEntry(baseDenom, quoteDenom string) {
 	const invalidEntryType = 1
 	p.canonicalOrderBookForBaseQuoteDenom.Store(formatBaseQuoteDenom(baseDenom, quoteDenom), invalidEntryType)
 }

--- a/pools/usecase/export_test.go
+++ b/pools/usecase/export_test.go
@@ -1,0 +1,7 @@
+package usecase
+
+import "github.com/osmosis-labs/osmosis/osmomath"
+
+func (p *poolsUseCase) ProcessOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom string, poolID uint64, poolLiquidityCapitalization osmomath.Int) (updatedBool bool, err error) {
+	return p.processOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom, poolID, poolLiquidityCapitalization)
+}

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -351,6 +351,7 @@ func (p *poolsUseCase) processOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom 
 	return true, nil
 }
 
+// GetCanonicalOrderbookPoolID implements mvc.PoolsUsecase.
 func (p *poolsUseCase) GetCanonicalOrderbookPoolID(baseDenom, quoteDenom string) (uint64, error) {
 	baseQuote := formatBaseQuoteDenom(baseDenom, quoteDenom)
 	topLiquidityOrderBook, found := p.canonicalOrderBookForBaseQuoteDenom.Load(baseQuote)
@@ -368,7 +369,6 @@ func (p *poolsUseCase) GetCanonicalOrderbookPoolID(baseDenom, quoteDenom string)
 
 // GetAllCanonicalOrderbookPoolIDs implements mvc.PoolsUsecase.
 func (p *poolsUseCase) GetAllCanonicalOrderbookPoolIDs() ([]domain.CanonicalOrderBooksResult, error) {
-
 	var (
 		results []domain.CanonicalOrderBooksResult
 		err     error

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -197,7 +197,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 			routerRepo.SetTakerFees(tc.takerFeeMap)
 
 			// Create pools use case
-			poolsUsecase := usecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepo, domain.UnsetScalingFactorGetterCb)
+			poolsUsecase := usecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepo, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
 
 			poolsUsecase.StorePools(tc.pools)
 

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -371,6 +371,11 @@ func (s *PoolsUsecaseTestSuite) TestStorePools() {
 
 		invalidBaseDenom = denomThree
 
+		defaultOrderbookContractInfo = cosmwasmpool.ContractInfo{
+			Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+			Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+		}
+
 		validOrderBookPool = &mocks.MockRoutablePool{
 			ChainPoolModel: &mocks.ChainPoolMock{
 				ID:   defaultPoolID + 1,
@@ -378,10 +383,7 @@ func (s *PoolsUsecaseTestSuite) TestStorePools() {
 			},
 			ID: defaultPoolID + 1,
 			CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
-				ContractInfo: cosmwasmpool.ContractInfo{
-					Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
-					Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
-				},
+				ContractInfo: defaultOrderbookContractInfo,
 
 				Data: cosmwasmpool.CosmWasmPoolData{
 					Orderbook: &cosmwasmpool.OrderbookData{
@@ -399,10 +401,7 @@ func (s *PoolsUsecaseTestSuite) TestStorePools() {
 			},
 			ID: defaultPoolID + 2,
 			CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
-				ContractInfo: cosmwasmpool.ContractInfo{
-					Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
-					Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
-				},
+				ContractInfo: defaultOrderbookContractInfo,
 
 				Data: cosmwasmpool.CosmWasmPoolData{
 					Orderbook: &cosmwasmpool.OrderbookData{

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -42,7 +42,7 @@ var (
 	defaultAmt0 = routertesting.DefaultAmt0
 	defaultAmt1 = routertesting.DefaultAmt1
 
-	defaultPoolLiduidityCap = osmomath.NewInt(100)
+	defaultPoolLiquidityCap = osmomath.NewInt(100)
 )
 
 func TestPoolsUsecaseTestSuite(t *testing.T) {
@@ -257,7 +257,7 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 		expectedError   bool
 		expectedUpdated bool
 
-		expctedCanonicalOrderbookPoolID uint64
+		expectedCanonicalOrderbookPoolID uint64
 	}{
 		{
 			name:  "valid entry - no pre set",
@@ -265,10 +265,10 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 			quote: denomTwo,
 
 			poolID:                      defaultPoolID,
-			poolLiquidityCapitalization: defaultPoolLiduidityCap,
+			poolLiquidityCapitalization: defaultPoolLiquidityCap,
 
-			expectedUpdated:                 true,
-			expctedCanonicalOrderbookPoolID: defaultPoolID,
+			expectedUpdated:                  true,
+			expectedCanonicalOrderbookPoolID: defaultPoolID,
 		},
 		{
 			name:  "valid entry - pre set with smaller cap -> overriden",
@@ -276,12 +276,12 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 			quote: denomTwo,
 
 			poolID:                      defaultPoolID,
-			poolLiquidityCapitalization: defaultPoolLiduidityCap,
+			poolLiquidityCapitalization: defaultPoolLiquidityCap,
 
-			preStoreValidEntryCap: defaultPoolLiduidityCap.Sub(osmomath.OneInt()),
+			preStoreValidEntryCap: defaultPoolLiquidityCap.Sub(osmomath.OneInt()),
 
-			expectedUpdated:                 true,
-			expctedCanonicalOrderbookPoolID: defaultPoolID,
+			expectedUpdated:                  true,
+			expectedCanonicalOrderbookPoolID: defaultPoolID,
 		},
 		{
 			name:  "valid entry - pre set with larger cap -> not overriden",
@@ -289,12 +289,12 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 			quote: denomTwo,
 
 			poolID:                      defaultPoolID,
-			poolLiquidityCapitalization: defaultPoolLiduidityCap,
+			poolLiquidityCapitalization: defaultPoolLiquidityCap,
 
-			preStoreValidEntryCap: defaultPoolLiduidityCap.Add(osmomath.OneInt()),
+			preStoreValidEntryCap: defaultPoolLiquidityCap.Add(osmomath.OneInt()),
 
-			expectedUpdated:                 false,
-			expctedCanonicalOrderbookPoolID: differentPoolID,
+			expectedUpdated:                  false,
+			expectedCanonicalOrderbookPoolID: differentPoolID,
 		},
 		{
 			name:  "invalid entry - pre set with larger cap -> not overriden",
@@ -302,7 +302,7 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 			quote: denomTwo,
 
 			poolID:                      defaultPoolID,
-			poolLiquidityCapitalization: defaultPoolLiduidityCap,
+			poolLiquidityCapitalization: defaultPoolLiquidityCap,
 
 			preStoreInvalidEntry: true,
 
@@ -318,7 +318,7 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 
 			// Pre-set invalid data for the base/quote
 			if tc.preStoreInvalidEntry {
-				poolsUsecase.StoreInvalidOrdeBookEntry(tc.base, tc.quote)
+				poolsUsecase.StoreInvalidOrderBookEntry(tc.base, tc.quote)
 			}
 
 			// Pre-set valid data for the base/quote
@@ -342,7 +342,7 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 			canonicalPoolID, err := poolsUsecase.GetCanonicalOrderbookPoolID(tc.base, tc.quote)
 			s.Require().NoError(err)
 
-			s.Require().Equal(tc.expctedCanonicalOrderbookPoolID, canonicalPoolID)
+			s.Require().Equal(tc.expectedCanonicalOrderbookPoolID, canonicalPoolID)
 		})
 	}
 }
@@ -422,7 +422,7 @@ func (s *PoolsUsecaseTestSuite) TestStorePools() {
 	poolsUsecase := newDefaultPoolsUseCase()
 
 	// Pre-set invalid data for the base/quote
-	poolsUsecase.StoreInvalidOrdeBookEntry(invalidBaseDenom, orderBookQuoteDenom)
+	poolsUsecase.StoreInvalidOrderBookEntry(invalidBaseDenom, orderBookQuoteDenom)
 
 	// System under test
 	poolsUsecase.StorePools(validPools)
@@ -458,10 +458,10 @@ func (s *PoolsUsecaseTestSuite) TestGetAllCanonicalOrderbookPoolIDs_HappyPath() 
 	poolsUseCase := newDefaultPoolsUseCase()
 
 	// Denom one and denom two
-	poolsUseCase.StoreValidOrdeBookEntry(denomOne, denomTwo, defaultPoolID, defaultPoolLiduidityCap)
+	poolsUseCase.StoreValidOrdeBookEntry(denomOne, denomTwo, defaultPoolID, defaultPoolLiquidityCap)
 
 	// Denom three and denom four
-	poolsUseCase.StoreValidOrdeBookEntry(denomThree, denomFour, defaultPoolID+1, defaultPoolLiduidityCap.Add(osmomath.OneInt()))
+	poolsUseCase.StoreValidOrdeBookEntry(denomThree, denomFour, defaultPoolID+1, defaultPoolLiquidityCap.Add(osmomath.OneInt()))
 
 	expectedCanonicalOrderbookPoolIDs := []domain.CanonicalOrderBooksResult{
 		{

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -451,6 +451,44 @@ func (s *PoolsUsecaseTestSuite) TestStorePools() {
 	s.Require().Error(err)
 }
 
+// This test validates that the canonical orderbook pool IDs are returned as intended
+// if they are correctly set. The correctness of setting them is ensured
+// by the StorePools and ProcessOrderbookPoolIDForBaseQuote tests.
+func (s *PoolsUsecaseTestSuite) TestGetAllCanonicalOrderbookPoolIDs_HappyPath() {
+
+	poolsUseCase := newDefaultPoolsUseCase()
+
+	// Denom one and denom two
+	poolsUseCase.StoreValidOrdeBookEntry(denomOne, denomTwo, defaultPoolID, defaultPoolLiduidityCap)
+
+	// Denom three and denom four
+	poolsUseCase.StoreValidOrdeBookEntry(denomThree, denomFour, defaultPoolID+1, defaultPoolLiduidityCap.Add(osmomath.OneInt()))
+
+	expectedCanonicalOrderbookPoolIDs := []domain.CanonicalOrderBooksResult{
+		{
+			Base:   denomOne,
+			Quote:  denomTwo,
+			PoolID: defaultPoolID,
+		},
+		{
+			Base:   denomThree,
+			Quote:  denomFour,
+			PoolID: defaultPoolID + 1,
+		},
+	}
+
+	// System under test
+	canonicalOrderbookPoolIDs, err := poolsUseCase.GetAllCanonicalOrderbookPoolIDs()
+	s.Require().NoError(err)
+
+	// Validate that the correct number of canonical orderbook pool IDs are returned
+	s.Require().Equal(len(canonicalOrderbookPoolIDs), 2)
+
+	// Validate that the correct canonical orderbook pool IDs are returned
+	s.Require().Equal(expectedCanonicalOrderbookPoolIDs, canonicalOrderbookPoolIDs)
+
+}
+
 func (s *PoolsUsecaseTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolIDs domain.CosmWasmPoolRouterConfig) domain.RoutablePool {
 	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolIDs, domain.UnsetScalingFactorGetterCb)
 	s.Require().NoError(err)

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -314,8 +314,7 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 		tc := tc
 		s.Run(tc.name, func() {
 
-			routerRepo := routerrepo.New(&log.NoOpLogger{})
-			poolsUsecase := usecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepo, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+			poolsUsecase := newDefaultPoolsUseCase()
 
 			// Pre-set invalid data for the base/quote
 			if tc.preStoreInvalidEntry {
@@ -421,8 +420,7 @@ func (s *PoolsUsecaseTestSuite) TestStorePools() {
 		}
 	)
 
-	routerRepo := routerrepo.New(&log.NoOpLogger{})
-	poolsUsecase := usecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepo, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+	poolsUsecase := newDefaultPoolsUseCase()
 
 	// Pre-set invalid data for the base/quote
 	poolsUsecase.StoreInvalidOrdeBookEntry(invalidBaseDenom, orderBookQuoteDenom)
@@ -457,4 +455,10 @@ func (s *PoolsUsecaseTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDe
 	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolIDs, domain.UnsetScalingFactorGetterCb)
 	s.Require().NoError(err)
 	return routablePool
+}
+
+func newDefaultPoolsUseCase() *usecase.PoolsUsecase {
+	routerRepo := routerrepo.New(&log.NoOpLogger{})
+	poolsUsecase := usecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepo, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+	return poolsUsecase
 }

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -688,7 +688,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuote_Mainnet_UOSMOU
 	tokensRepositoryMock.SetTakerFees(mainnetState.TakerFeeMap)
 
 	// Setup pools usecase mock.
-	poolsUsecase := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", tokensRepositoryMock, domain.UnsetScalingFactorGetterCb)
+	poolsUsecase := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", tokensRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
 	poolsUsecase.StorePools(mainnetState.Pools)
 
 	tokenMetaDataHolderMock := &mocks.TokenMetadataHolderMock{}

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -969,7 +969,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuotes_Mainnet_UOSMO
 	routerRepositoryMock.SetTakerFees(mainnetState.TakerFeeMap)
 
 	// Setup pools usecase mock.
-	poolsUsecase := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepositoryMock, domain.UnsetScalingFactorGetterCb)
+	poolsUsecase := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
 	poolsUsecase.StorePools(mainnetState.Pools)
 
 	tokenMetaDataHolder := mocks.TokenMetadataHolderMock{}

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -387,7 +387,7 @@ func (s *RouterTestHelper) SetupRouterAndPoolsUsecase(mainnetState MockMainnetSt
 	routerRepositoryMock.SetCandidateRouteSearchData(mainnetState.CandidateRouteSearchData)
 
 	// Setup pools usecase mock.
-	poolsUsecase := poolsusecase.NewPoolsUsecase(&options.PoolsConfig, "node-uri-placeholder", routerRepositoryMock, domain.UnsetScalingFactorGetterCb)
+	poolsUsecase := poolsusecase.NewPoolsUsecase(&options.PoolsConfig, "node-uri-placeholder", routerRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
 	err = poolsUsecase.StorePools(mainnetState.Pools)
 	s.Require().NoError(err)
 

--- a/tests/sqs_service.py
+++ b/tests/sqs_service.py
@@ -11,6 +11,7 @@ TOKENS_METADATA_URL = "/tokens/metadata"
 TOKENS_PRICES_URL = "/tokens/prices"
 
 POOLS_URL = "/pools"
+CANONICAL_ORDERBOOKS_URL = "/pools/canonical-orderbooks"
 
 CONFIG_URL = "/config"
 
@@ -140,3 +141,15 @@ class SQSService:
                 self.asset_list[asset[coin_minimal_denom_key]] = asset.get(coingecko_id_key, None)
 
         return self.asset_list.get(denom, None)
+
+    def get_canonical_orderbooks(self):
+        """
+        Fetches the canonical orderbooks from the specified endpoint and returns them.
+        Raises error if non-200 is returned from the endpoint.
+        """
+        response = requests.get(self.url + CANONICAL_ORDERBOOKS_URL, headers=self.headers)
+
+        if response.status_code != 200:
+            raise Exception(f"Error fetching canonical orderbooks: {response.text}")
+
+        return response.json()

--- a/tests/test_pools.py
+++ b/tests/test_pools.py
@@ -66,3 +66,29 @@ class TestPools:
             assert actual_error < error_tolerance, f"ID ({pool_id}) Pool liquidity cap was {sqs_liquidity_cap} - expected {pool_liquidity}, actual error {actual_error} error tolerance {error_tolerance}" 
         else:
             pytest.skip("Pool liquidity is too low - skipping to reduce flakiness")
+
+    def test_canonical_orderbook(self, environment_url):
+        # Note, that this is the first orderbook created on mainnet. As a result, it is the canonical orderbook.
+        # If more orederbooks are added in the future and liquidity changes, this might have to be refactored.
+        expected_orderbook_pool_id = 1904
+        base = "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc"
+        quote = "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+
+        sqs_service = SERVICE_MAP[environment_url]
+        canonical_orderbooks = sqs_service.get_canonical_orderbooks()
+
+        assert canonical_orderbooks is not None, "Canonical orderbooks are None"
+        assert len(canonical_orderbooks) > 0, "Canonical orderbooks are empty"
+
+        didFind = False
+
+        for orderbook in canonical_orderbooks:
+            if orderbook.get("pool_id") == expected_orderbook_pool_id:
+                assert orderbook.get("base") == base, "Base asset is not correct"
+                assert orderbook.get("quote") == quote, "Quote asset is not correct"
+
+                didFind = True
+                return
+
+        # This may fail as we keep adding more orderbooks. If it does, we need to refactor this test.
+        assert didFind, "Expected canonical orderbook was not found"


### PR DESCRIPTION
https://linear.app/osmosis/issue/DATA-273/expose-endpoint-for-canonical-orderbook-pools

## Background

This PR implements the new canonical orderbook API.

The pools use case provides functionality for identifying the canonical orderbook pools among all orderbook-type pools.

The canonical orderbook is defined as the orderbook with the highest liquidity for a given token pair.

During the ingestion process, as the system stores pools, it processes the orderbook pools to determine the canonical orderbook for each token pair.

The system then exposes an API that allows querying the canonical orderbook for a specific token pair as well as retrieving all canonical orderbooks for all token pairs.

## Testing

- Added unit tests
- Added integration test
- Tested with swagger against mainnet state

### Test Against Mainnet State

Get all
```bash
curl http://localhost:9092/pools/canonical-orderbooks

[
  {
    "base": "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc",
    "quote": "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4",
    "pool_id": 1904
  }
]
```

Get specific
```bash
curl http://localhost:9092/pools/canonical-orderbook?base=factory%2Fosmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743%2Fwbtc&quote=ibc%2F498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4
1904
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new endpoints for retrieving canonical orderbook pool IDs and entries.

- **Documentation**
	- Updated documentation with references and descriptions for new endpoints.
	- Added a reference link in `introduction.md` to direct users to more detailed information in `pools.md`.

- **Bug Fixes**
	- Corrected endpoint and method names for canonical orderbook pool ID retrieval.

- **Refactor**
	- Removed the `is_unlisted` property from the `Token` object to streamline its structure.
   
- **Tests**
	- Added new test functions for orderbook processing and pool storage functionality.
	- Introduced new methods in `poolsUseCase` struct for testing orderbook entries.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->