### PR TITLE
feat: alloyed static rate limit poc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - Alloyed rate limiter boilerplate in sqsdomain
 - Add rate limiter to alloyed pools
 
+Chain compatibility: v25.x-c775cee7-1722825184
+
 ## 25.7.0
 
 - Fix bug with filters n /pools API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,17 +35,18 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
-## Unreleased
+## 25.8.0
 
 - Remove sqs_requests_total and sqs_request_duration_seconds metrics
 - Numia Pools APR fetcher, associated configs and wiring
 - Timeseries pool fees fetcher, associated configs and wiring
+- Fix alloyed overflow bug
+- Alloyed rate limiter boilerplate in sqsdomain
+- Add rate limiter to alloyed pools
 
 ## 25.7.0
 
 - Fix bug with filters n /pools API
-- Fix alloyed overflow bug
-- Alloyed rate limiter boilerplate in sqsdomain
 
 Chain compatibility: v25.x-c8140e68-1722532245
 

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -314,3 +314,13 @@ type FailCastCanonicalOrderbookKeyError struct {
 func (e FailCastCanonicalOrderbookKeyError) Error() string {
 	return fmt.Sprintf("failed to cast key with value %v, expected string", e.BaseQuoteKey)
 }
+
+type StaticRateLimiterInvalidUpperLimitError struct {
+	UpperLimit string
+	Weight     string
+	Denom      string
+}
+
+func (e StaticRateLimiterInvalidUpperLimitError) Error() string {
+	return fmt.Sprintf("invalid upper limit (%s) for weight (%s) and denom (%s)", e.UpperLimit, e.Weight, e.Denom)
+}

--- a/ingest/usecase/export_test.go
+++ b/ingest/usecase/export_test.go
@@ -35,3 +35,7 @@ func ComputeStandardNormalizationFactor(assetConfigs []cosmwasmpool.TransmuterAs
 func ComputeNormalizationScalingFactors(standardNormalizationFactor osmomath.Int, assetConfigs []cosmwasmpool.TransmuterAssetConfig) ([]osmomath.Int, error) {
 	return computeNormalizationScalingFactors(standardNormalizationFactor, assetConfigs)
 }
+
+func ProcessAlloyedPool(sqsModel *sqsdomain.SQSPool) error {
+	return processAlloyedPool(sqsModel)
+}

--- a/ingest/usecase/export_test.go
+++ b/ingest/usecase/export_test.go
@@ -2,8 +2,10 @@ package usecase
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/sqsdomain"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 )
 
 type (
@@ -24,4 +26,8 @@ func ProcessSQSModelMut(sqsModel *sqsdomain.SQSPool) error {
 
 func UpdateCurrentBlockLiquidityMapAlloyed(currentBlockLiquidityMap domain.DenomPoolLiquidityMap, poolID uint64, alloyedDenom string) domain.DenomPoolLiquidityMap {
 	return updateCurrentBlockLiquidityMapAlloyed(currentBlockLiquidityMap, poolID, alloyedDenom)
+}
+
+func ComputeStandardNormalizationFactor(assetConfigs []cosmwasmpool.TransmuterAssetConfig) (osmomath.Int, error) {
+	return computeStandardNormalizationFactor(assetConfigs)
 }

--- a/ingest/usecase/export_test.go
+++ b/ingest/usecase/export_test.go
@@ -31,3 +31,7 @@ func UpdateCurrentBlockLiquidityMapAlloyed(currentBlockLiquidityMap domain.Denom
 func ComputeStandardNormalizationFactor(assetConfigs []cosmwasmpool.TransmuterAssetConfig) (osmomath.Int, error) {
 	return computeStandardNormalizationFactor(assetConfigs)
 }
+
+func ComputeNormalizationScalingFactors(standardNormalizationFactor osmomath.Int, assetConfigs []cosmwasmpool.TransmuterAssetConfig) ([]osmomath.Int, error) {
+	return computeNormalizationScalingFactors(standardNormalizationFactor, assetConfigs)
+}

--- a/ingest/usecase/export_test.go
+++ b/ingest/usecase/export_test.go
@@ -32,7 +32,7 @@ func ComputeStandardNormalizationFactor(assetConfigs []cosmwasmpool.TransmuterAs
 	return computeStandardNormalizationFactor(assetConfigs)
 }
 
-func ComputeNormalizationScalingFactors(standardNormalizationFactor osmomath.Int, assetConfigs []cosmwasmpool.TransmuterAssetConfig) ([]osmomath.Int, error) {
+func ComputeNormalizationScalingFactors(standardNormalizationFactor osmomath.Int, assetConfigs []cosmwasmpool.TransmuterAssetConfig) (map[string]osmomath.Int, error) {
 	return computeNormalizationScalingFactors(standardNormalizationFactor, assetConfigs)
 }
 

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -452,6 +452,11 @@ func processSQSModelMut(sqsModel *sqsdomain.SQSPool) error {
 		alloyedDenom := cosmWasmModel.Data.AlloyTransmuter.AlloyedDenom
 
 		sqsModel.PoolDenoms = append(sqsModel.PoolDenoms, alloyedDenom)
+
+		// Process the alloyed pool
+		if err := processAlloyedPool(sqsModel); err != nil {
+			return err
+		}
 	}
 
 	// Remove gamm shares from balances

--- a/ingest/usecase/ingest_usecase_test.go
+++ b/ingest/usecase/ingest_usecase_test.go
@@ -571,7 +571,12 @@ func (s *IngestUseCaseTestSuite) TestProcessSQSModelMut() {
 			sqsModel: modelWithCWModelSet,
 
 			// Note: append wrangling is done to avoid mutation of defaultModel.
-			expectedSQSModel: withAssetConfigs(withPoolDenoms(modelWithCWModelSet, append(append([]string{}, reorderedDefaultDenoms...), routertesting.ALLUSDT)...), []cosmwasmpool.TransmuterAssetConfig{}),
+			expectedSQSModel: withAssetConfigs(withPoolDenoms(modelWithCWModelSet, append(append([]string{}, reorderedDefaultDenoms...), routertesting.ALLUSDT)...), []cosmwasmpool.TransmuterAssetConfig{
+				{
+					Denom:               ATOM,
+					NormalizationFactor: tenE6,
+				},
+			}),
 		},
 		{
 			name: "cosmwasm model not correctly set -> error",

--- a/ingest/usecase/ingest_usecase_test.go
+++ b/ingest/usecase/ingest_usecase_test.go
@@ -524,6 +524,12 @@ func (s *IngestUseCaseTestSuite) TestProcessSQSModelMut() {
 			return sqsPool
 		}
 
+		withAssetConfigs = func(sqsPool *sqsdomain.SQSPool, assetConfigs []cosmwasmpool.TransmuterAssetConfig) *sqsdomain.SQSPool {
+			sqsPool = deepCopy(sqsPool)
+			sqsPool.CosmWasmPoolModel.Data.AlloyTransmuter.AssetConfigs = assetConfigs
+			return sqsPool
+		}
+
 		reorderedDefaultModel = withPoolDenoms(defaultModel, reorderedDefaultDenoms...)
 
 		modelWithCWModelSet = withCosmWasmModel(defaultModel, defaultCosmWasmModel)
@@ -565,7 +571,7 @@ func (s *IngestUseCaseTestSuite) TestProcessSQSModelMut() {
 			sqsModel: modelWithCWModelSet,
 
 			// Note: append wrangling is done to avoid mutation of defaultModel.
-			expectedSQSModel: withPoolDenoms(modelWithCWModelSet, append(append([]string{}, reorderedDefaultDenoms...), routertesting.ALLUSDT)...),
+			expectedSQSModel: withAssetConfigs(withPoolDenoms(modelWithCWModelSet, append(append([]string{}, reorderedDefaultDenoms...), routertesting.ALLUSDT)...), []cosmwasmpool.TransmuterAssetConfig{}),
 		},
 		{
 			name: "cosmwasm model not correctly set -> error",

--- a/ingest/usecase/process_alloyed_pool.go
+++ b/ingest/usecase/process_alloyed_pool.go
@@ -1,0 +1,54 @@
+package usecase
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/sqsdomain"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
+)
+
+// CONTRACT: the caller checked that this is an alloyed pool
+func processAlloyedPool(sqsModel *sqsdomain.SQSPool) error {
+	if len(sqsModel.CosmWasmPoolModel.Data.AlloyTransmuter.AssetConfigs) == 0 {
+		return fmt.Errorf("no asset configs found for alloyed pool")
+	}
+
+	cosmWasmModel := sqsModel.CosmWasmPoolModel
+
+	standardNormalizationFactor := computeStandardNormalizationFactor(cosmWasmModel.Data.AlloyTransmuter.AssetConfigs)
+
+	normalizationScalingFactors := computeNormalizationScalingFactors(standardNormalizationFactor, cosmWasmModel.Data.AlloyTransmuter.AssetConfigs)
+
+	cosmWasmModel.Data.AlloyTransmuter.PreComputedData.StdNormFactor = standardNormalizationFactor
+
+	cosmWasmModel.Data.AlloyTransmuter.PreComputedData.NormalizationScalingFactors = normalizationScalingFactors
+
+	return nil
+}
+
+// computeStandardNormalizationFactor computes the standard normalization factor for the pool.
+func computeStandardNormalizationFactor(assetConfigs []cosmwasmpool.TransmuterAssetConfig) osmomath.Int {
+	result := osmomath.OneInt().BigIntMut()
+	for i := 0; i < len(assetConfigs); i++ {
+		currentNormFactor := assetConfigs[i].NormalizationFactor.BigInt()
+		currentNormFactor = Lcm(result, currentNormFactor)
+	}
+	return osmomath.NewIntFromBigInt(result)
+}
+
+// computeNormalizationScalingFactors computes the normalization scaling factors for each denom in the asset config
+// using the standard normalization factor.
+func computeNormalizationScalingFactors(standardNormalizationFactor osmomath.Int, assetConfigs []cosmwasmpool.TransmuterAssetConfig) []osmomath.Int {
+	scalingFactors := make([]osmomath.Int, len(assetConfigs))
+	for i := 0; i < len(assetConfigs); i++ {
+		scalingFactors[i] = standardNormalizationFactor.Quo(assetConfigs[i].NormalizationFactor)
+	}
+	return scalingFactors
+}
+
+// Lcm calculates the least common multiple of two big.Int values.
+func Lcm(a *big.Int, b *big.Int) *big.Int {
+	return new(big.Int).Div(new(big.Int).Mul(a, b), new(big.Int).GCD(nil, nil, a, b))
+}

--- a/ingest/usecase/process_alloyed_pool.go
+++ b/ingest/usecase/process_alloyed_pool.go
@@ -33,7 +33,7 @@ func computeStandardNormalizationFactor(assetConfigs []cosmwasmpool.TransmuterAs
 	result := osmomath.OneInt().BigIntMut()
 	for i := 0; i < len(assetConfigs); i++ {
 		currentNormFactor := assetConfigs[i].NormalizationFactor.BigInt()
-		currentNormFactor = Lcm(result, currentNormFactor)
+		result = Lcm(result, currentNormFactor)
 	}
 	return osmomath.NewIntFromBigInt(result)
 }

--- a/ingest/usecase/process_alloyed_pool.go
+++ b/ingest/usecase/process_alloyed_pool.go
@@ -60,25 +60,26 @@ func computeStandardNormalizationFactor(assetConfigs []cosmwasmpool.TransmuterAs
 // Returns error if one of the asset normalization factors is nil or zero.
 // Returns error if the standard normalization factor is nil or zero.
 // Returns error if asset scaling factor truncates to zero.
-func computeNormalizationScalingFactors(standardNormalizationFactor osmomath.Int, assetConfigs []cosmwasmpool.TransmuterAssetConfig) ([]osmomath.Int, error) {
+func computeNormalizationScalingFactors(standardNormalizationFactor osmomath.Int, assetConfigs []cosmwasmpool.TransmuterAssetConfig) (map[string]osmomath.Int, error) {
 	if standardNormalizationFactor.IsNil() || standardNormalizationFactor.IsZero() {
 		return nil, fmt.Errorf("standard normalization factor is nil or zero")
 	}
 
-	scalingFactors := make([]osmomath.Int, len(assetConfigs))
+	scalingFactors := make(map[string]osmomath.Int, len(assetConfigs))
 	for i := 0; i < len(assetConfigs); i++ {
-		assetNormalizationFactor := assetConfigs[i].NormalizationFactor
+		assetConfig := assetConfigs[i]
+		assetNormalizationFactor := assetConfig.NormalizationFactor
 		if assetNormalizationFactor.IsNil() || assetNormalizationFactor.IsZero() {
-			return nil, fmt.Errorf("normalization factor is nil or zero for asset %s", assetConfigs[i].Denom)
+			return nil, fmt.Errorf("normalization factor is nil or zero for asset %s", assetConfig.Denom)
 		}
 
 		assetScalingFactor := standardNormalizationFactor.Quo(assetNormalizationFactor)
 
 		if assetScalingFactor.IsZero() {
-			return nil, fmt.Errorf("scaling factor truncated to zero for asset %s", assetConfigs[i].Denom)
+			return nil, fmt.Errorf("scaling factor truncated to zero for asset %s", assetConfig.Denom)
 		}
 
-		scalingFactors[i] = assetScalingFactor
+		scalingFactors[assetConfig.Denom] = assetScalingFactor
 	}
 	return scalingFactors, nil
 }

--- a/ingest/usecase/process_alloyed_pool.go
+++ b/ingest/usecase/process_alloyed_pool.go
@@ -9,6 +9,9 @@ import (
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 )
 
+// processAlloyedPool processes the alloyed pool and computes the standard normalization factor and normalization scaling factors.
+// Mutates the model with the computed values.
+// Returns error if fails to computed either.
 // CONTRACT: the caller checked that this is an alloyed pool
 func processAlloyedPool(sqsModel *sqsdomain.SQSPool) error {
 	if len(sqsModel.CosmWasmPoolModel.Data.AlloyTransmuter.AssetConfigs) == 0 {

--- a/ingest/usecase/process_alloyed_pool_test.go
+++ b/ingest/usecase/process_alloyed_pool_test.go
@@ -1,0 +1,17 @@
+package usecase_test
+
+import (
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/ingest/usecase"
+)
+
+func (s *IngestUseCaseTestSuite) TestLcm() {
+	a := osmomath.NewInt(10).ToLegacyDec().Power(18).TruncateInt()
+	b := osmomath.NewInt(10).ToLegacyDec().Power(12).TruncateInt()
+
+	lcm := usecase.Lcm(a.BigInt(), b.BigInt())
+
+	lcmInt := osmomath.NewIntFromBigInt(lcm)
+
+	s.Require().Equal(osmomath.NewInt(10).ToLegacyDec().Power(18).TruncateInt(), lcmInt)
+}

--- a/ingest/usecase/process_alloyed_pool_test.go
+++ b/ingest/usecase/process_alloyed_pool_test.go
@@ -39,9 +39,9 @@ func (s *IngestUseCaseTestSuite) TestProcessAlloyedPool() {
 
 	expectedPreComputedData := cosmwasmpool.PrecomputedData{
 		StdNormFactor: tenE18,
-		NormalizationScalingFactors: []osmomath.Int{
-			oneInt,
-			tenE12,
+		NormalizationScalingFactors: map[string]osmomath.Int{
+			ALLUSDT: oneInt,
+			USDC:    tenE12,
 		},
 	}
 
@@ -143,7 +143,7 @@ func (s *IngestUseCaseTestSuite) TestComputeNormalizationScalingFactors() {
 		standardNormalizationFactor osmomath.Int
 		assetConfigs                []cosmwasmpool.TransmuterAssetConfig
 
-		expected      []osmomath.Int
+		expected      map[string]osmomath.Int
 		expectedError bool
 	}{
 		{
@@ -152,7 +152,7 @@ func (s *IngestUseCaseTestSuite) TestComputeNormalizationScalingFactors() {
 			standardNormalizationFactor: tenE6,
 			assetConfigs:                []cosmwasmpool.TransmuterAssetConfig{},
 
-			expected: []osmomath.Int{},
+			expected: map[string]osmomath.Int{},
 		},
 		{
 			name: "one asset",
@@ -165,8 +165,8 @@ func (s *IngestUseCaseTestSuite) TestComputeNormalizationScalingFactors() {
 				},
 			},
 
-			expected: []osmomath.Int{
-				oneInt,
+			expected: map[string]osmomath.Int{
+				ATOM: osmomath.OneInt(),
 			},
 		},
 		{
@@ -184,9 +184,9 @@ func (s *IngestUseCaseTestSuite) TestComputeNormalizationScalingFactors() {
 				},
 			},
 
-			expected: []osmomath.Int{
-				tenE12,
-				tenE10,
+			expected: map[string]osmomath.Int{
+				ATOM:   tenE12,
+				ALLBTC: tenE10,
 			},
 		},
 		{
@@ -232,8 +232,8 @@ func (s *IngestUseCaseTestSuite) TestComputeNormalizationScalingFactors() {
 			}
 
 			s.Require().Len(normalizationFactors, len(tc.expected))
-			for i := range normalizationFactors {
-				s.Require().Equal(tc.expected[i].String(), normalizationFactors[i].String())
+			for k, v := range tc.expected {
+				s.Require().Equal(v.String(), normalizationFactors[k].String())
 			}
 		})
 	}

--- a/ingest/usecase/process_alloyed_pool_test.go
+++ b/ingest/usecase/process_alloyed_pool_test.go
@@ -3,7 +3,100 @@ package usecase_test
 import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/ingest/usecase"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 )
+
+var (
+	tenE6  = osmomath.NewInt(10).ToLegacyDec().Power(6).TruncateInt()
+	tenE8  = osmomath.NewInt(10).ToLegacyDec().Power(8).TruncateInt()
+	tenE12 = osmomath.NewInt(10).ToLegacyDec().Power(12).TruncateInt()
+	tenE9  = osmomath.NewInt(10).ToLegacyDec().Power(9).TruncateInt()
+	tenE18 = osmomath.NewInt(10).ToLegacyDec().Power(18).TruncateInt()
+)
+
+func (s *IngestUseCaseTestSuite) TestComputeStandardNormalizationFactor() {
+	testCases := []struct {
+		name         string
+		assetConfigs []cosmwasmpool.TransmuterAssetConfig
+
+		expected      osmomath.Int
+		expectedError bool
+	}{
+		{
+			name: "empty",
+
+			assetConfigs: []cosmwasmpool.TransmuterAssetConfig{},
+
+			expected: osmomath.OneInt(),
+		},
+		{
+			name: "single",
+
+			assetConfigs: []cosmwasmpool.TransmuterAssetConfig{
+				{
+					Denom:               ATOM,
+					NormalizationFactor: tenE6,
+				},
+			},
+
+			expected: tenE6,
+		},
+
+		{
+			name: "multiple",
+
+			assetConfigs: []cosmwasmpool.TransmuterAssetConfig{
+				{
+					Denom:               ATOM,
+					NormalizationFactor: tenE6,
+				},
+				{
+					Denom:               UOSMO,
+					NormalizationFactor: tenE8,
+				},
+				{
+					Denom:               USDC,
+					NormalizationFactor: tenE12,
+				},
+				{
+					Denom:               ALLBTC,
+					NormalizationFactor: tenE9,
+				},
+				{
+					Denom:               ALLUSDT,
+					NormalizationFactor: tenE18,
+				},
+			},
+
+			expected: tenE18,
+		},
+		{
+			name: "no normalization factor",
+
+			assetConfigs: []cosmwasmpool.TransmuterAssetConfig{
+				{
+					Denom: ATOM,
+				},
+			},
+
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+
+			normalizetionFactor, error := usecase.ComputeStandardNormalizationFactor(tc.assetConfigs)
+
+			if tc.expectedError {
+				s.Require().Error(error)
+				return
+			}
+
+			s.Require().Equal(tc.expected, normalizetionFactor)
+		})
+	}
+}
 
 func (s *IngestUseCaseTestSuite) TestLcm() {
 	a := osmomath.NewInt(10).ToLegacyDec().Power(18).TruncateInt()

--- a/router/usecase/pools/export_test.go
+++ b/router/usecase/pools/export_test.go
@@ -1,6 +1,7 @@
 package pools
 
 import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/osmosis/osmomath"
 	cwpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
 	"github.com/osmosis-labs/sqs/domain"
@@ -24,4 +25,8 @@ func NewRoutableCosmWasmPoolWithCustomModel(
 	takerFee osmomath.Dec,
 ) (domain.RoutablePool, error) {
 	return newRoutableCosmWasmPoolWithCustomModel(pool, cosmwasmPool, cosmWasmPoolsParams, tokenOutDenom, takerFee)
+}
+
+func (r *routableAlloyTransmuterPoolImpl) CheckStaticRateLimiter(tokenInCoin sdk.Coin) error {
+	return r.checkStaticRateLimiter(tokenInCoin)
 }

--- a/router/usecase/pools/routable_cw_alloy_transmuter_pool.go
+++ b/router/usecase/pools/routable_cw_alloy_transmuter_pool.go
@@ -201,9 +201,8 @@ func (r *routableAlloyTransmuterPoolImpl) CalcTokenOutAmt(tokenIn sdk.Coin, toke
 // Note: static rate limit only has an upper limit.
 // Therefore, we only need to validate the token in balance.
 func (r *routableAlloyTransmuterPoolImpl) checkStaticRateLimiter(tokenInCoin sdk.Coin) error {
-
 	// If no static rate limiter is set, return
-	if len(r.AlloyTransmuterData.RateLimiterConfig.StaticLimiterByDenomMap) < 0 {
+	if len(r.AlloyTransmuterData.RateLimiterConfig.StaticLimiterByDenomMap) == 0 {
 		return nil
 	}
 

--- a/sqsdomain/cosmwasmpool/alloy_transmuter.go
+++ b/sqsdomain/cosmwasmpool/alloy_transmuter.go
@@ -37,7 +37,7 @@ type PrecomputedData struct {
 	// NormalizationScalingFactors is the scaling factor for each asset in the pool.
 	// Each index corresponds to the asset at the same index in the AssetConfigs.
 	// This is used for computing asset weights for checking rate limitin.
-	NormalizationScalingFactors []osmomath.Int `json:"normalization_scaling_factors"`
+	NormalizationScalingFactors map[string]osmomath.Int `json:"normalization_scaling_factors"`
 }
 
 // Configuration for each asset in the transmuter pool

--- a/sqsdomain/cosmwasmpool/alloy_transmuter.go
+++ b/sqsdomain/cosmwasmpool/alloy_transmuter.go
@@ -23,6 +23,21 @@ type AlloyTransmuterData struct {
 	AlloyedDenom      string                  `json:"alloyed_denom"`
 	AssetConfigs      []TransmuterAssetConfig `json:"asset_configs"`
 	RateLimiterConfig AlloyedRateLimiter      `json:"rate_limiter"`
+
+	PreComputedData PrecomputedData `json:"precomputed_data"`
+}
+
+// PrecomputedData for the alloyed pool.
+type PrecomputedData struct {
+	// StdNormFactor is the standard normalization factor for the pool.
+	// It is computed as the LCM of all the normalization factors of the assets in the pool.
+	// This is used for computing asset weights for checking rate limiting.
+	StdNormFactor osmomath.Int `json:"std_norm_factor"`
+
+	// NormalizationScalingFactors is the scaling factor for each asset in the pool.
+	// Each index corresponds to the asset at the same index in the AssetConfigs.
+	// This is used for computing asset weights for checking rate limitin.
+	NormalizationScalingFactors []osmomath.Int `json:"normalization_scaling_factors"`
 }
 
 // Configuration for each asset in the transmuter pool


### PR DESCRIPTION
This is the POC of the alloyed static rate limit.

Core idea:
- precompute normalization scaling factors for the pool at time of ingest
- during route estimation, check if token in balance + token in amount goes over the static rate limit. If so, return error

This would filter out the rate limited routes during ranked route construction. If they are cached, the rate limited routes would still be invalidated and removed from cache after 45 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced Numia Pools APR fetcher and Timeseries pool fees fetcher.
	- Added a new error type for improved rate limiter error handling.
	- Enhanced asset configuration processing within pools.
	- Implemented a rate limiter for alloyed pools.

- **Bug Fixes**
	- Resolved an alloyed overflow bug.

- **Tests**
	- Added tests for processing alloyed pools and rate limiter functionality.
	- Expanded testing scenarios for asset configuration handling. 

- **Documentation**
	- Updated changelog to reflect version 25.8.0 changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->