### PR TITLE
Order book rounding direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - Orderbook plugin
 - Change tick iteration exit condition in CL in orderbook from zero to smallest Dec (18 decimals).
+- Add rounding direction to the order book
 
 ## v25.9.0
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/osmosis-labs/osmosis/osmomath v0.0.13
 	github.com/osmosis-labs/osmosis/osmoutils v0.0.13
 	github.com/osmosis-labs/osmosis/v25 v25.0.2-0.20240524131320-44f70454a543
-	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810061452-1b8fd4dbec90
+	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810225250-04d58c7c19a0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -901,6 +901,8 @@ github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240806061719-a66eb7ff47b8 h1:u
 github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240806061719-a66eb7ff47b8/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
 github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810061452-1b8fd4dbec90 h1:HYe8JrpkVhII+C9VBRh+xqwKaAspo5dc+nB3Pz3C8sI=
 github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810061452-1b8fd4dbec90/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810225250-04d58c7c19a0 h1:tKCEThvtPd6N8+6Kkbk4m91MIgDkRrv4i4PtXBaUXeM=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810225250-04d58c7c19a0/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
 github.com/osmosis-labs/wasmd v0.45.0-osmo h1:NIp7pvJV5HuBN1HwPgEmXKQM2TjVIVdJErIHnB9IMO8=
 github.com/osmosis-labs/wasmd v0.45.0-osmo/go.mod h1:J6eRvwii5T1WxhetZkBg1kOJS3GTn1Bw2OLyZBb8EVU=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=

--- a/router/usecase/pools/routable_concentrated_pool.go
+++ b/router/usecase/pools/routable_concentrated_pool.go
@@ -21,7 +21,7 @@ import (
 )
 
 var _ domain.RoutablePool = &routableConcentratedPoolImpl{}
-var zeroBigDec = osmomath.ZeroBigDec()
+var smallestDec = osmomath.BigDecFromDec(osmomath.SmallestDec())
 
 type routableConcentratedPoolImpl struct {
 	ChainPool     *concentratedmodel.Pool "json:\"cl_pool\""
@@ -130,7 +130,7 @@ func (r *routableConcentratedPoolImpl) CalculateTokenOutByTokenIn(ctx context.Co
 	}
 
 	// Initialize the swap strategy.
-	swapStrategy := swapstrategy.New(isZeroForOne, zeroBigDec, &storetypes.KVStoreKey{}, concentratedPool.SpreadFactor)
+	swapStrategy := swapstrategy.New(isZeroForOne, smallestDec, &storetypes.KVStoreKey{}, concentratedPool.SpreadFactor)
 
 	var (
 		// Swap state

--- a/router/usecase/pools/routable_cw_orderbook_pool.go
+++ b/router/usecase/pools/routable_cw_orderbook_pool.go
@@ -89,17 +89,17 @@ func (r *routableOrderbookPoolImpl) CalculateTokenOutByTokenIn(ctx context.Conte
 	amountOutTotal := osmomath.ZeroBigDec()
 	amountInRemaining := osmomath.BigDecFromSDKInt(tokenIn.Amount)
 
-	// var amountInToExhaustLiquidity osmomath.BigDec
-	// if *directionIn == cosmwasmpool.BID {
-	// 	amountInToExhaustLiquidity = r.OrderbookData.BidAmountToExhaustAskLiquidity
-	// } else {
-	// 	amountInToExhaustLiquidity = r.OrderbookData.AskAmountToExhaustBidLiquidity
-	// }
+	var amountInToExhaustLiquidity osmomath.BigDec
+	if *directionIn == cosmwasmpool.BID {
+		amountInToExhaustLiquidity = r.OrderbookData.BidAmountToExhaustAskLiquidity
+	} else {
+		amountInToExhaustLiquidity = r.OrderbookData.AskAmountToExhaustBidLiquidity
+	}
 
-	// // check if amount in > amountInToExhaustLiquidity, if so this swap is not possible due to insufficient liquidity
-	// if amountInRemaining.GT(amountInToExhaustLiquidity) {
-	// 	return sdk.Coin{}, domain.OrderbookNotEnoughLiquidityToCompleteSwapError{PoolId: r.GetId(), AmountIn: tokenIn.String()}
-	// }
+	// check if amount in > amountInToExhaustLiquidity, if so this swap is not possible due to insufficient liquidity
+	if amountInRemaining.GT(amountInToExhaustLiquidity) {
+		return sdk.Coin{}, domain.OrderbookNotEnoughLiquidityToCompleteSwapError{PoolId: r.GetId(), AmountIn: tokenIn.String()}
+	}
 
 	// ASSUMPTION: Ticks are ordered
 	for amountInRemaining.GT(smallestDec) {
@@ -129,6 +129,7 @@ func (r *routableOrderbookPoolImpl) CalculateTokenOutByTokenIn(ctx context.Conte
 		// from the remaining amount of tokens in
 		inputFilled := cosmwasmpool.OrderbookValueInOppositeDirection(outputFilled, tickPrice, directionOut, cosmwasmpool.ROUND_UP)
 
+		// Note: left for convinience for debugging
 		// fmt.Println("amountInRemaining", amountInRemaining)
 		// fmt.Println("tickPrice", tickPrice)
 		// fmt.Println("tickIdx", tickIdx)


### PR DESCRIPTION
When working on the fill bot and using order book APIs for estimates, I've run into an issue with the lack of deterministic rounding direction causing over estimates of arb amounts.

This PR fixes the rounding direction to be consistent with the contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a rounding direction feature in the order book plugin to enhance precision in financial calculations.
	- Added a new type, `RoundingDirection`, to manage rounding behavior during token conversions.
  
- **Enhancements**
	- Updated methods to improve how tick indices are managed and rounding is applied, leading to more accurate calculations in order book operations.

- **Dependency Updates**
	- Updated the version of a key dependency to ensure improved functionality and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->