### PR TITLE
fix: Orderbook blocks ingest panic

### DIFF
--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -314,7 +314,7 @@ func (p *poolsUseCase) StorePools(pools []sqsdomain.PoolI) error {
 		// If orderbook, update top liquidity pool for base and quote denom if it has higher liquidity capitalization.
 		sqsModel := pool.GetSQSPoolModel()
 		cosmWasmPoolModel := sqsModel.CosmWasmPoolModel
-		if cosmWasmPoolModel != nil && cosmWasmPoolModel.IsOrderbook() {
+		if cosmWasmPoolModel != nil && cosmWasmPoolModel.Data.Orderbook != nil && cosmWasmPoolModel.IsOrderbook() {
 			baseDenom := cosmWasmPoolModel.Data.Orderbook.BaseDenom
 			quoteDenom := cosmWasmPoolModel.Data.Orderbook.QuoteDenom
 			poolLiquidityCapitalization := pool.GetLiquidityCap()


### PR DESCRIPTION
This pull request fixes panic that happens during storing of orderbook pools. Please see a log for reproducing bug on `v25.x` branch below.

```
❯ git branch --show-current
v25.x
❯ make run
go run -ldflags="-X github.com/osmosis-labs/sqs/version=25.5.0-10-gb40ab653" app/*.go  --config config.json
configPath config.json
hostName sqs
1.7222559946856668e+09  info    log level       {"is_debug": false, "log_level": "info"}
1.7222559946857095e+09  info    Starting sidecar query server
1.722255994875756e+09   info    Starting sidecar query server   {"address": ":9092"}

   ____    __
  / __/___/ /  ___
 / _// __/ _ \/ _ \
/___/\__/_//_/\___/ v4.12.0
High performance, minimalist Go web framework
https://echo.labstack.com
____________________________________O/_______
                                    O\
1.7222559948758118e+09  info    Starting grpc ingest server
1.7222559948758402e+09  info    Starting profiling server
⇨ http server started on [::]:9092
1.7222559960038772e+09  info    setting first block height      {"height": 18594143}
1.7222559960039263e+09  info    starting block processing       {"height": 18594143}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x2409f95]

goroutine 79 [running]:
github.com/osmosis-labs/sqs/pools/usecase.(*poolsUseCase).StorePools(0xc0011d01a0, {0xc002e8c008?, 0x5b49520?, 0xc0018e2008?})
        /home/deividas/go/src/github.com/deividaspetraitis/sqs/pools/usecase/pools_usecase.go:318 +0x155
github.com/osmosis-labs/sqs/ingest/usecase.(*ingestUseCase).ProcessBlockData(0xc001438210, {0x41901b0, 0x5b49520}, 0x11bb95f, 0xc000d9f0e0, {0xc0018e2008, 0x7a5, 0x8ff})
        /home/deividas/go/src/github.com/deividaspetraitis/sqs/ingest/usecase/ingest_usecase.go:121 +0x370
github.com/osmosis-labs/sqs/ingest/delivery/grpc.(*IngestGRPCHandler).ProcessBlock.func1()
        /home/deividas/go/src/github.com/deividaspetraitis/sqs/ingest/delivery/grpc/ingest_grpc_handler.go:75 +0x57
github.com/osmosis-labs/sqs/domain/workerpool.Worker[...].Start.func1()
        /home/deividas/go/src/github.com/deividaspetraitis/sqs/domain/workerpool/worker_pool.go:45 +0x67
created by github.com/osmosis-labs/sqs/domain/workerpool.Worker[...].Start in goroutine 62
        /home/deividas/go/src/github.com/deividaspetraitis/sqs/domain/workerpool/worker_pool.go:36 +0xca
exit status 2
make: *** [Makefile:40: run] Error 1
~/go/src/github.com/deividaspetraitis/sqs on v25.x ⇡20 !2 ?370 ❯                                                                                                                                                  took 7s at 15:26:36
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling by ensuring that the application checks for the presence of the `Orderbook` before accessing related data, enhancing stability and preventing potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->