### PR TITLE
feat: add additional fields to metadata

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -362,6 +362,14 @@ const docTemplate = `{
         "domain.Token": {
             "type": "object",
             "properties": {
+                "name": {
+                    "type": "string"
+                    "description": "Name is the name of the token."
+                },
+                "denom": {
+                    "type": "string"
+                    "description": "Denom is the chain denom of the token."
+                },
                 "coingeckoId": {
                     "type": "string"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -353,6 +353,14 @@
         "domain.Token": {
             "type": "object",
             "properties": {
+                "name": {
+                    "description": "Name is the name of the token.",
+                    "type": "string"
+                },
+                "denom": {
+                    "description": "Denom is the chain denom of the token.",
+                    "type": "string"
+                },
                 "coingeckoId": {
                     "type": "string"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -12,6 +12,12 @@ definitions:
     type: object
   domain.Token:
     properties:
+      name:
+        description: Name is the name of the token.
+        type: string
+      denom:
+        description: Denom is the chain denom of the token.
+        type: string
       coingeckoId:
         type: string
       decimals:

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -6,8 +6,12 @@ import (
 
 // Token represents the token's domain model
 type Token struct {
+	// Name
+	Name string `json:"name"`
 	// HumanDenom is the human readable denom.
 	HumanDenom string `json:"symbol"`
+	// Denom is the chain denom of the token.
+	Denom string `json:"coinMinimalDenom"`
 	// Precision is the precision of the token.
 	Precision int `json:"decimals"`
 	// IsUnlisted is true if the token is unlisted.

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -8,10 +8,10 @@ import (
 type Token struct {
 	// Name
 	Name string `json:"name"`
-	// HumanDenom is the human readable denom.
+	// HumanDenom is the human readable denom, e.g. atom
 	HumanDenom string `json:"symbol"`
-	// Denom is the chain denom of the token.
-	Denom string `json:"coinMinimalDenom"`
+	// Denom is the chain denom of the token, e.g. ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2
+	CoinMinimalDenom string `json:"coinMinimalDenom"`
 	// Precision is the precision of the token.
 	Precision int `json:"decimals"`
 	// IsUnlisted is true if the token is unlisted.

--- a/tokens/usecase/token_registry.go
+++ b/tokens/usecase/token_registry.go
@@ -50,7 +50,7 @@ func GetTokensFromChainRegistry(chainRegistryAssetsFileURL string) (map[string]d
 		token.IsUnlisted = asset.Preview
 		token.CoingeckoID = asset.CoingeckoID
 		token.Name = asset.Name
-		token.Denom = asset.CoinMinimalDenom
+		token.CoinMinimalDenom = asset.CoinMinimalDenom
 		tokensByChainDenom[asset.CoinMinimalDenom] = token
 	}
 

--- a/tokens/usecase/token_registry.go
+++ b/tokens/usecase/token_registry.go
@@ -49,6 +49,8 @@ func GetTokensFromChainRegistry(chainRegistryAssetsFileURL string) (map[string]d
 		token.HumanDenom = asset.Symbol
 		token.IsUnlisted = asset.Preview
 		token.CoingeckoID = asset.CoingeckoID
+		token.Name = asset.Name
+		token.Denom = asset.CoinMinimalDenom
 		tokensByChainDenom[asset.CoinMinimalDenom] = token
 	}
 

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	"github.com/osmosis-labs/sqs/domain/workerpool"
 	"github.com/osmosis-labs/sqs/log"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
 const (
@@ -53,6 +54,7 @@ type tokensUseCase struct {
 type AssetList struct {
 	ChainName string `json:"chainName"`
 	Assets    []struct {
+		Name             string `json:"name"`
 		CoinMinimalDenom string `json:"coinMinimalDenom"`
 		Symbol           string `json:"symbol"`
 		Decimals         int    `json:"decimals"`

--- a/tokens/usecase/tokens_usecase_test.go
+++ b/tokens/usecase/tokens_usecase_test.go
@@ -98,7 +98,7 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().Equal(defaultCosmosExponent, atomToken.Precision)
 	s.Require().NotEmpty(atomToken.CoingeckoID)
 	s.Require().NotEmpty(atomToken.Name)
-	s.Require().NotEmpty(atomToken.Denom)
+	s.Require().NotEmpty(atomToken.CoinMinimalDenom)
 
 	// ION is present
 	ionMainnetDenom := "uion"
@@ -107,7 +107,7 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().Equal(defaultCosmosExponent, ionToken.Precision)
 	s.Require().NotEmpty(ionToken.CoingeckoID)
 	s.Require().NotEmpty(ionToken.Name)
-	s.Require().NotEmpty(ionToken.Denom)
+	s.Require().NotEmpty(ionToken.CoinMinimalDenom)
 
 	// IBCX is present
 	ibcxMainnetDenom := "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx"
@@ -116,7 +116,7 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().Equal(defaultCosmosExponent, ibcxToken.Precision)
 	s.Require().NotEmpty(ibcxToken.CoingeckoID)
 	s.Require().NotEmpty(ibcxToken.Name)
-	s.Require().NotEmpty(ibcxToken.Denom)
+	s.Require().NotEmpty(ibcxToken.CoinMinimalDenom)
 
 	// DYSON is present, but doesn't have coingecko id
 	dysonMainnetDenom := "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D"
@@ -124,7 +124,7 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().True(ok)
 	s.Require().Equal(0, dysonToken.Precision)
 	s.Require().NotEmpty(dysonToken.Name)
-	s.Require().NotEmpty(dysonToken.Denom)
+	s.Require().NotEmpty(dysonToken.CoinMinimalDenom)
 
 	// ETH is present
 	ethToken, ok := tokensMap[ETH]
@@ -133,7 +133,7 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().False(ethToken.IsUnlisted)
 	s.Require().NotEmpty(ethToken.CoingeckoID)
 	s.Require().NotEmpty(ethToken.Name)
-	s.Require().NotEmpty(ethToken.Denom)
+	s.Require().NotEmpty(ethToken.CoinMinimalDenom)
 
 	// AAVE is present but is unlisted
 	aaveToken, ok := tokensMap[AAVE_UNLISTED]
@@ -141,7 +141,7 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().True(aaveToken.IsUnlisted)
 	s.Require().NotEmpty(aaveToken.CoingeckoID)
 	s.Require().NotEmpty(aaveToken.Name)
-	s.Require().NotEmpty(aaveToken.Denom)
+	s.Require().NotEmpty(aaveToken.CoinMinimalDenom)
 }
 
 func (s *TokensUseCaseTestSuite) TestParseExponents_Testnet() {

--- a/tokens/usecase/tokens_usecase_test.go
+++ b/tokens/usecase/tokens_usecase_test.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/cache"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
 	tokensusecase "github.com/osmosis-labs/sqs/tokens/usecase"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
 type TokensUseCaseTestSuite struct {
@@ -96,6 +97,8 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().True(ok)
 	s.Require().Equal(defaultCosmosExponent, atomToken.Precision)
 	s.Require().NotEmpty(atomToken.CoingeckoID)
+	s.Require().NotEmpty(atomToken.Name)
+	s.Require().NotEmpty(atomToken.Denom)
 
 	// ION is present
 	ionMainnetDenom := "uion"
@@ -103,6 +106,8 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().True(ok)
 	s.Require().Equal(defaultCosmosExponent, ionToken.Precision)
 	s.Require().NotEmpty(ionToken.CoingeckoID)
+	s.Require().NotEmpty(ionToken.Name)
+	s.Require().NotEmpty(ionToken.Denom)
 
 	// IBCX is present
 	ibcxMainnetDenom := "factory/osmo14klwqgkmackvx2tqa0trtg69dmy0nrg4ntq4gjgw2za4734r5seqjqm4gm/uibcx"
@@ -110,12 +115,16 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().True(ok)
 	s.Require().Equal(defaultCosmosExponent, ibcxToken.Precision)
 	s.Require().NotEmpty(ibcxToken.CoingeckoID)
+	s.Require().NotEmpty(ibcxToken.Name)
+	s.Require().NotEmpty(ibcxToken.Denom)
 
 	// DYSON is present, but doesn't have coingecko id
 	dysonMainnetDenom := "ibc/E27CD305D33F150369AB526AEB6646A76EC3FFB1A6CA58A663B5DE657A89D55D"
 	dysonToken, ok := tokensMap[dysonMainnetDenom]
 	s.Require().True(ok)
 	s.Require().Equal(0, dysonToken.Precision)
+	s.Require().NotEmpty(dysonToken.Name)
+	s.Require().NotEmpty(dysonToken.Denom)
 
 	// ETH is present
 	ethToken, ok := tokensMap[ETH]
@@ -123,12 +132,16 @@ func (s *TokensUseCaseTestSuite) TestParseAssetList() {
 	s.Require().Equal(ethExponent, ethToken.Precision)
 	s.Require().False(ethToken.IsUnlisted)
 	s.Require().NotEmpty(ethToken.CoingeckoID)
+	s.Require().NotEmpty(ethToken.Name)
+	s.Require().NotEmpty(ethToken.Denom)
 
 	// AAVE is present but is unlisted
 	aaveToken, ok := tokensMap[AAVE_UNLISTED]
 	s.Require().True(ok)
 	s.Require().True(aaveToken.IsUnlisted)
 	s.Require().NotEmpty(aaveToken.CoingeckoID)
+	s.Require().NotEmpty(aaveToken.Name)
+	s.Require().NotEmpty(aaveToken.Denom)
 }
 
 func (s *TokensUseCaseTestSuite) TestParseExponents_Testnet() {


### PR DESCRIPTION
This PR adds additional two fields to sqs `/tokens/metadata` endpoint:

1. name
2. denom

Currently, indexer's endpoints are fetching asset list directly from github repo. As we're planning to make the indexer's endpoints to solely use sqs endpoints for fetching token metadata, we need additional the field in order to fulfill the data requirements from Dexscreener, aka `name`. The `denom` field is also added as it can be used as a key for the consumer of `/tokens/metadata` to locally cache the results. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Enhanced documentation for the `domain.Token` object with new properties: `name` and `denom`, providing clearer insights for developers.
  - Expanded API schema definitions for the `Token` object in both JSON and YAML formats to include `name` and `denom`.
  - Added `Name` and `CoinMinimalDenom` fields to token representations, allowing for a more detailed capture of token attributes.

- **Bug Fixes**
  - Improved validation in tests to ensure that the `Name` and `CoinMinimalDenom` fields of token objects are populated, enhancing data integrity checks.

- **Chores**
  - Reintroduced the `osmomath` package, enhancing mathematical functionalities for asset calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->