### PR TITLE
GetPools: add min capitalization filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - Mitigate the alloy rebalancing router breakage by invalidating route cache if all routes fail and ordering denoms by balances.
 - Prioritize canonical orderbook in router and caches
+- Add liquidity filter to pools query
 
 ## v25.5.0
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -61,6 +61,12 @@ const docTemplate = `{
                         "description": "Comma-separated list of pool IDs to fetch, e.g., '1,2,3'",
                         "name": "IDs",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Minimum pool liquidity cap",
+                        "name": "min_liquidity_cap",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -52,6 +52,12 @@
                         "description": "Comma-separated list of pool IDs to fetch, e.g., '1,2,3'",
                         "name": "IDs",
                         "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Minimum pool liquidity cap",
+                        "name": "min_liquidity_cap",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -98,6 +98,10 @@ paths:
         in: query
         name: IDs
         type: string
+      - description: Minimum pool liquidity cap
+        in: query
+        name: min_liquidity_cap
+        type: integer
       produces:
       - application/json
       responses:

--- a/domain/mocks/pool_handler_mock.go
+++ b/domain/mocks/pool_handler_mock.go
@@ -3,7 +3,6 @@ package mocks
 import (
 	"cosmossdk.io/math"
 	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	"github.com/osmosis-labs/sqs/sqsdomain"
@@ -37,14 +36,14 @@ func (p *PoolHandlerMock) GetPools(opts ...domain.PoolsOption) ([]sqsdomain.Pool
 	if len(options.PoolIDFilter) > 0 {
 		for _, id := range options.PoolIDFilter {
 			for _, pool := range p.Pools {
-				if pool.GetId() == id && pool.GetLiquidityCap().GTE(osmomath.NewInt(options.MinPoolLiquidityCap)) {
+				if pool.GetId() == id {
 					result = append(result, pool)
 				}
 			}
 		}
 	} else {
 		for _, pool := range p.Pools {
-			if pool.GetLiquidityCap().GTE(osmomath.NewInt(options.MinPoolLiquidityCap)) {
+			if pool.GetLiquidityCap().Uint64() > options.MinPoolLiquidityCap {
 				result = append(result, pool)
 			}
 		}

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -19,7 +19,7 @@ var _ mvc.PoolsUsecase = &PoolsUsecaseMock{}
 
 type PoolsUsecaseMock struct {
 	GetAllPoolsFunc             func() ([]sqsdomain.PoolI, error)
-	GetPoolsFunc                func(poolIDs []uint64) ([]sqsdomain.PoolI, error)
+	GetPoolsFunc                func(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, error)
 	StorePoolsFunc              func(pools []sqsdomain.PoolI) error
 	GetRoutesFromCandidatesFunc func(candidateRoutes sqsdomain.CandidateRoutes, tokenInDenom, tokenOutDenom string) ([]route.RouteImpl, error)
 	GetTickModelMapFunc         func(poolIDs []uint64) (map[uint64]*sqsdomain.TickModel, error)
@@ -68,9 +68,9 @@ func (pm *PoolsUsecaseMock) GetCosmWasmPoolConfig() domain.CosmWasmPoolRouterCon
 }
 
 // GetPools implements mvc.PoolsUsecase.
-func (pm *PoolsUsecaseMock) GetPools(poolIDs []uint64) ([]sqsdomain.PoolI, error) {
+func (pm *PoolsUsecaseMock) GetPools(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, error) {
 	if pm.GetPoolsFunc != nil {
-		return pm.GetPoolsFunc(poolIDs)
+		return pm.GetPoolsFunc(opts...)
 	}
 	panic("unimplemented")
 }

--- a/domain/mvc/pools.go
+++ b/domain/mvc/pools.go
@@ -47,7 +47,7 @@ type PoolsUsecase interface {
 
 type PoolHandler interface {
 	// GetPools returns the pools corresponding to the given IDs.
-	GetPools(poolIDs []uint64) ([]sqsdomain.PoolI, error)
+	GetPools(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, error)
 
 	// StorePools stores the given pools in the usecase
 	StorePools(pools []sqsdomain.PoolI) error

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -66,3 +66,19 @@ type CanonicalOrderBooksResult struct {
 	PoolID          uint64 `json:"pool_id"`
 	ContractAddress string `json:"contract_address"`
 }
+
+type PoolsOptions struct {
+	MinPoolLiquidityCap uint64
+	PoolIDFilter        []uint64
+}
+
+// RouterOption configures the router options.
+type PoolsOption func(*PoolsOptions)
+
+// WithMinPooslLiquidityCap configures the router options with the min pool liquidity
+// capitalization.
+func WithMinPoolsLiquidityCap(minPoolLiquidityCap uint64) PoolsOption {
+	return func(o *PoolsOptions) {
+		o.MinPoolLiquidityCap = minPoolLiquidityCap
+	}
+}

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -68,7 +68,7 @@ type CanonicalOrderBooksResult struct {
 }
 
 type PoolsOptions struct {
-	MinPoolLiquidityCap int64
+	MinPoolLiquidityCap uint64
 	PoolIDFilter        []uint64
 }
 
@@ -77,7 +77,7 @@ type PoolsOption func(*PoolsOptions)
 
 // WithMinPooslLiquidityCap configures with the min pool liquidity
 // capitalization.
-func WithMinPoolsLiquidityCap(minPoolLiquidityCap int64) PoolsOption {
+func WithMinPoolsLiquidityCap(minPoolLiquidityCap uint64) PoolsOption {
 	return func(o *PoolsOptions) {
 		o.MinPoolLiquidityCap = minPoolLiquidityCap
 	}

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -68,16 +68,16 @@ type CanonicalOrderBooksResult struct {
 }
 
 type PoolsOptions struct {
-	MinPoolLiquidityCap uint64
+	MinPoolLiquidityCap int64
 	PoolIDFilter        []uint64
 }
 
 // RouterOption configures the router options.
 type PoolsOption func(*PoolsOptions)
 
-// WithMinPooslLiquidityCap configures the router options with the min pool liquidity
+// WithMinPooslLiquidityCap configures with the min pool liquidity
 // capitalization.
-func WithMinPoolsLiquidityCap(minPoolLiquidityCap uint64) PoolsOption {
+func WithMinPoolsLiquidityCap(minPoolLiquidityCap int64) PoolsOption {
 	return func(o *PoolsOptions) {
 		o.MinPoolLiquidityCap = minPoolLiquidityCap
 	}

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -72,7 +72,7 @@ type PoolsOptions struct {
 	PoolIDFilter        []uint64
 }
 
-// RouterOption configures the router options.
+// PoolsOption configures the pools filter options.
 type PoolsOption func(*PoolsOptions)
 
 // WithMinPooslLiquidityCap configures with the min pool liquidity
@@ -80,5 +80,12 @@ type PoolsOption func(*PoolsOptions)
 func WithMinPoolsLiquidityCap(minPoolLiquidityCap int64) PoolsOption {
 	return func(o *PoolsOptions) {
 		o.MinPoolLiquidityCap = minPoolLiquidityCap
+	}
+}
+
+// WithPoolIDFilter configures the pools options with the pool ID filter.
+func WithPoolIDFilter(poolIDFilter []uint64) PoolsOption {
+	return func(o *PoolsOptions) {
+		o.PoolIDFilter = poolIDFilter
 	}
 }

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -63,6 +63,7 @@ func NewPoolsHandler(e *echo.Echo, us mvc.PoolsUsecase) {
 // @ID get-pools
 // @Produce  json
 // @Param  IDs  query  string  false  "Comma-separated list of pool IDs to fetch, e.g., '1,2,3'"
+// @Param  min_liquidity_cap  query  int  false  "Minimum pool liquidity cap"
 // @Success 200  {array}  sqsdomain.PoolI  "List of pool(s) details"
 // @Router /pools [get]
 func (a *PoolsHandler) GetPools(c echo.Context) error {

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -76,36 +76,28 @@ func (a *PoolsHandler) GetPools(c echo.Context) error {
 		err   error
 	)
 
-	// if IDs are not given, get all pools
-	if len(poolIDsStr) == 0 {
-		pools, err = a.PUsecase.GetAllPools()
-		if err != nil {
-			return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
-		}
-	} else {
-		// Parse them to numbers
-		poolIDs, err := domain.ParseNumbers(poolIDsStr)
-		if err != nil {
-			return c.JSON(http.StatusBadRequest, ResponseError{Message: err.Error()})
-		}
+	// Parse numbers
+	poolIDs, err := domain.ParseNumbers(poolIDsStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ResponseError{Message: err.Error()})
+	}
 
-		// Parse min liquidity cap if provided
-		var minLiquidityCap int64
-		if minLiquidityCapStr != "" {
-			minLiquidityCap, err = strconv.ParseInt(minLiquidityCapStr, 10, 64)
-			if err != nil {
-				return c.JSON(http.StatusBadRequest, ResponseError{Message: "Invalid min_liquidity_cap value"})
-			}
-		}
-
-		// Get pools
-		pools, err = a.PUsecase.GetPools(
-			domain.WithMinPoolsLiquidityCap(minLiquidityCap),
-			domain.WithPoolIDFilter(poolIDs),
-		)
+	// Parse min liquidity cap if provided
+	var minLiquidityCap int64
+	if minLiquidityCapStr != "" {
+		minLiquidityCap, err = strconv.ParseInt(minLiquidityCapStr, 10, 64)
 		if err != nil {
-			return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
+			return c.JSON(http.StatusBadRequest, ResponseError{Message: "Invalid min_liquidity_cap value"})
 		}
+	}
+
+	// Get pools
+	pools, err = a.PUsecase.GetPools(
+		domain.WithMinPoolsLiquidityCap(minLiquidityCap),
+		domain.WithPoolIDFilter(poolIDs),
+	)
+	if err != nil {
+		return c.JSON(getStatusCode(err), ResponseError{Message: err.Error()})
 	}
 
 	// Convert pools to the appropriate format

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -83,9 +83,9 @@ func (a *PoolsHandler) GetPools(c echo.Context) error {
 	}
 
 	// Parse min liquidity cap if provided
-	var minLiquidityCap int64
+	var minLiquidityCap uint64
 	if minLiquidityCapStr != "" {
-		minLiquidityCap, err = strconv.ParseInt(minLiquidityCapStr, 10, 64)
+		minLiquidityCap, err = strconv.ParseUint(minLiquidityCapStr, 10, 64)
 		if err != nil {
 			return c.JSON(http.StatusBadRequest, ResponseError{Message: "Invalid min_liquidity_cap value"})
 		}

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -304,30 +304,28 @@ func (p *poolsUseCase) GetPools(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, 
 
 	pools := []sqsdomain.PoolI{}
 
+	var poolIDs []uint64
 	if len(options.PoolIDFilter) > 0 {
-		for _, poolID := range options.PoolIDFilter {
-			pool, err := p.GetPool(poolID)
-			if err != nil {
-				return nil, err
-			}
-
-			if pool.GetLiquidityCap().GTE(osmomath.NewInt(options.MinPoolLiquidityCap)) {
-				pools = append(pools, pool)
-			}
-		}
+		poolIDs = options.PoolIDFilter
 	} else {
 		p.pools.Range(func(key, value interface{}) bool {
 			pool, ok := value.(sqsdomain.PoolI)
-			if !ok {
-				return false
+			if ok {
+				poolIDs = append(poolIDs, pool.GetId())
 			}
-
-			if pool.GetLiquidityCap().GTE(osmomath.NewInt(options.MinPoolLiquidityCap)) {
-				pools = append(pools, pool)
-			}
-
 			return true
 		})
+	}
+
+	for _, poolID := range poolIDs {
+		pool, err := p.GetPool(poolID)
+		if err != nil {
+			return nil, err
+		}
+
+		if pool.GetLiquidityCap().GTE(osmomath.NewInt(options.MinPoolLiquidityCap)) {
+			pools = append(pools, pool)
+		}
 	}
 
 	return pools, nil

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -292,19 +292,34 @@ func (p *poolsUseCase) getTicksAndSetTickModelIfConcentrated(pool sqsdomain.Pool
 }
 
 // GetPools implements mvc.PoolsUsecase.
-func (p *poolsUseCase) GetPools(poolIDs []uint64) ([]sqsdomain.PoolI, error) {
-	pools := make([]sqsdomain.PoolI, 0, len(poolIDs))
-
-	for _, poolID := range poolIDs {
-		pool, err := p.GetPool(poolID)
-		if err != nil {
-			return nil, err
-		}
-
-		pools = append(pools, pool)
+func (p *poolsUseCase) GetPools(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, error) {
+	options := domain.PoolsOptions{
+		MinPoolLiquidityCap: 0,
+		PoolIDFilter:        []uint64{},
 	}
 
-	return pools, nil
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	if len(options.PoolIDFilter) > 0 {
+		pools := make([]sqsdomain.PoolI, 0, len(options.PoolIDFilter))
+
+		for _, poolID := range options.PoolIDFilter {
+			pool, err := p.GetPool(poolID)
+			if err != nil {
+				return nil, err
+			}
+
+			pools = append(pools, pool)
+		}
+
+		return pools, nil
+	}
+
+	// TODO: min filter logic
+
+	return nil, nil
 }
 
 // StorePools implements mvc.PoolsUsecase.

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -545,6 +545,35 @@ func (s *PoolsUsecaseTestSuite) TestCalcExitCFMMPool_HappyPath() {
 	s.Require().False(actualCoins.Empty())
 }
 
+func (s *PoolsUsecaseTestSuite) TestGetPools() {
+	mainnetState := s.SetupMainnetState()
+
+	usecase := s.SetupRouterAndPoolsUsecase(mainnetState)
+
+	// No filter
+	pools, err := usecase.Pools.GetPools()
+	s.Require().NoError(err)
+	s.Require().True(len(pools) > 1500)
+
+	// Pool 32 is garbage and has zero liq.
+	// Pools 1 and 1066 are major pools.
+	poolsFilter := []uint64{32, 1, 1066}
+
+	// Pool ID filter
+	pools, err = usecase.Pools.GetPools(domain.WithPoolIDFilter(poolsFilter))
+	s.Require().NoError(err)
+	s.Require().Len(pools, len(poolsFilter))
+
+	// Min liquidity cap filter
+	pools, err = usecase.Pools.GetPools(domain.WithMinPoolsLiquidityCap(1_000_000))
+	s.Require().NoError(err)
+	s.Require().True(len(pools) < 100)
+
+	pools, err = usecase.Pools.GetPools(domain.WithMinPoolsLiquidityCap(1), domain.WithPoolIDFilter(poolsFilter))
+	s.Require().NoError(err)
+	s.Require().Len(pools, 2)
+}
+
 func (s *PoolsUsecaseTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmConfig domain.CosmWasmPoolRouterConfig) domain.RoutablePool {
 	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
 		Config:                cosmWasmConfig,

--- a/router/usecase/worker/candidate_route_search_data_worker.go
+++ b/router/usecase/worker/candidate_route_search_data_worker.go
@@ -86,7 +86,9 @@ func (c *candidateRouteSearchDataWorker) compute(blockPoolMetaData domain.BlockP
 
 			denomPoolsIDs := domain.KeysFromMap(denomLiquidityData.Pools)
 
-			unsortedDenomPools, err := c.poolsHandler.GetPools(denomPoolsIDs)
+			unsortedDenomPools, err := c.poolsHandler.GetPools(
+				domain.WithPoolIDFilter(denomPoolsIDs),
+			)
 			if err != nil {
 				// TODO: add counter
 				c.logger.Error("failed to get pools in candidate route worker", zap.Error(err))

--- a/tokens/usecase/pricing/worker/pool_liquidity_pricer_worker.go
+++ b/tokens/usecase/pricing/worker/pool_liquidity_pricer_worker.go
@@ -207,7 +207,7 @@ func (p *poolLiquidityPricerWorker) hasLaterUpdateThanHeight(denom string, heigh
 func (p *poolLiquidityPricerWorker) repricePoolLiquidityCap(poolIDs map[uint64]struct{}, blockPriceUpdates domain.PricesResult) error {
 	blockPoolIDs := domain.KeysFromMap(poolIDs)
 
-	pools, err := p.poolHandler.GetPools(blockPoolIDs)
+	pools, err := p.poolHandler.GetPools(domain.WithPoolIDFilter(blockPoolIDs))
 	if err != nil {
 		return err
 	}

--- a/tokens/usecase/pricing/worker/pool_liquidity_pricer_worket_test.go
+++ b/tokens/usecase/pricing/worker/pool_liquidity_pricer_worket_test.go
@@ -873,7 +873,7 @@ func (s *PoolLiquidityComputeWorkerSuite) TestRepricePoolLiquidityCap() {
 			}
 
 			// Get pools
-			actualPools, err := poolHandlerMock.GetPools(expectedPoolIDs)
+			actualPools, err := poolHandlerMock.GetPools(domain.WithPoolIDFilter(expectedPoolIDs))
 			s.Require().Equal(len(tt.expectedLiquidityResultByID), len(poolHandlerMock.Pools))
 
 			// Validate that liquidity cap is set correctly on each pool


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new query parameter `min_liquidity_cap` to enhance API functionality, allowing users to filter pool queries based on minimum liquidity cap.
	- Added flexible input options for retrieving pools through new configuration structures and options.

- **Bug Fixes**
	- Improved error handling for the new `min_liquidity_cap` parameter in API requests.

- **Documentation**
	- Updated API documentation to reflect the addition of the `min_liquidity_cap` query parameter and its usage.
	- Enhanced routing logic documentation for better clarity on liquidity filtering functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->