### PR TITLE
refactor: remove spread factor from fee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+- Remove spread factor from fee as it is included in the price impact
+
 ## v25.3.2
 
 - Fix telemetry issues around coingecko pricing source

--- a/domain/router.go
+++ b/domain/router.go
@@ -52,7 +52,7 @@ type Quote interface {
 	GetAmountIn() sdk.Coin
 	GetAmountOut() osmomath.Int
 	GetRoute() []SplitRoute
-	GetEffectiveSpreadFactor() osmomath.Dec
+	GetEffectiveFee() osmomath.Dec
 	GetPriceImpact() osmomath.Dec
 
 	// PrepareResult mutates the quote to prepare

--- a/router/usecase/quote.go
+++ b/router/usecase/quote.go
@@ -51,14 +51,11 @@ func (q *quoteImpl) PrepareResult(ctx context.Context, scalingFactor osmomath.De
 
 		// Calculate the spread factor across pools in the route
 		for _, pool := range curRoute.GetPools() {
-			poolSpreadFactor := pool.GetSpreadFactor()
 			poolTakerFee := pool.GetTakerFee()
 
-			totalPoolFee := poolSpreadFactor.Add(poolTakerFee)
-
 			routeTotalFee.AddMut(
-				//  (1 - routeSpreadFactor) * poolSpreadFactor
-				osmomath.OneDec().SubMut(routeTotalFee).MulTruncateMut(totalPoolFee),
+				//  (1 - routeTotalFee) * poolTakerFee
+				osmomath.OneDec().SubMut(routeTotalFee).MulTruncateMut(poolTakerFee),
 			)
 		}
 
@@ -111,8 +108,8 @@ func (q *quoteImpl) GetRoute() []domain.SplitRoute {
 	return q.Route
 }
 
-// GetEffectiveSpreadFactor implements Quote.
-func (q *quoteImpl) GetEffectiveSpreadFactor() osmomath.Dec {
+// GetEffectiveFee implements Quote.
+func (q *quoteImpl) GetEffectiveFee() osmomath.Dec {
 	return q.EffectiveFee
 }
 

--- a/router/usecase/quote_test.go
+++ b/router/usecase/quote_test.go
@@ -36,7 +36,6 @@ var (
 // Route 2: 1 hop
 //
 // Validate that the effective swap fee is computed correctly.
-// TODO: validate that taker fees are accounted for.
 func (s *RouterTestSuite) TestPrepareResult() {
 	s.SetupTest()
 
@@ -223,18 +222,18 @@ func (s *RouterTestSuite) TestPrepareResult() {
 	}
 
 	// Compute expected total fee and validate against actual
-	expectedPoolOneTotalFee := poolOne.GetSpreadFactor(sdk.Context{}).Add(takerFeeOne)
-	expectedPoolTwoTotalFee := poolTwo.GetSpreadFactor(sdk.Context{}).Add(takerFeeTwo)
-	expectedPoolThreeTotalFee := poolThree.GetSpreadFactor(sdk.Context{}).Add(takerFeeThree)
+	expectedPoolOneTotalFee := takerFeeOne
+	expectedPoolTwoTotalFee := takerFeeTwo
+	expectedPoolThreeTotalFee := takerFeeThree
 
 	expectedRouteOneFee := expectedPoolOneTotalFee.Add(osmomath.OneDec().Sub(expectedPoolOneTotalFee).MulMut(expectedPoolTwoTotalFee)).MulMut(osmomath.NewDecWithPrec(5, 1))
-	expectedRouteTwoFee := expectedPoolThreeTotalFee.MulMut(osmomath.NewDecWithPrec(5, 1))
+	expectedRouteTwoFee := expectedPoolThreeTotalFee.Mul(osmomath.NewDecWithPrec(5, 1))
 
-	// ((0.01 + 0.02) + (1 - (0.01 + 0.02)) * (0.03 + 0.0004)) * 0.5 + (0.005 + 0.003) * 0.5
-	expectedEffectiveSpreadFactor := expectedRouteOneFee.Add(expectedRouteTwoFee)
+	// (0.02 + (1 - 0.02) * 0.0004) * 0.5 + 0.003 * 0.5
+	expectedEffectiveFee := expectedRouteOneFee.Add(expectedRouteTwoFee)
 
 	// System under test
-	routes, effectiveSpreadFactor, err := testQuote.PrepareResult(context.TODO(), defaultSpotPriceScalingFactor)
+	routes, effectiveFee, err := testQuote.PrepareResult(context.TODO(), defaultSpotPriceScalingFactor)
 	s.Require().NoError(err)
 
 	// Validate routes.
@@ -242,8 +241,8 @@ func (s *RouterTestSuite) TestPrepareResult() {
 	s.validateRoutes(expectedRoutes, testQuote.GetRoute())
 
 	// Validate effective spread factor.
-	s.Require().Equal(expectedEffectiveSpreadFactor.String(), effectiveSpreadFactor.String())
-	s.Require().Equal(expectedEffectiveSpreadFactor.String(), testQuote.GetEffectiveSpreadFactor().String())
+	s.Require().Equal(expectedEffectiveFee.String(), effectiveFee.String())
+	s.Require().Equal(expectedEffectiveFee.String(), testQuote.GetEffectiveFee().String())
 }
 
 // This test validates that price impact is computed correctly.


### PR DESCRIPTION
Related to: https://linear.app/osmosis/issue/PROD-187/refactor-the-way-we-treat-price-impact-and-fees#comment-35a74c34

The spread factor is currently included in the price impact. As a result, we should remove it from fee. Requested by @sunnya97 

- Covered by unit test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated fee calculation mechanism to include fees within the price impact, simplifying fee representation.
  
- **Bug Fixes**
  - Resolved telemetry issues related to the Coingecko pricing source, ensuring accurate data tracking and reporting.

- **Documentation**
  - Added an "Unreleased" section to the changelog for better version tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->