### PR TITLE
perf: micro benchmark worker pool in prices

### DIFF
--- a/new_bench_100
+++ b/new_bench_100
@@ -1,0 +1,16 @@
+goos: linux
+goarch: amd64
+pkg: github.com/osmosis-labs/sqs/tokens/usecase
+cpu: Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+BenchmarkGetPrices-4   	   13288	     77141 ns/op	   17323 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   15249	     88799 ns/op	   17280 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   14292	     79626 ns/op	   17296 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   15897	     86329 ns/op	   17262 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   14767	     82517 ns/op	   17283 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   14636	     80610 ns/op	   17287 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   13702	     89749 ns/op	   17312 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   14504	     88232 ns/op	   17290 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   15216	     79942 ns/op	   17277 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   15733	     88687 ns/op	   17265 B/op	     210 allocs/op
+PASS
+ok  	github.com/osmosis-labs/sqs/tokens/usecase	40.297s

--- a/new_bench_400
+++ b/new_bench_400
@@ -1,0 +1,16 @@
+goos: linux
+goarch: amd64
+pkg: github.com/osmosis-labs/sqs/tokens/usecase
+cpu: Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+BenchmarkGetPrices-4   	   14635	     85071 ns/op	   17286 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   16036	     81866 ns/op	   17257 B/op	     209 allocs/op
+BenchmarkGetPrices-4   	   11571	     92016 ns/op	   17376 B/op	     211 allocs/op
+BenchmarkGetPrices-4   	   13250	     88501 ns/op	   17324 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   14750	     89394 ns/op	   17292 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   12614	     86331 ns/op	   17340 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   15441	     86651 ns/op	   17272 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   14919	     81053 ns/op	   17281 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   15302	     96638 ns/op	   17273 B/op	     210 allocs/op
+BenchmarkGetPrices-4   	   13167	     87346 ns/op	   17324 B/op	     210 allocs/op
+PASS
+ok  	github.com/osmosis-labs/sqs/tokens/usecase	40.425s

--- a/old_bench
+++ b/old_bench
@@ -1,0 +1,16 @@
+goos: linux
+goarch: amd64
+pkg: github.com/osmosis-labs/sqs/tokens/usecase
+cpu: Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+BenchmarkGetPrices-4   	   14170	     81275 ns/op	   16143 B/op	     198 allocs/op
+BenchmarkGetPrices-4   	   14992	     78558 ns/op	   16132 B/op	     198 allocs/op
+BenchmarkGetPrices-4   	   17280	     92623 ns/op	   16086 B/op	     197 allocs/op
+BenchmarkGetPrices-4   	   16074	     78806 ns/op	   16106 B/op	     197 allocs/op
+BenchmarkGetPrices-4   	   14736	     78429 ns/op	   16132 B/op	     198 allocs/op
+BenchmarkGetPrices-4   	   13755	     83517 ns/op	   16156 B/op	     198 allocs/op
+BenchmarkGetPrices-4   	   14791	     77054 ns/op	   16142 B/op	     198 allocs/op
+BenchmarkGetPrices-4   	   15456	     91901 ns/op	   16118 B/op	     198 allocs/op
+BenchmarkGetPrices-4   	   15577	     79640 ns/op	   16115 B/op	     198 allocs/op
+BenchmarkGetPrices-4   	   13953	     83414 ns/op	   16153 B/op	     198 allocs/op
+PASS
+ok  	github.com/osmosis-labs/sqs/tokens/usecase	38.248s

--- a/tokens/usecase/prices_bench_test.go
+++ b/tokens/usecase/prices_bench_test.go
@@ -24,7 +24,7 @@ func BenchmarkGetPrices(b *testing.B) {
 	// Customize cache config
 	mainnetState.PricingConfig.CacheExpiryMs = pricingCacheExpiry
 
-	mainnetUsecase := s.SetupRouterAndPoolsUsecase(mainnetState, routertesting.WithRouterConfig(defaultPricingRouterConfig), routertesting.WithPricingConfig(defaultPricingConfig))
+	mainnetUsecase := s.SetupRouterAndPoolsUsecase(mainnetState, routertesting.WithRouterConfig(defaultPricingRouterConfig), routertesting.WithPricingConfig(defaultPricingConfig), routertesting.WithLoggerDisabled())
 
 	b.ResetTimer()
 

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -18,7 +18,7 @@ import (
 const (
 	// Max number of workers to fetch prices concurrently
 	// TODO: move to config
-	maxNumWorkes = 10
+	maxNumWorkes = 100
 )
 
 type tokensUseCase struct {


### PR DESCRIPTION
This shows that worker pool limitation is not the cause of performance regression by benchmarking `GetPrices` query with all prices.

The difference between 10 and 100 workers for CPU time is not statistically significant. At the same time, 400 workers showed an 8% regression relative to 10:
```go
benchstat old_bench new_bench_400
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/tokens/usecase
cpu: Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
            │  old_bench   │           new_bench_400            │
            │    sec/op    │   sec/op     vs base               │
GetPrices-4   80.46µ ± 14%   87.00µ ± 6%  +8.13% (p=0.035 n=10)

            │  old_bench   │            new_bench_400            │
            │     B/op     │     B/op      vs base               │
GetPrices-4   15.75Ki ± 0%   16.88Ki ± 0%  +7.17% (p=0.000 n=10)

            │ old_bench  │           new_bench_400           │
            │ allocs/op  │ allocs/op   vs base             
```