### PR TITLE
feat: Numia Pools APR fetcher, associated configs and wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+- Numia Pools APR fetcher, associated configs and wiring
+
 ## 25.7.0
 
 - Fix bug with filters n /pools API

--- a/app/sqs_config.go
+++ b/app/sqs_config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/osmosis-labs/sqs/domain"
+	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 )
 
 // DefaultConfig defines the default config for the sidecar query server.
@@ -44,5 +45,10 @@ var DefaultConfig = domain.Config{
 		MinPoolLiquidityCap:    50,
 		CoingeckoUrl:           "https://prices.osmosis.zone/api/v3/simple/price",
 		CoingeckoQuoteCurrency: "usd",
+	},
+
+	Passthrough: &passthroughdomain.PassthroughConfig{
+		NumiaURL:                "https://public-osmosis-api.numia.xyz",
+		APRFetchIntervalMinutes: 5,
 	},
 }

--- a/config-testnet.json
+++ b/config-testnet.json
@@ -53,6 +53,10 @@
         "coingecko-url": "https://prices.osmosis.zone/api/v3/simple/price",
         "coingecko-quote-currency": "usd"
     },
+    "passthrough":{
+        "numia-url": "https://public-osmosis-api.numia.xyz",
+        "apr-fetch-interval-minutes": 5
+    },
     "grpc-ingester": {
         "enabled": false,
         "max-receive-msg-size-bytes": 16777216,

--- a/config.json
+++ b/config.json
@@ -72,6 +72,10 @@
         "coingecko-quote-currency": "usd",
         "worker-min-pool-liquidity-cap": 1
     },
+    "passthrough":{
+        "numia-url": "https://public-osmosis-api.numia.xyz",
+        "apr-fetch-interval-minutes": 5
+    },
     "grpc-ingester":{
         "enabled": true,
         "max-receive-msg-size-bytes": 16777216,

--- a/domain/config.go
+++ b/domain/config.go
@@ -1,6 +1,10 @@
 package domain
 
-import "fmt"
+import (
+	"fmt"
+
+	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
+)
 
 // Config defines the config for the sidecar query server.
 type Config struct {
@@ -31,6 +35,9 @@ type Config struct {
 	Pools *PoolsConfig `mapstructure:"pools"`
 
 	Pricing *PricingConfig `mapstructure:"pricing"`
+
+	// Passthrough encapsulates the passthrough module config.
+	Passthrough *passthroughdomain.PassthroughConfig `mapstructure:"passthrough"`
 
 	// GRPC ingester server configuration.
 	GRPCIngester *GRPCIngesterConfig `mapstructure:"grpc-ingester"`

--- a/domain/passthrough/config.go
+++ b/domain/passthrough/config.go
@@ -1,0 +1,8 @@
+package passthroughdomain
+
+type PassthroughConfig struct {
+	// The url of the Numia data source.
+	NumiaURL string `mapstructure:"numia-url"`
+	// The interval at which the APR data is fetched.
+	APRFetchIntervalMinutes int `mapstructure:"apr-fetch-interval-minutes"`
+}

--- a/domain/passthrough/numia_http_client.go
+++ b/domain/passthrough/numia_http_client.go
@@ -1,0 +1,55 @@
+package passthroughdomain
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/osmosis-labs/sqs/sqsdomain/json"
+)
+
+type NumiaHTTPClient interface {
+	// GetPoolAPRsRange returns the APR data of the pools as ranges
+	GetPoolAPRsRange() ([]PoolAPR, error)
+}
+
+type NumiaHTTPClientImpl struct {
+	client *http.Client
+	url    string
+}
+
+var _ NumiaHTTPClient = &NumiaHTTPClientImpl{}
+
+const (
+	poolAPRRangeEndpoint = "/pools_apr_range"
+)
+
+func NewNumiaHTTPClient(url string) *NumiaHTTPClientImpl {
+	return &NumiaHTTPClientImpl{
+		client: &http.Client{},
+		url:    url,
+	}
+}
+
+// GetPoolAPRsRange implements NumiaHTTPClient.
+func (n *NumiaHTTPClientImpl) GetPoolAPRsRange() ([]PoolAPR, error) {
+	resp, err := n.client.Get(n.url + poolAPRRangeEndpoint)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the response body
+	var poolAPRs []PoolAPR
+	if err := json.Unmarshal(body, &poolAPRs); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal pool APRs: %w", err)
+	}
+
+	return poolAPRs, nil
+}

--- a/domain/passthrough/pool_apr.go
+++ b/domain/passthrough/pool_apr.go
@@ -1,0 +1,56 @@
+package passthroughdomain
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/osmosis-labs/sqs/sqsdomain/json"
+)
+
+// PoolDataRange represents the range of the pool APR data.
+type PoolDataRange struct {
+	Lower float64 `json:"lower"`
+	Upper float64 `json:"upper"`
+}
+
+// PoolAPR represents the APR data of the pool.
+type PoolAPR struct {
+	// PoolID represents the pool ID.
+	PoolID uint64 `json:"pool_id"`
+	// Swap Fees represents the swap fees.
+	SwapFees PoolDataRange `json:"swap_fees"`
+	// Superfluid APR represents the superfluid APR.
+	SuperfluidAPR PoolDataRange `json:"superfluid"`
+	// Osmosis APR represents the osmosis APR.
+	OsmosisAPR PoolDataRange `json:"osmosis"`
+	// Boost APR represents the boosted APR.
+	BoostAPR PoolDataRange `json:"boost"`
+	// Total APR represents the total APR.
+	TotalAPR PoolDataRange `json:"total"`
+}
+
+// UnmarshalJSON custom unmarshal method to handle PoolID as uint64.
+func (p *PoolAPR) UnmarshalJSON(data []byte) error {
+	// Create a temporary struct to unmarshal the data into.
+	type Alias PoolAPR
+	temp := &struct {
+		PoolID string `json:"pool_id"`
+		*Alias
+	}{
+		Alias: (*Alias)(p),
+	}
+
+	// Unmarshal the data into the temporary struct.
+	if err := json.Unmarshal(data, temp); err != nil {
+		return err
+	}
+
+	// Convert the PoolID from string to uint64.
+	id, err := strconv.ParseUint(temp.PoolID, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid pool_id: %w", err)
+	}
+	p.PoolID = id
+
+	return nil
+}

--- a/domain/telemetry.go
+++ b/domain/telemetry.go
@@ -70,6 +70,11 @@ var (
 	// * quote - the quote asset symbol
 	SQSPricingFallbackCounterMetricName = "sqs_pricing_fallback_total"
 
+	// sqs_passthrough_numia_aprs_fetch_error_total
+	//
+	// counter that measures the number of errors when fetching APRs from Numia in a passthrough module.
+	SQSPassthroughNumiaAPRsFetchErrorCounterMetricName = "sqs_passthrough_numia_aprs_fetch_error_total"
+
 	SQSIngestHandlerProcessBlockDurationGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: SQSIngestUsecaseProcessBlockDurationMetricName,
@@ -137,6 +142,14 @@ var (
 		},
 		[]string{"base", "quote"},
 	)
+
+	SQSPassthroughNumiaAPRsFetchErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: SQSPassthroughNumiaAPRsFetchErrorCounterMetricName,
+			Help: "Total number of errors when fetching APRs from Numia in a passthrough module.",
+		},
+		[]string{"base", "quote"},
+	)
 )
 
 func init() {
@@ -149,4 +162,5 @@ func init() {
 	prometheus.MustRegister(SQSUpdateAssetsAtHeightIntervalErrorCounter)
 	prometheus.MustRegister(SQSPricingErrorCounter)
 	prometheus.MustRegister(SQSPricingFallbackCounter)
+	prometheus.MustRegister(SQSPassthroughNumiaAPRsFetchErrorCounter)
 }

--- a/passthrough/usecase/passthrough_usecase.go
+++ b/passthrough/usecase/passthrough_usecase.go
@@ -14,6 +14,7 @@ import (
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/log"
+	"github.com/osmosis-labs/sqs/sqsutil/datafetchers"
 )
 
 type passthroughUseCase struct {
@@ -23,6 +24,8 @@ type passthroughUseCase struct {
 	defaultQuoteDenom     string
 	liquidityPricer       domain.LiquidityPricer
 	passthroughGRPCClient passthroughdomain.PassthroughGRPCClient
+
+	aprPrefetcher datafetchers.Fetcher[[]passthroughdomain.PoolAPR]
 
 	logger log.Logger
 }
@@ -348,6 +351,10 @@ func (p *passthroughUseCase) GetPortfolioAssets(ctx context.Context, address str
 	}
 
 	return finalResult, nil
+}
+
+func (p *passthroughUseCase) RegisterAPRFetcher(aprFetcher datafetchers.Fetcher[[]passthroughdomain.PoolAPR]) {
+	p.aprPrefetcher = aprFetcher
 }
 
 // computeCapitalizationForCoins instruments the coins with their liquiditiy capitalization values.

--- a/sqsutil/datafetchers/numia_apr_fetcher.go
+++ b/sqsutil/datafetchers/numia_apr_fetcher.go
@@ -1,0 +1,25 @@
+package datafetchers
+
+import (
+	"github.com/osmosis-labs/sqs/domain"
+	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
+	"github.com/osmosis-labs/sqs/log"
+	"go.uber.org/zap"
+)
+
+// GetFetchtPoolAPRsFromNumiaCb returns a callback to fetch pool APRs from Numia.
+// It increments the error counter if the pool APRs fetching fails.
+// It returns a callback function that returns the pool APRs on success.
+func GetFetchtPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClient, logger log.Logger) func() []passthroughdomain.PoolAPR {
+	return func() []passthroughdomain.PoolAPR {
+		// Fetch pool APRs from the passthrough grpc client
+		poolAPRs, err := numiaHTTPClient.GetPoolAPRsRange()
+		if err != nil {
+			logger.Error("Failed to fetch pool APRs", zap.Error(err))
+
+			// Increment the error counter
+			domain.SQSPassthroughNumiaAPRsFetchErrorCounter.WithLabelValues().Inc()
+		}
+		return poolAPRs
+	}
+}

--- a/sqsutil/datafetchers/prefetch.go
+++ b/sqsutil/datafetchers/prefetch.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+// Fetcher is an interface that provides a method to get a value.
+type Fetcher[T any] interface {
+	Get() (T, time.Time, error)
+}
+
 // IntervalFetcher is a struct that prefetches a value at a given interval
 // and provides a method to get the latest value.
 // NOTE: It may return stale data if the update function takes longer than the interval.


### PR DESCRIPTION
We are moving incentivized pools query from FE into SQS as it is slow:
https://github.com/osmosis-labs/osmosis-frontend/blob/21d52d8e9f0c47fa9375a7bbccc2e4724ceb8e1b/packages/trpc/src/pools.ts#L87

As part of [this task](https://linear.app/osmosis/issue/SQS-308/wire-fetcher-for-pool-aprs-from-numia), we define a Numia fetcher for pool APRs and register it on the passthrough usecase.

The full development plan is documented via sub-tasks here:
https://linear.app/osmosis/issue/SQS-307/move-getmarketincentivepools-query-into-sqs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Numia Pools APR fetcher, enhancing the app's capability to retrieve financial data.
	- Added new configuration options for Numia API integration, including URL and fetch intervals in configuration files.

- **Bug Fixes**
	- Enhanced error tracking for APR fetching operations, improving monitoring and reliability.

- **Documentation**
	- Updated the CHANGELOG.md to reflect upcoming features and improvements related to the APR fetcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->