### PR TITLE
refactor: resolve goroutine leak stemming from creating a grpc connection for every cosmwasm pool in route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## v25.4.1
+
+- Resolve goroutine leak stemming from creating a grpc connection for every cosmwasm pool in route. Share one connection.
+
 ## v25.4.0
 
 - Remove spread factor from fee as it is included in the price impact

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -122,7 +122,10 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 	}
 
 	// Initialize pools repository, usecase and HTTP handler
-	poolsUseCase := poolsUseCase.NewPoolsUsecase(config.Pools, config.ChainGRPCGatewayEndpoint, routerRepository, tokensUseCase.GetChainScalingFactorByDenomMut, logger)
+	poolsUseCase, err := poolsUseCase.NewPoolsUsecase(config.Pools, config.ChainGRPCGatewayEndpoint, routerRepository, tokensUseCase.GetChainScalingFactorByDenomMut, logger)
+	if err != nil {
+		return nil, err
+	}
 
 	// Initialize candidate route searcher
 	candidateRouteSearcher := routerUseCase.NewCandidateRouteFinder(routerRepository, logger)

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -93,7 +93,9 @@ func (pm *PoolsUsecaseMock) GetRoutesFromCandidates(candidateRoutes sqsdomain.Ca
 			}
 
 			// TODO: note that taker fee is force set to zero
-			routablePool, err := pools.NewRoutablePool(foundPool, candidatePool.TokenOutDenom, osmomath.ZeroDec(), domain.CosmWasmPoolRouterConfig{}, domain.UnsetScalingFactorGetterCb)
+			routablePool, err := pools.NewRoutablePool(foundPool, candidatePool.TokenOutDenom, osmomath.ZeroDec(), pools.CosmWasmPoolsParams{
+				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -688,7 +688,8 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuote_Mainnet_UOSMOU
 	tokensRepositoryMock.SetTakerFees(mainnetState.TakerFeeMap)
 
 	// Setup pools usecase mock.
-	poolsUsecase := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", tokensRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+	poolsUsecase, err := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", tokensRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+	s.Require().NoError(err)
 	poolsUsecase.StorePools(mainnetState.Pools)
 
 	tokenMetaDataHolderMock := &mocks.TokenMetadataHolderMock{}

--- a/router/usecase/pools/cosmwasm_utils.go
+++ b/router/usecase/pools/cosmwasm_utils.go
@@ -4,27 +4,16 @@ import (
 	"context"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/sqsdomain/json"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 )
 
-// initializeWasmClient initializes the wasm client given the node URI
-// Returns error if fails to initialize the client
-func initializeWasmClient(grpcGatewayEndpoint string) (wasmtypes.QueryClient, error) {
-	grpcClient, err := grpc.NewClient(grpcGatewayEndpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
-		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	wasmClient := wasmtypes.NewQueryClient(grpcClient)
-
-	return wasmClient, nil
+type CosmWasmPoolsParams struct {
+	Config                domain.CosmWasmPoolRouterConfig
+	WasmClient            wasmtypes.QueryClient
+	ScalingFactorGetterCb domain.ScalingFactorGetterCb
 }
 
 // queryCosmwasmContract queries the cosmwasm contract given the contract address, request and response

--- a/router/usecase/pools/export_test.go
+++ b/router/usecase/pools/export_test.go
@@ -19,9 +19,9 @@ type (
 func NewRoutableCosmWasmPoolWithCustomModel(
 	pool sqsdomain.PoolI,
 	cosmwasmPool *cwpoolmodel.CosmWasmPool,
-	cosmWasmConfig domain.CosmWasmPoolRouterConfig,
+	cosmWasmPoolsParams CosmWasmPoolsParams,
 	tokenOutDenom string,
 	takerFee osmomath.Dec,
 ) (domain.RoutablePool, error) {
-	return newRoutableCosmWasmPoolWithCustomModel(pool, cosmwasmPool, cosmWasmConfig, tokenOutDenom, takerFee)
+	return newRoutableCosmWasmPoolWithCustomModel(pool, cosmwasmPool, cosmWasmPoolsParams, tokenOutDenom, takerFee)
 }

--- a/router/usecase/pools/pool_factory.go
+++ b/router/usecase/pools/pool_factory.go
@@ -120,7 +120,6 @@ func newRoutableCosmWasmPool(pool sqsdomain.PoolI, tokenOutDenom string, takerFe
 
 	_, isGeneralizedCosmWasmPool := cosmWasmPoolsParams.Config.GeneralCosmWasmCodeIDs[cosmwasmPool.CodeId]
 	if isGeneralizedCosmWasmPool {
-
 		spreadFactor := pool.GetSQSPoolModel().SpreadFactor
 
 		// for most other CosmWasm pools, interaction with the chain will

--- a/router/usecase/pools/pool_factory_test.go
+++ b/router/usecase/pools/pool_factory_test.go
@@ -190,7 +190,10 @@ func TestNewRoutableCosmWasmPoolWithCustomModel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			routablePool, err := pools.NewRoutableCosmWasmPoolWithCustomModel(tt.pool, tt.cosmwasmPool, tt.cosmWasmConfig, tt.tokenOutDenom, tt.takerFee)
+			cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+				Config: tt.cosmWasmConfig,
+			}
+			routablePool, err := pools.NewRoutableCosmWasmPoolWithCustomModel(tt.pool, tt.cosmwasmPool, cosmWasmPoolsParams, tt.tokenOutDenom, tt.takerFee)
 
 			if tt.expectedError != nil {
 				require.Equal(t, tt.expectedError, err)

--- a/router/usecase/pools/routable_concentrated_pool_test.go
+++ b/router/usecase/pools/routable_concentrated_pool_test.go
@@ -88,7 +88,10 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 					PoolDenoms:            []string{"foo", "bar"},
 				},
 			}
-			routablePool, err := pools.NewRoutablePool(poolWrapper, tc.TokenOutDenom, noTakerFee, domain.CosmWasmPoolRouterConfig{}, domain.UnsetScalingFactorGetterCb)
+			cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
+			}
+			routablePool, err := pools.NewRoutablePool(poolWrapper, tc.TokenOutDenom, noTakerFee, cosmWasmPoolsParams)
 			s.Require().NoError(err)
 
 			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(context.TODO(), tc.TokenIn)

--- a/router/usecase/pools/routable_cw_alloy_transmuter_pool_test.go
+++ b/router/usecase/pools/routable_cw_alloy_transmuter_pool_test.go
@@ -49,11 +49,15 @@ func (s *RoutablePoolTestSuite) SetupRoutableAlloyTransmuterPool(tokenInDenom, t
 		TakerFee: takerFee,
 	}
 
-	routablePool, err := pools.NewRoutablePool(mock, tokenOutDenom, takerFee, domain.CosmWasmPoolRouterConfig{
-		AlloyedTransmuterCodeIDs: map[uint64]struct{}{
-			defaultPoolID: {},
+	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+		Config: domain.CosmWasmPoolRouterConfig{
+			AlloyedTransmuterCodeIDs: map[uint64]struct{}{
+				defaultPoolID: {},
+			},
 		},
-	}, domain.UnsetScalingFactorGetterCb)
+		ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
+	}
+	routablePool, err := pools.NewRoutablePool(mock, tokenOutDenom, takerFee, cosmWasmPoolsParams)
 	s.Require().NoError(err)
 
 	return routablePool

--- a/router/usecase/pools/routable_cw_orderbook_pool_test.go
+++ b/router/usecase/pools/routable_cw_orderbook_pool_test.go
@@ -62,11 +62,15 @@ func (s *RoutablePoolTestSuite) SetupRoutableOrderbookPool(
 		TakerFee: takerFee,
 	}
 
-	routablePool, err := pools.NewRoutablePool(mock, tokenOutDenom, takerFee, domain.CosmWasmPoolRouterConfig{
-		OrderbookCodeIDs: map[uint64]struct{}{
-			cosmwasmPool.GetId(): {},
+	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+		Config: domain.CosmWasmPoolRouterConfig{
+			OrderbookCodeIDs: map[uint64]struct{}{
+				cosmwasmPool.GetId(): {},
+			},
 		},
-	}, domain.UnsetScalingFactorGetterCb)
+		ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
+	}
+	routablePool, err := pools.NewRoutablePool(mock, tokenOutDenom, takerFee, cosmWasmPoolsParams)
 	s.Require().NoError(err)
 
 	return routablePool

--- a/router/usecase/pools/routable_cw_pool.go
+++ b/router/usecase/pools/routable_cw_pool.go
@@ -38,7 +38,7 @@ type routableCosmWasmPoolImpl struct {
 }
 
 // NewRoutableCosmWasmPool returns a new routable cosmwasm pool with the given parameters.
-func NewRoutableCosmWasmPool(pool *cwpoolmodel.CosmWasmPool, balances sdk.Coins, tokenOutDenom string, takerFee osmomath.Dec, spreadFactor osmomath.Dec, wasmClient wasmtypes.QueryClient, scalingFactorGetterCb domain.ScalingFactorGetterCb) domain.RoutablePool {
+func NewRoutableCosmWasmPool(pool *cwpoolmodel.CosmWasmPool, balances sdk.Coins, tokenOutDenom string, takerFee osmomath.Dec, spreadFactor osmomath.Dec, cosmWasmPoolsParams CosmWasmPoolsParams) domain.RoutablePool {
 	// Initializa routable cosmwasm pool
 	routableCosmWasmPool := &routableCosmWasmPoolImpl{
 		ChainPool:     pool,
@@ -46,7 +46,7 @@ func NewRoutableCosmWasmPool(pool *cwpoolmodel.CosmWasmPool, balances sdk.Coins,
 		TokenOutDenom: tokenOutDenom,
 		TakerFee:      takerFee,
 		SpreadFactor:  spreadFactor,
-		wasmClient:    wasmClient,
+		wasmClient:    cosmWasmPoolsParams.WasmClient,
 
 		// Note, that there is no calculator set
 		// since we need to wire quote calculation callback to it.
@@ -54,7 +54,7 @@ func NewRoutableCosmWasmPool(pool *cwpoolmodel.CosmWasmPool, balances sdk.Coins,
 	}
 
 	// Initialize spot price calculator.
-	spotPriceCalculator := NewSpotPriceQuoteComputer(scalingFactorGetterCb, routableCosmWasmPool.calculateTokenOutByTokenIn)
+	spotPriceCalculator := NewSpotPriceQuoteComputer(cosmWasmPoolsParams.ScalingFactorGetterCb, routableCosmWasmPool.calculateTokenOutByTokenIn)
 
 	// Set it on the routable cosmwasm pool.
 	routableCosmWasmPool.spotPriceQuoteCalculator = spotPriceCalculator

--- a/router/usecase/pools/routable_cw_transmuter_pool_test.go
+++ b/router/usecase/pools/routable_cw_transmuter_pool_test.go
@@ -60,11 +60,16 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Transmuter() {
 			poolType := cosmwasmPool.GetType()
 
 			mock := &mocks.MockRoutablePool{ChainPoolModel: cosmwasmPool.AsSerializablePool(), Balances: tc.balances, PoolType: poolType}
-			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmPoolRouterConfig{
-				TransmuterCodeIDs: map[uint64]struct{}{
-					cosmwasmPool.GetCodeId(): {},
+
+			cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+				Config: domain.CosmWasmPoolRouterConfig{
+					TransmuterCodeIDs: map[uint64]struct{}{
+						cosmwasmPool.GetCodeId(): {},
+					},
 				},
-			}, domain.UnsetScalingFactorGetterCb)
+				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
+			}
+			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, cosmWasmPoolsParams)
 			s.Require().NoError(err)
 
 			// Overwrite pool type for edge case testing

--- a/router/usecase/pools/routable_pool_test.go
+++ b/router/usecase/pools/routable_pool_test.go
@@ -94,7 +94,10 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_CFMM() {
 			s.Require().NoError(err)
 
 			mock := &mocks.MockRoutablePool{ChainPoolModel: pool, PoolType: tc.poolType}
-			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, domain.CosmWasmPoolRouterConfig{}, domain.UnsetScalingFactorGetterCb)
+			cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
+			}
+			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, cosmWasmPoolsParams)
 			s.Require().NoError(err)
 
 			tokenOut, err := routablePool.CalculateTokenOutByTokenIn(context.TODO(), tc.tokenIn)

--- a/router/usecase/quote_test.go
+++ b/router/usecase/quote_test.go
@@ -336,7 +336,11 @@ func (s *RouterTestSuite) validateRoutes(expectedRoutes []domain.SplitRoute, act
 }
 
 func (s *RouterTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmConfig domain.CosmWasmPoolRouterConfig) domain.RoutablePool {
-	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmConfig, domain.UnsetScalingFactorGetterCb)
+	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+		Config:                cosmWasmConfig,
+		ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
+	}
+	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolsParams)
 	s.Require().NoError(err)
 	return routablePool
 }

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -969,7 +969,8 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuotes_Mainnet_UOSMO
 	routerRepositoryMock.SetTakerFees(mainnetState.TakerFeeMap)
 
 	// Setup pools usecase mock.
-	poolsUsecase := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+	poolsUsecase, err := poolsusecase.NewPoolsUsecase(&domain.PoolsConfig{}, "node-uri-placeholder", routerRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+	s.Require().NoError(err)
 	poolsUsecase.StorePools(mainnetState.Pools)
 
 	tokenMetaDataHolder := mocks.TokenMetadataHolderMock{}

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -387,7 +387,8 @@ func (s *RouterTestHelper) SetupRouterAndPoolsUsecase(mainnetState MockMainnetSt
 	routerRepositoryMock.SetCandidateRouteSearchData(mainnetState.CandidateRouteSearchData)
 
 	// Setup pools usecase mock.
-	poolsUsecase := poolsusecase.NewPoolsUsecase(&options.PoolsConfig, "node-uri-placeholder", routerRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+	poolsUsecase, err := poolsusecase.NewPoolsUsecase(&options.PoolsConfig, "node-uri-placeholder", routerRepositoryMock, domain.UnsetScalingFactorGetterCb, &log.NoOpLogger{})
+	s.Require().NoError(err)
 	err = poolsUsecase.StorePools(mainnetState.Pools)
 	s.Require().NoError(err)
 


### PR DESCRIPTION
A goroutine leak was found
![image](https://github.com/user-attachments/assets/1dcc26b4-babb-41cf-9da5-8042c95fe3a1)

Profiler
![image](https://github.com/user-attachments/assets/b7cf9f6b-6bd6-44ce-b505-06b69d71a677)

We were creating a grpc callback serializer that would block on a select statement.

Debugging traced the source to creating a grpc connection for every cw pool found in route that would never end up getting properly closed.

The solution is to share one grpc connection for all cosmwasm pools.


The new profile taken under load test does not show the leak anymore:
![image](https://github.com/user-attachments/assets/4fe1c09e-fe27-4e47-a179-d4090fdfd2b1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling in the creation of pool use cases to ensure robustness and prevent crashes.

- **Refactor**
  - Refactored the parameter structure for pool creation functions to use a new `CosmWasmPoolsParams` struct for improved readability and maintainability.

- **Tests**
  - Updated test cases to reflect changes in parameter handling and added error handling to ensure comprehensive test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->