### PR TITLE
remove request duration metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+- Remove sqs_requests_total and sqs_request_duration_seconds metrics
 - Numia Pools APR fetcher, associated configs and wiring
 - Timeseries pool fees fetcher, associated configs and wiring
 

--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,10 @@ test-prices-mainnet:
 
 # Run E2E tests in verbose mode (-s) -n 4 concurrent workers
 e2e-run-stage:
-	SQS_ENVIRONMENTS=stage pytest -s -n 4 --ignore=tests/test_syntheic_geo.py
+	SQS_ENVIRONMENTS=stage pytest -s -n 4 --ignore=tests/test_synthetic_geo.py
 
 e2e-run-local:
-	SQS_ENVIRONMENTS=local pytest -s -n 4 --ignore=tests/test_syntheic_geo.py
+	SQS_ENVIRONMENTS=local pytest -s -n 4 --ignore=tests/test_synthetic_geo.py
 
 #### E2E Python Setup
 
@@ -209,7 +209,7 @@ e2e-update-requirements:
 
 # Set DATADOG_API_KEY in the environment
 datadog-agent-start:
-	export DATADOG_API_KEY=your-key; \
+	export DATADOG_API_KEY=095a7a8c6007d0fa325c3e0b2ee898d4; \
 	docker run --cgroupns host \
 				--pid host \
 				-v /var/run/docker.sock:/var/run/docker.sock:ro \


### PR DESCRIPTION
Given DataDog migration, we don't need custom latency metrics anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the test command to properly ignore the intended test file.

- **Chores**
  - Removed outdated SQS tracking metrics to simplify monitoring.
  - Updated the Datadog API key to a specific value for improved configuration.
  
- **Refactor**
  - Streamlined middleware by removing request counting and latency tracking metrics, enhancing control flow but reducing observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->