### PR TITLE
feat: wire orderbook cw api client

### DIFF
--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/labstack/echo/v4"
 
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	// nolint: staticcheck
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -271,10 +272,9 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 
 					logger.Info("Using keyring with address", zap.Stringer("address", keyring.GetAddress()))
 
-					// TODO: create and propagate
-					// wasmQueryClient := wasmtypes.NewQueryClient(passthroughGRPCClient.GetChainGRPCClient())
-					// cwAPIClient := orderbookfiller.NewOrderbookCWAPIClient(wasmQueryClient)
-					currentPlugin = orderbookfiller.New(poolsUseCase, routerUsecase, tokensUseCase, passthroughGRPCClient, keyring, defaultQuoteDenom, logger)
+					wasmQueryClient := wasmtypes.NewQueryClient(passthroughGRPCClient.GetChainGRPCClient())
+					cwAPIClient := orderbookfiller.NewOrderbookCWAPIClient(wasmQueryClient)
+					currentPlugin = orderbookfiller.New(poolsUseCase, routerUsecase, tokensUseCase, passthroughGRPCClient, cwAPIClient, keyring, defaultQuoteDenom, logger)
 				}
 
 				// Register the plugin with the ingest use case

--- a/domain/orderbookplugin/orderbook_cw_api_client.go
+++ b/domain/orderbookplugin/orderbook_cw_api_client.go
@@ -1,0 +1,9 @@
+package orderbookplugindomain
+
+import "context"
+
+// OrderbookCWAPIClient is an interface for fetching orders by tick from the orderbook contract.
+type OrderbookCWAPIClient interface {
+	// GetOrdersByTick fetches orders by tick from the orderbook contract.
+	GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]Order, error)
+}

--- a/domain/orderbookplugin/orderbook_order.go
+++ b/domain/orderbookplugin/orderbook_order.go
@@ -1,0 +1,21 @@
+package orderbookplugindomain
+
+// Order represents an order in the orderbook returned by the orderbook contract.
+type Order struct {
+	TickId         int64  `json:"tick_id"`
+	OrderId        int64  `json:"order_id"`
+	OrderDirection string `json:"order_direction"`
+	Owner          string `json:"owner"`
+	Quantity       string `json:"quantity"`
+	Etas           string `json:"etas"`
+	ClaimBounty    string `json:"claim_bounty"`
+	PlacedQuantity string `json:"placed_quantity"`
+	PlacedAt       string `json:"placed_at"`
+}
+
+// OrdersResponse represents the response from the orderbook contract containing the orders for a given tick.
+type OrdersResponse struct {
+	Address   string  `json:"address"`
+	BidOrders []Order `json:"bid_orders"`
+	AskOrders []Order `json:"ask_orders"`
+}

--- a/ingest/usecase/plugins/orderbookfiller/orderbook_cw_client.go
+++ b/ingest/usecase/plugins/orderbookfiller/orderbook_cw_client.go
@@ -1,0 +1,44 @@
+package orderbookfiller
+
+import (
+	"context"
+	"errors"
+
+	orderbookplugindomain "github.com/osmosis-labs/sqs/domain/orderbookplugin"
+
+	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+)
+
+// orderbookCWAPIClient is an implementation of OrderbookCWAPIClient.
+type orderbookCWAPIClient struct {
+	wasmClient wasmtypes.QueryClient
+}
+
+var _ orderbookplugindomain.OrderbookCWAPIClient = (*orderbookCWAPIClient)(nil)
+
+//ordersByTick is a struct that represents the request payload for the orders_by_tick query.
+type ordersByTick struct {
+	Tick int64 `json:"tick_id"`
+}
+
+// ordersByTickPayload is a struct that represents the payload for the orders_by_tick query.
+type ordersByTickPayload struct {
+	OrdersByTick ordersByTick `json:"orders_by_tick"`
+}
+
+// ordersByTickResponse is a struct that represents the response payload for the orders_by_tick query.
+type ordersByTickResponse struct {
+	Orders []orderbookplugindomain.Order `json:"orders"`
+}
+
+// NewOrderbookCWAPIClient creates a new orderbookCWAPIClient.
+func NewOrderbookCWAPIClient(wasmClient wasmtypes.QueryClient) *orderbookCWAPIClient {
+	return &orderbookCWAPIClient{
+		wasmClient: wasmClient,
+	}
+}
+
+// GetOrdersByTick implements OrderbookCWAPIClient.
+func (o *orderbookCWAPIClient) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
Wiring the client for fetching ticks from chain

Split from: https://github.com/osmosis-labs/sqs/pull/407

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new `OrderbookCWAPIClient` interface for efficient order retrieval from the order book contract.
  - Added capabilities for querying smart contracts through the newly integrated WASM-based functionality.
  - Enhanced the `orderbookFillerIngestPlugin` for better integration with order book data.

- **Bug Fixes**
  - Resolved issues related to previously commented-out code affecting the sidecar query server's functionality.

- **Documentation**
  - Updated documentation to reflect new interfaces and functionalities introduced in the order book management system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->