### PR TITLE
feat: keyring

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,11 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/app",
+      "env": {
+        "OSMOSIS_KEYRING_PATH":"/root/.osmosisd/keyring-test",
+        "OSMOSIS_KEYRING_PASSWORD": "test",
+	    "OSMOSIS_KEYRING_KEY_NAME": "local.info"
+      },
       "args": [
         "--config",
         "config.json",

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/cache"
+	"github.com/osmosis-labs/sqs/domain/keyring"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/middleware"
@@ -217,7 +218,15 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 		// TODO: move to config.
 		const isOrderBookFillerPluginEnabled = true
 		if isOrderBookFillerPluginEnabled {
-			orderbookFillerPlugin := orderbookfiller.New(poolsUseCase, routerUsecase, tokensUseCase, logger)
+			// Create keyring
+			keyring, err := keyring.New()
+			if err != nil {
+				return nil, err
+			}
+
+			logger.Info("Using keyring with address", zap.Stringer("address", keyring.GetAddress()))
+
+			orderbookFillerPlugin := orderbookfiller.New(poolsUseCase, routerUsecase, tokensUseCase, keyring, logger)
 			ingestUseCase.RegisterEndBlockProcessPlugin(orderbookFillerPlugin)
 		}
 

--- a/domain/keyring/osmosis_keyring.go
+++ b/domain/keyring/osmosis_keyring.go
@@ -1,0 +1,94 @@
+package keyring
+
+import (
+	"os"
+
+	"github.com/99designs/keyring"
+	sdkkeyring "github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// Keyring is the interface for the keyring
+type Keyring interface {
+
+	// GetKey returns the private key
+	GetKey() secp256k1.PrivKey
+
+	// GetAddress returns the address
+	GetAddress() sdk.AccAddress
+
+	// GetPubKey returns the public key
+	GetPubKey() cryptotypes.PubKey
+}
+
+type keyringImpl struct {
+	Key secp256k1.PrivKey
+}
+
+const (
+	keyringServiceName = "cosmos"
+
+	osmosisKeyringPathEnvName     = "OSMOSIS_KEYRING_PATH"
+	osmosisKeyringPasswordEnvName = "OSMOSIS_KEYRING_PASSWORD"
+	osmosisKeyringKeyNameEnvName  = "OSMOSIS_KEYRING_KEY_NAME"
+)
+
+var _ Keyring = &keyringImpl{}
+
+func New() (*keyringImpl, error) {
+
+	keyringConfig := keyring.Config{
+		ServiceName:              keyringServiceName,
+		FileDir:                  os.Getenv(osmosisKeyringPathEnvName),
+		KeychainTrustApplication: true,
+		FilePasswordFunc: func(prompt string) (string, error) {
+			return os.Getenv(osmosisKeyringPasswordEnvName), nil
+		},
+	}
+
+	// Open the keyring
+	openKeyring, err := keyring.Open(keyringConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the keyring record
+	openRecord, err := openKeyring.Get(os.Getenv(osmosisKeyringKeyNameEnvName))
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the keyring record
+	keyringRecord := new(sdkkeyring.Record)
+	if err := keyringRecord.Unmarshal(openRecord.Data); err != nil {
+		return nil, err
+	}
+
+	// Get the right type
+	localRecord := keyringRecord.GetLocal()
+
+	// Unmarshal the private key
+	privKey := secp256k1.PrivKey{}
+	if err := privKey.Unmarshal(localRecord.PrivKey.Value); err != nil {
+		return nil, err
+
+	}
+
+	return &keyringImpl{
+		Key: privKey,
+	}, nil
+}
+
+func (k keyringImpl) GetKey() secp256k1.PrivKey {
+	return k.Key
+}
+
+func (k keyringImpl) GetAddress() sdk.AccAddress {
+	return sdk.AccAddress(k.Key.PubKey().Address())
+}
+
+func (k keyringImpl) GetPubKey() cryptotypes.PubKey {
+	return k.Key.PubKey()
+}

--- a/ingest/usecase/plugins/orderbookfiller/ordebook_filler_ingest_plugin.go
+++ b/ingest/usecase/plugins/orderbookfiller/ordebook_filler_ingest_plugin.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/domain/keyring"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	"github.com/osmosis-labs/sqs/log"
 	"go.uber.org/zap"
@@ -15,22 +16,33 @@ type orderbookFillerIngestPlugin struct {
 	routerUseCase mvc.RouterUsecase
 	tokensUseCase mvc.TokensUsecase
 
+	keyring keyring.Keyring
+
 	logger log.Logger
 }
 
 var _ domain.EndBlockProcessPlugin = &orderbookFillerIngestPlugin{}
 
-func New(poolsUseCase mvc.PoolsUsecase, routerUseCase mvc.RouterUsecase, tokensUseCase mvc.TokensUsecase, logger log.Logger) *orderbookFillerIngestPlugin {
+func New(poolsUseCase mvc.PoolsUsecase, routerUseCase mvc.RouterUsecase, tokensUseCase mvc.TokensUsecase, keyring keyring.Keyring, logger log.Logger) *orderbookFillerIngestPlugin {
 	return &orderbookFillerIngestPlugin{
 		poolsUseCase:  poolsUseCase,
 		routerUseCase: routerUseCase,
 		tokensUseCase: tokensUseCase,
-		logger:        logger,
+
+		keyring: keyring,
+
+		logger: logger,
 	}
 }
 
 // ProcessEndBlock implements domain.EndBlockProcessPlugin.
 func (o *orderbookFillerIngestPlugin) ProcessEndBlock(ctx context.Context, blockHeight uint64, metadata domain.BlockPoolMetadata) error {
+
+	// TODO:
+	// do one swap using keyring
+	// Have an atomic.Bool, check if we the swap was done
+	// Swap 2000uosmo to validate that everything works end-to-end
+
 	o.logger.Info("processing end block in orderbook filler ingest plugin", zap.Uint64("block_height", blockHeight))
 	return nil
 }


### PR DESCRIPTION
```
osmosisd keys add local --recover --keyring-backend test
```

This creates a keyring for signing messages. Assumes that a key with the name `local` is created on test keyring. Updates `launch.json` with the relevant env variables necessary to start this.