### PR TITLE
fix: liquidity truncation bug

### DIFF
--- a/tokens/usecase/pricing/worker/liquidity_pricer.go
+++ b/tokens/usecase/pricing/worker/liquidity_pricer.go
@@ -79,7 +79,7 @@ func (p *liquidityPricer) PriceBalances(balances sdk.Coins, prices domain.Prices
 			liquidityCapErrorStr += formatLiquidityCapErrorStr(denom)
 		}
 
-		totalCapitalization = totalCapitalization.Add(currentCapitalization.TruncateInt())
+		totalCapitalization = totalCapitalization.Add(currentCapitalization.Ceil().TruncateInt())
 	}
 
 	return totalCapitalization, liquidityCapErrorStr


### PR DESCRIPTION
We started noticing many integration test failures.

The identified source was candidate route search data pre-computation here:
https://github.com/osmosis-labs/sqs/blob/f02644ef250c2c72cd95b2ad46c3f44e33bc5523/ingest/usecase/ingest_usecase.go#L160-L164

It is needed since we want to recompute the search data upon repricing pool liquidities.

However, the pricing logic would truncate the pool liquidity capitalization for some of the pools with <$1 of value, breaking our test suite.

It is unclear why this small edge case resurfaced days after introducing the change. The current hunch is that due to new token launches.

The fix in this PR rounds up the pool liquidity cap instead of rounding down as to simplify this edge case handling in our test suite.

We've tested that this PR has fixed a large portion of the tests/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the calculation of total capitalization to provide more accurate pricing results by adjusting the rounding mechanism. 

- **Bug Fixes**
	- Improved the logic for total capitalization calculations which may affect downstream processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->