### PR TITLE
Add a float coins map

### DIFF
--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -736,12 +736,12 @@ func (r *routerUseCaseImpl) GetRouterState() (domain.RouterState, error) {
 
 // formatRouteCacheKey formats the given token in and token out denoms to a string.
 func formatRouteCacheKey(tokenInDenom string, tokenOutDenom string) string {
-	return fmt.Sprintf("%s%s%s", tokenInDenom, denomSeparatorChar, tokenOutDenom)
+	return fmt.Sprintf("%s|%s", tokenInDenom, tokenOutDenom)
 }
 
 // formatRankedRouteCacheKey formats the given token in and token out denoms and order of magnitude to a string.
 func formatRankedRouteCacheKey(tokenInDenom string, tokenOutDenom string, tokenIOrderOfMagnitude int) string {
-	return fmt.Sprintf("%s%s%d", formatRouteCacheKey(tokenInDenom, tokenOutDenom), denomSeparatorChar, tokenIOrderOfMagnitude)
+	return fmt.Sprintf("%s|%d", formatRouteCacheKey(tokenInDenom, tokenOutDenom), tokenIOrderOfMagnitude)
 }
 
 // formatCandidateRouteCacheKey formats the given token in and token out denoms to a string.

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -54,7 +54,7 @@ const (
 	// for candidate route cache, there is no order of magnitude
 	noOrderOfMagnitude = ""
 
-	denomSeparatorChar = "|"
+	// denomSeparatorChar = "|"
 )
 
 var (

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -54,7 +54,7 @@ const (
 	// for candidate route cache, there is no order of magnitude
 	noOrderOfMagnitude = ""
 
-	// denomSeparatorChar = "|"
+	denomSeparatorChar = "|"
 )
 
 var (
@@ -736,12 +736,12 @@ func (r *routerUseCaseImpl) GetRouterState() (domain.RouterState, error) {
 
 // formatRouteCacheKey formats the given token in and token out denoms to a string.
 func formatRouteCacheKey(tokenInDenom string, tokenOutDenom string) string {
-	return fmt.Sprintf("%s|%s", tokenInDenom, tokenOutDenom)
+	return fmt.Sprintf("%s%s%s", tokenInDenom, denomSeparatorChar, tokenOutDenom)
 }
 
 // formatRankedRouteCacheKey formats the given token in and token out denoms and order of magnitude to a string.
 func formatRankedRouteCacheKey(tokenInDenom string, tokenOutDenom string, tokenIOrderOfMagnitude int) string {
-	return fmt.Sprintf("%s|%d", formatRouteCacheKey(tokenInDenom, tokenOutDenom), tokenIOrderOfMagnitude)
+	return fmt.Sprintf("%s%s%d", formatRouteCacheKey(tokenInDenom, tokenOutDenom), denomSeparatorChar, tokenIOrderOfMagnitude)
 }
 
 // formatCandidateRouteCacheKey formats the given token in and token out denoms to a string.

--- a/sqsutil/floatcoin.go
+++ b/sqsutil/floatcoin.go
@@ -1,0 +1,107 @@
+package sqsutil
+
+import (
+	"math/big"
+
+	sdkmath "cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tidwall/btree"
+)
+
+type FloatCoin struct {
+	// The name of the coin
+	Denom string `json:"denom"`
+	// The symbol of the coin
+	Amount float64 `json:"amount"`
+}
+
+type RoundingMode int
+
+const (
+	RoundDown RoundingMode = iota
+	RoundUp
+	RoundUnspecified
+)
+
+type FloatCoinsMap struct {
+	*btree.Map[string, float64]
+}
+
+func NewFloatCoinsMap() *FloatCoinsMap {
+	return &FloatCoinsMap{btree.NewMap[string, float64](4)}
+}
+
+// Mutative methods
+func (m *FloatCoinsMap) Add(denom string, amount float64) {
+	amt, ok := m.Get(denom)
+	newAmt := amount
+	if ok {
+		newAmt = amt + amount
+	}
+
+	if newAmt == 0 {
+		m.Delete(denom)
+	} else {
+		m.Set(denom, newAmt)
+	}
+}
+
+// Mutative
+func (m *FloatCoinsMap) Sub(denom string, amount float64) {
+	amt, ok := m.Get(denom)
+	newAmt := -amount
+	if ok {
+		newAmt = amt - amount
+	}
+
+	if newAmt == 0 {
+		m.Delete(denom)
+	} else {
+		m.Set(denom, newAmt)
+	}
+}
+
+func (m *FloatCoinsMap) ToSortedList() []FloatCoin {
+	coins := make([]FloatCoin, 0, m.Len())
+	m.Scan(func(denom string, amount float64) bool {
+		coins = append(coins, FloatCoin{Denom: denom, Amount: amount})
+		return true
+	})
+	return coins
+}
+
+var oneInt = big.NewInt(1)
+
+func floatToBigInt(scratchFloat *big.Float, amount float64, roundingMode RoundingMode) *big.Int {
+	bigAmount := scratchFloat.SetFloat64(amount)
+
+	bigInt := new(big.Int)
+	bigInt, accuracy := bigAmount.Int(bigInt)
+
+	switch roundingMode {
+	case RoundDown:
+		// do nothing, rounds down by default
+	case RoundUp:
+		if accuracy != big.Exact {
+			bigInt.Add(bigInt, oneInt)
+		}
+	case RoundUnspecified:
+		// No rounding specified, use the default rounding mode
+	}
+
+	return bigInt
+}
+
+func (m *FloatCoinsMap) ToSdkCoins(r RoundingMode) sdk.Coins {
+	coins := make([]sdk.Coin, 0, m.Len())
+	scratchFloat := new(big.Float)
+	m.Scan(func(denom string, amount float64) bool {
+		amt := floatToBigInt(scratchFloat, amount, r)
+		amtInt := sdkmath.NewIntFromBigIntMut(amt)
+		if amt.Sign() != 0 {
+			coins = append(coins, sdk.Coin{Denom: denom, Amount: amtInt})
+		}
+		return true
+	})
+	return coins
+}

--- a/sqsutil/floatcoin_test.go
+++ b/sqsutil/floatcoin_test.go
@@ -1,0 +1,90 @@
+package sqsutil
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func baseFloatCoinsMap() *FloatCoinsMap {
+	// Create a new FloatCoinsMap
+	fcm := NewFloatCoinsMap()
+
+	// Add some coins to the map
+	fcm.Add("BTC", 1.5)
+	fcm.Add("ETH", 2.3)
+	fcm.Add("SOL", 3)
+	fcm.Add("XRP", 0.8)
+	return fcm
+}
+
+func TestFloatCoinsMap_ToSortedList(t *testing.T) {
+	// Create a new FloatCoinsMap
+	fcm := baseFloatCoinsMap()
+
+	// Get the sorted list of coins
+	coins := fcm.ToSortedList()
+
+	// Check the length of the sorted list
+	if len(coins) != 4 {
+		t.Errorf("Expected sorted list length to be 3, got %d", len(coins))
+	}
+
+	// Check the order of the coins in the sorted list
+	expectedCoins := []FloatCoin{
+		{Denom: "BTC", Amount: 1.5},
+		{Denom: "ETH", Amount: 2.3},
+		{Denom: "SOL", Amount: 3},
+		{Denom: "XRP", Amount: 0.8},
+	}
+	for i, coin := range coins {
+		if coin != expectedCoins[i] {
+			t.Errorf("Expected coin at index %d to be %v, got %v", i, expectedCoins[i], coin)
+		}
+	}
+}
+func TestFloatCoinsMap_ToSdkCoins(t *testing.T) {
+	tests := []struct {
+		name          string
+		coinsMap      *FloatCoinsMap
+		expectedCoins []sdk.Coin
+		rounding      RoundingMode
+	}{
+		{
+			name:     "Round down",
+			coinsMap: baseFloatCoinsMap(),
+			expectedCoins: []sdk.Coin{
+				{Denom: "BTC", Amount: sdk.NewInt(1)},
+				{Denom: "ETH", Amount: sdk.NewInt(2)},
+				{Denom: "SOL", Amount: sdk.NewInt(3)},
+			},
+			rounding: RoundDown,
+		},
+		{
+			name:     "Round up",
+			coinsMap: baseFloatCoinsMap(),
+			expectedCoins: []sdk.Coin{
+				{Denom: "BTC", Amount: sdk.NewInt(2)},
+				{Denom: "ETH", Amount: sdk.NewInt(3)},
+				{Denom: "SOL", Amount: sdk.NewInt(3)},
+				{Denom: "XRP", Amount: sdk.NewInt(1)},
+			},
+			rounding: RoundUp,
+		}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			coins := tt.coinsMap.ToSdkCoins(tt.rounding)
+
+			if len(coins) != len(tt.expectedCoins) {
+				t.Errorf("Expected SDK coins length to be %d, got %d", len(tt.expectedCoins), len(coins))
+			}
+
+			for i, coin := range coins {
+				if !coin.Equal(tt.expectedCoins[i]) {
+					t.Errorf("Expected SDK coin at index %d to be %v, got %v", i, tt.expectedCoins[i], coin)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `FloatCoinsMap` functionality for managing floating-point currency denominations.
	- Added methods for adding, subtracting amounts, and converting to sorted lists and SDK coin formats.
	- Implemented rounding options for currency conversions.

- **Tests**
	- Created unit tests for `FloatCoinsMap` to ensure correct functionality and integration with SDK coins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->