### PR TITLE
fix: e2e test flakiness

### DIFF
--- a/config.json
+++ b/config.json
@@ -51,7 +51,7 @@
             148,
             254
         ],
-        "alloyed-transmuter-code-ids": [814],
+        "alloyed-transmuter-code-ids": [814, 867],
         "orderbook-code-ids": [885],
         "general-cosmwasm-code-ids": [
             503,

--- a/tests/chain_service.py
+++ b/tests/chain_service.py
@@ -1,0 +1,34 @@
+import requests
+
+PUBLIC_CHAIN_ENDPOINT = "https://lcd.osmosis.zone"
+
+TAKER_FEE_URL = "/osmosis/poolmanager/v1beta1/trading_pair_takerfee"
+
+class ChainService:
+    def __init__(self):
+        self.url = PUBLIC_CHAIN_ENDPOINT
+        self.taker_fee_map = {}
+
+    def get_trading_pair_taker_fee(self, denom0, denom1):
+        """
+        Fetches the trading pair taker fee by denoms and caches them
+
+        Raises error if non-200 is returned from the endpoint.
+        """
+
+        sortedDenoms = sorted([denom0, denom1])
+        
+        taker_fee = self.taker_fee_map.get((denom0, denom1), None)
+        if taker_fee is not None:
+            return taker_fee
+
+        response = requests.get(self.url + TAKER_FEE_URL, params={"denom_0": sortedDenoms[0], "denom_1": sortedDenoms[1]})
+
+        if response.status_code != 200:
+            raise Exception(f"Error fetching config: {response.text}")
+
+        taker_fee = response.json()
+
+        self.taker_fee_map[(denom0, denom1)] = taker_fee
+
+        return taker_fee

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from constants import *
 from rand_util import construct_token_in_combos
 from coingecko_service import *
 from constants import *
+from chain_service import ChainService
 from util import *
 from decimal import *
 
@@ -78,6 +79,8 @@ SERVICE_MAP = {
     SQS_PROD: SERVICE_SQS_PROD,
     SQS_LOCAL: SERVICE_SQS_LOCAL
 }
+
+CHAIN_SERVICE = ChainService()
 
 # Numia pool type constants using an Enum
 class NumiaPoolType(Enum):
@@ -285,7 +288,6 @@ def create_chain_denom_to_data_map(tokens_data):
 
 def get_token_data_copy():
     """Return deep copy of all tokens from shared_test_state."""
-    global all_tokens_data
     return copy.deepcopy(shared_test_state.all_tokens_data)
 
 
@@ -591,6 +593,9 @@ def pytest_sessionstart(session):
 
         # One Orderbook token pair [[pool_id, ['denom0', 'denom1']]]
         shared_test_state.orderbook_token_pair = choose_orderbook_pool_tokens_by_liq_asc(shared_test_state.pool_type_to_denoms, 1)
+
+        # Filter tokens data to only contain listed
+        shared_test_state.all_tokens_data = [token for token in shared_test_state.all_tokens_data if token['denom'] in shared_test_state.valid_listed_tokens]
 
         shared_test_state.misc_token_pairs = create_misc_token_pairs()
 


### PR DESCRIPTION
Fixes all outstanding integration test flakiness:
- Numia returning delisted tokens => filter to only consider listed in the integration tests
- Fee validation not accounting for spread factor removed from fees => query chain for taker fees to construct the expected value
- New alloyed pool code id missing => enable it 


One failure remaining that stems from Numia:
```
FAILED tests/test_pools.py::TestPools::test_pools_pool_liquidity_cap[http://localhost:9092-1264] - AssertionError: ID (1264) Pool liquidity cap was 161327 - expected 174541.1253716336, actual error 0.07570780435555248 error tolerance 0.07
```

Reported it [here](https://osmosis-network.slack.com/archives/C04M8FQ5Y2G/p1722019988645269).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded the set of identifiers for the alloyed transmuter, enhancing its functionality.
  - Introduced a new `ChainService` for fetching trading pair taker fees from the Osmosis blockchain, with caching to improve efficiency.
  
- **Bug Fixes**
  - Enhanced fee validation logic to ensure correct trading pair fees are being checked, improving the reliability of the quote validation process.

- **Chores**
  - Updated test setup to integrate the `ChainService` and refined token data management for better encapsulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->