### PR TITLE
feat: contract address in canonical orderbook API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 - Remove spread factor from fee as it is included in the price impact
+- Format contract address in canonical orderbook endpoints
 
 ## v25.3.2
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -69,7 +69,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Canonical Orderbook Pool ID for the given base and quote",
                         "schema": {
-                            "type": "uint64"
+                            "type": "struct"
                         }
                     }
                 }
@@ -346,6 +346,9 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "base": {
+                    "type": "string"
+                },
+                "contract_address": {
                     "type": "string"
                 },
                 "pool_id": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -60,7 +60,7 @@
                     "200": {
                         "description": "Canonical Orderbook Pool ID for the given base and quote",
                         "schema": {
-                            "type": "uint64"
+                            "type": "struct"
                         }
                     }
                 }
@@ -337,6 +337,9 @@
             "type": "object",
             "properties": {
                 "base": {
+                    "type": "string"
+                },
+                "contract_address": {
                     "type": "string"
                 },
                 "pool_id": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3,6 +3,8 @@ definitions:
     properties:
       base:
         type: string
+      contract_address:
+        type: string
       pool_id:
         type: integer
       quote:
@@ -95,7 +97,7 @@ paths:
         "200":
           description: Canonical Orderbook Pool ID for the given base and quote
           schema:
-            type: uint64
+            type: struct
       summary: Get canonical orderbook pool ID for the given base and quote.
   /pools/canonical-orderbooks:
     get:

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -35,8 +35,8 @@ func (pm *PoolsUsecaseMock) GetAllCanonicalOrderbookPoolIDs() ([]domain.Canonica
 	panic("unimplemented")
 }
 
-// GetCanonicalOrderbookPoolID implements mvc.PoolsUsecase.
-func (pm *PoolsUsecaseMock) GetCanonicalOrderbookPoolID(baseDenom string, quoteDenom string) (uint64, error) {
+// GetCanonicalOrderbookPool implements mvc.PoolsUsecase.
+func (pm *PoolsUsecaseMock) GetCanonicalOrderbookPool(baseDenom string, quoteDenom string) (uint64, string, error) {
 	panic("unimplemented")
 }
 

--- a/domain/mvc/pools.go
+++ b/domain/mvc/pools.go
@@ -28,9 +28,10 @@ type PoolsUsecase interface {
 
 	GetCosmWasmPoolConfig() domain.CosmWasmPoolRouterConfig
 
-	// GetCanonicalOrderbookPoolID returns the canonical orderbook pool ID for the given base and quote denoms.
-	// Returns error if the pool ID is not found for the given pair.
-	GetCanonicalOrderbookPoolID(baseDenom, quoteDenom string) (uint64, error)
+	// GetCanonicalOrderbookPool returns the canonical orderbook pool ID for the given base and quote denoms
+	// as well as the associated contract ID.
+	// Returns error if the pool is not found for the given pair.
+	GetCanonicalOrderbookPool(baseDenom, quoteDenom string) (uint64, string, error)
 
 	// GetAllCanonicalOrderbookPoolIDs returns all the canonical orderbook results
 	// where each base/quote denom is associated with a default pool ID.

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -61,7 +61,8 @@ var UnsetScalingFactorGetterCb ScalingFactorGetterCb = func(denom string) (osmom
 
 // CanonicalOrderBooksResult is a structure for serializing canonical orderbook result returned to clients.
 type CanonicalOrderBooksResult struct {
-	Base   string `json:"base"`
-	Quote  string `json:"quote"`
-	PoolID uint64 `json:"pool_id"`
+	Base            string `json:"base"`
+	Quote           string `json:"quote"`
+	PoolID          uint64 `json:"pool_id"`
+	ContractAddress string `json:"contract_address"`
 }

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -145,7 +145,7 @@ func getStatusCode(err error) int {
 // @Produce  json
 // @Param  base  query  string  true  "Base denom"
 // @Param  quote  query  string  true  "Quote denom"
-// @Success 200  uint64  "Canonical Orderbook Pool ID for the given base and quote"
+// @Success 200  struct domain.CanonicalOrderBooksResult  "Canonical Orderbook Pool ID for the given base and quote"
 // @Router /pools/canonical-orderbook [get]
 func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 	base := c.QueryParam("base")
@@ -158,12 +158,17 @@ func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, ResponseError{Message: "quote must be provided"})
 	}
 
-	poolID, err := a.PUsecase.GetCanonicalOrderbookPoolID(base, quote)
+	poolID, contractAddres, err := a.PUsecase.GetCanonicalOrderbookPool(base, quote)
 	if err != nil {
 		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
 	}
 
-	return c.JSON(http.StatusOK, poolID)
+	return c.JSON(http.StatusOK, domain.CanonicalOrderBooksResult{
+		Base:            base,
+		Quote:           quote,
+		PoolID:          poolID,
+		ContractAddress: contractAddres,
+	})
 }
 
 // @Summary Get entries for all supported orderbook base and quote denoms.

--- a/pools/usecase/export_test.go
+++ b/pools/usecase/export_test.go
@@ -9,8 +9,12 @@ type (
 	PoolsUsecase   = poolsUseCase
 )
 
-func (p *poolsUseCase) ProcessOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom string, poolID uint64, poolLiquidityCapitalization osmomath.Int) (updatedBool bool, err error) {
-	return p.processOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom, poolID, poolLiquidityCapitalization)
+const (
+	OriginalOrderbookAddress = "original-address"
+)
+
+func (p *poolsUseCase) ProcessOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom string, poolID uint64, poolLiquidityCapitalization osmomath.Int, contractAddress string) (updatedBool bool, err error) {
+	return p.processOrderbookPoolIDForBaseQuote(baseDenom, quoteDenom, poolID, poolLiquidityCapitalization, contractAddress)
 }
 
 // WARNING: this method is only meant for setting up tests. Do not move out of export_test.go
@@ -18,6 +22,7 @@ func (p *poolsUseCase) StoreValidOrdeBookEntry(baseDenom, quoteDenom string, poo
 	p.canonicalOrderBookForBaseQuoteDenom.Store(formatBaseQuoteDenom(baseDenom, quoteDenom), orderBookEntry{
 		PoolID:       poolID,
 		LiquidityCap: poolLiquidityCapitalization,
+		ContractAddress: OriginalOrderbookAddress,
 	})
 }
 

--- a/tests/test_pools.py
+++ b/tests/test_pools.py
@@ -73,6 +73,7 @@ class TestPools:
         expected_orderbook_pool_id = 1904
         base = "factory/osmo1z0qrq605sjgcqpylfl4aa6s90x738j7m58wyatt0tdzflg2ha26q67k743/wbtc"
         quote = "ibc/498A0751C798A0D9A389AA3691123DADA57DAA4FE165D5C75894505B876BA6E4"
+        expected_contract_address = "osmo18nzruvalfuukut9fq5st5mg5sn6s8nu4u42kuwwgynu3fne6sd5sxnrwf2"
 
         sqs_service = SERVICE_MAP[environment_url]
         canonical_orderbooks = sqs_service.get_canonical_orderbooks()
@@ -86,6 +87,10 @@ class TestPools:
             if orderbook.get("pool_id") == expected_orderbook_pool_id:
                 assert orderbook.get("base") == base, "Base asset is not correct"
                 assert orderbook.get("quote") == quote, "Quote asset is not correct"
+
+                actual_contract_address = orderbook.get("contract_address")
+                assert actual_contract_address == expected_contract_address, f"Contract address is not correct, actual: {actual_contract_address}, expected: {expected_contract_address}"
+
 
                 didFind = True
                 return


### PR DESCRIPTION
Requested by @crnbarr93 
https://linear.app/osmosis/issue/DATA-284/no-urgent-need-to-map-pool-info-to-contract-address-using-a-second

- Added contract address in the canonical orderbook API
- Unit tested at various levels of abstraction
- Integration tested
- Updated swagger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `ContractAddress` field to responses for canonical orderbook endpoints, providing more comprehensive information.
  
- **Bug Fixes**
  - Removed the spread factor from the fee as it is now included in the price impact.

- **Documentation**
  - Updated schema definitions and response types in API documentation to reflect new `ContractAddress` field.

- **Tests**
  - Enhanced test coverage to include checks for the new `ContractAddress` field in various test cases.
  
- **Refactor**
  - Modified method signatures to include or return `ContractAddress` in relevant functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->