### PR TITLE
Locust access host

### DIFF
--- a/locust/docker-compose.yml
+++ b/locust/docker-compose.yml
@@ -9,10 +9,15 @@ services:
       - ./:/mnt/locust
     # 167.172.160.95:9092 Roman's personal set up
     # 174.138.102.174:80 stage set up
+    # host.docker.internal:9092 local set up, make sure host firewall accepts incoming connections
     command: -f /mnt/locust/locustfile.py --master -H http://159.89.14.212:9092
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
   
   worker:
     image: locustio/locust
     volumes:
       - ./:/mnt/locust
     command: -f /mnt/locust/locustfile.py --worker --master-host master
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
Configure locust docker instances to allow access of SQS instances running on host machine. Such setup in convenient for local dev env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Locust setup for improved local development by adding `extra_hosts` entries for better communication between Docker containers and the host machine.

- **Documentation**
  - Added comments to clarify the purpose of the new configuration for local setup.

- **Style**
  - Adjusted formatting for consistency across the configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->