### PR TITLE
fix: orderbook direction

### DIFF
--- a/router/usecase/pools/routable_cw_orderbook_pool.go
+++ b/router/usecase/pools/routable_cw_orderbook_pool.go
@@ -121,14 +121,14 @@ func (r *routableOrderbookPoolImpl) CalculateTokenOutByTokenIn(ctx context.Conte
 
 		// Amount that should be filled given the current tick price and all the remaining amount of tokens in
 		// if the current tick has enough liquidity
-		outputAmount := cosmwasmpool.OrderbookValueInOppositeDirection(amountInRemaining, tickPrice, directionOut)
+		outputAmount := cosmwasmpool.OrderbookValueInOppositeDirection(amountInRemaining, tickPrice, *directionIn)
 
 		// Cap the output amount to the amount of tokens that can be filled in the current tick
 		outputFilled := tick.TickLiquidity.GetFillableAmount(outputAmount, directionOut)
 
 		// Convert the filled amount back to the input amount that should be deducted
 		// from the remaining amount of tokens in
-		inputFilled := cosmwasmpool.OrderbookValueInOppositeDirection(outputFilled, tickPrice, *directionIn)
+		inputFilled := cosmwasmpool.OrderbookValueInOppositeDirection(outputFilled, tickPrice, directionOut)
 
 		// Add the filled amount to the order total
 		amountOutTotal.AddMut(outputFilled)

--- a/router/usecase/pools/routable_cw_orderbook_pool_test.go
+++ b/router/usecase/pools/routable_cw_orderbook_pool_test.go
@@ -111,8 +111,8 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Orderbook() {
 		},
 		"BID: multi-tick/direction swap": {
 			tokenIn: sdk.NewCoin(QUOTE_DENOM, osmomath.NewInt(150)),
-			// 100*1 (tick: 0) + 50*2 (tick: LARGE_POSITIVE_TICK) = 200
-			expectedTokenOut: sdk.NewCoin(BASE_DENOM, osmomath.NewInt(200)),
+			// 100 / 1 (tick: 0) + 50/2 (tick: LARGE_POSITIVE_TICK) = 125
+			expectedTokenOut: sdk.NewCoin(BASE_DENOM, osmomath.NewInt(125)),
 			nextBidTickIndex: -1, // no next bid tick
 			nextAskTickIndex: 0,
 			ticks: []cosmwasmpool.OrderbookTick{
@@ -178,8 +178,8 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Orderbook() {
 		},
 		"ASK: multi-tick/direction swap": {
 			tokenIn: sdk.NewCoin(BASE_DENOM, osmomath.NewInt(150)),
-			// 25 at 0.5 tick price + 100 at 1 tick price = 125
-			expectedTokenOut: sdk.NewCoin(QUOTE_DENOM, osmomath.NewInt(125)),
+			// 50 at 2 tick price + 100 at 1 tick price = 200
+			expectedTokenOut: sdk.NewCoin(QUOTE_DENOM, osmomath.NewInt(200)),
 			nextBidTickIndex: 1,
 			nextAskTickIndex: 0,
 			ticks: []cosmwasmpool.OrderbookTick{
@@ -193,8 +193,8 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Orderbook() {
 				{
 					TickId: LARGE_POSITIVE_TICK,
 					TickLiquidity: cosmwasmpool.OrderbookTickLiquidity{
-						BidLiquidity: osmomath.NewBigDec(25),
-						AskLiquidity: osmomath.NewBigDec(25),
+						BidLiquidity: osmomath.NewBigDec(100),
+						AskLiquidity: osmomath.NewBigDec(100),
 					},
 				},
 			},
@@ -247,6 +247,18 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Orderbook() {
 				Denom:      INVALID_DENOM,
 				BaseDenom:  BASE_DENOM,
 				QuoteDenom: QUOTE_DENOM,
+			},
+		},
+		"error: overrid ": {
+			tokenIn:          sdk.NewCoin(QUOTE_DENOM, osmomath.NewInt(100)),
+			expectedTokenOut: sdk.NewCoin(BASE_DENOM, osmomath.NewInt(100)),
+			nextBidTickIndex: MIN_TICK,
+			nextAskTickIndex: 0,
+			ticks: []cosmwasmpool.OrderbookTick{
+				{TickId: 0, TickLiquidity: cosmwasmpool.OrderbookTickLiquidity{
+					BidLiquidity: osmomath.ZeroBigDec(),
+					AskLiquidity: osmomath.NewBigDec(100),
+				}},
 			},
 		},
 	}


### PR DESCRIPTION
Pointed out by @crnbarr93 when debugging edgenet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected calculation logic for `outputAmount` and `inputFilled` in token swap scenarios, ensuring accurate outcomes based on the direction of token exchange.

- **Tests**
  - Updated expected outcomes in various test cases to align with the corrected token calculations.
  - Added a new test case to handle error scenarios with overridden values, improving test coverage and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->