### PR TITLE
fix bug applying invalid pool liquidity filter in the liquidity pricing pipeline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - Mitigate the alloy rebalancing router breakage by invalidating route cache if all routes fail and ordering denoms by balances.
 - Prioritize canonical orderbook in router and caches
 - Add liquidity filter to pools query
+- Fix bug applying invalid pool liquidity filter in the liquidity pricing pipeline.
 
 ## v25.5.0
 

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -70,6 +70,9 @@ type CanonicalOrderBooksResult struct {
 type PoolsOptions struct {
 	MinPoolLiquidityCap uint64
 	PoolIDFilter        []uint64
+	// HadEmptyFilter is true if the pool ID filter was empty.
+	// This signifies avoid getting all pools and rather exit early.
+	HadEmptyFilter bool
 }
 
 // PoolsOption configures the pools filter options.
@@ -86,6 +89,12 @@ func WithMinPoolsLiquidityCap(minPoolLiquidityCap uint64) PoolsOption {
 // WithPoolIDFilter configures the pools options with the pool ID filter.
 func WithPoolIDFilter(poolIDFilter []uint64) PoolsOption {
 	return func(o *PoolsOptions) {
+		// We should simply return early rather than attempting to get all pools.
+		if len(poolIDFilter) == 0 {
+			o.HadEmptyFilter = true
+			return
+		}
+
 		o.PoolIDFilter = poolIDFilter
 	}
 }

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -296,10 +296,15 @@ func (p *poolsUseCase) GetPools(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, 
 	options := domain.PoolsOptions{
 		MinPoolLiquidityCap: 0,
 		PoolIDFilter:        []uint64{},
+		HadEmptyFilter:      false,
 	}
 
 	for _, opt := range opts {
 		opt(&options)
+	}
+
+	if options.HadEmptyFilter {
+		return nil, nil
 	}
 
 	var (
@@ -316,7 +321,7 @@ func (p *poolsUseCase) GetPools(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, 
 			}
 
 			// Check filter is non-zero to avoid more expensive get liquidity cap check.
-			if pool.GetLiquidityCap().Uint64() >= options.MinPoolLiquidityCap {
+			if options.MinPoolLiquidityCap == 0 || pool.GetLiquidityCap().Uint64() >= options.MinPoolLiquidityCap {
 				pools = append(pools, pool)
 			}
 		}
@@ -326,7 +331,7 @@ func (p *poolsUseCase) GetPools(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, 
 		p.pools.Range(func(key, value interface{}) bool {
 			pool, ok := value.(sqsdomain.PoolI)
 			// Check filter is non-zero to avoid more expensive get liquidity cap check.
-			if ok && pool.GetLiquidityCap().Uint64() >= options.MinPoolLiquidityCap {
+			if ok && (options.MinPoolLiquidityCap == 0 || pool.GetLiquidityCap().Uint64() >= options.MinPoolLiquidityCap) {
 				pools = append(pools, pool)
 			}
 			return true

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -572,6 +572,11 @@ func (s *PoolsUsecaseTestSuite) TestGetPools() {
 	pools, err = usecase.Pools.GetPools(domain.WithMinPoolsLiquidityCap(1), domain.WithPoolIDFilter(poolsFilter))
 	s.Require().NoError(err)
 	s.Require().Len(pools, 2)
+
+	// Empty filter signifies returning nothing and exiting early
+	pools, err = usecase.Pools.GetPools(domain.WithPoolIDFilter([]uint64{}))
+	s.Require().NoError(err)
+	s.Require().Empty(pools)
 }
 
 func (s *PoolsUsecaseTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec) domain.RoutablePool {

--- a/tokens/usecase/pricing/worker/pool_liquidity_pricer_worker.go
+++ b/tokens/usecase/pricing/worker/pool_liquidity_pricer_worker.go
@@ -14,7 +14,6 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	"github.com/osmosis-labs/sqs/log"
-	"github.com/osmosis-labs/sqs/sqsdomain"
 	"go.uber.org/zap"
 )
 
@@ -209,17 +208,9 @@ func (p *poolLiquidityPricerWorker) hasLaterUpdateThanHeight(denom string, heigh
 func (p *poolLiquidityPricerWorker) repricePoolLiquidityCap(poolIDs map[uint64]struct{}, blockPriceUpdates domain.PricesResult) error {
 	blockPoolIDs := domain.KeysFromMap(poolIDs)
 
-	var (
-		pools []sqsdomain.PoolI
-		err   error
-	)
-
-	// Since empty block
-	if len(blockPoolIDs) == 0 {
-		pools, err = p.poolHandler.GetPools(domain.WithPoolIDFilter(blockPoolIDs))
-		if err != nil {
-			return err
-		}
+	pools, err := p.poolHandler.GetPools(domain.WithPoolIDFilter(blockPoolIDs))
+	if err != nil {
+		return err
 	}
 
 	for i, pool := range pools {


### PR DESCRIPTION
With the recent liquidity filter change, we accidentally changed the semantics of what it means to request an empty pool ID slice.

The original invariant meant empty pool IDs = no pools / no-op/

The new filter => empty pool IDs => all pools.

This broke the liquidity pricing pipeline. When no pools were modified in a block, we would provide an empty pool IDs slice to `GetPools`. This would return all pools with tokens that did not have prices in that block.

Therefore, we would mistakenly override pool liquidity capitalization with error that would completely nuke the router filtering.

## Testing

This was not caught by the integration test suite ran pre-merge likely because there was a series of blocks with modified pools.

However, overnight in staging a number of liquidity overrides happened for pools, exposing the bug. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with invalid pool liquidity filters affecting pricing calculations, improving the reliability of the liquidity management system.

- **New Features**
  - Introduced a `HadEmptyFilter` option to optimize pool fetching by avoiding unnecessary data retrieval when no specific pool IDs are provided.

- **Tests**
  - Added a test case to validate the behavior of pool filtering when an empty pool ID filter is applied, enhancing the robustness of the functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->