### PR TITLE
move cosmwasm query helper into domain

### DIFF
--- a/domain/cosmwasm/cosmwasm_query.go
+++ b/domain/cosmwasm/cosmwasm_query.go
@@ -1,11 +1,13 @@
-package pools
+package cosmwasmdomain
 
 import (
 	"context"
 
+	"github.com/osmosis-labs/sqs/sqsdomain/json"
+
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	"github.com/osmosis-labs/sqs/domain"
-	"github.com/osmosis-labs/sqs/sqsdomain/json"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )
@@ -16,9 +18,9 @@ type CosmWasmPoolsParams struct {
 	ScalingFactorGetterCb domain.ScalingFactorGetterCb
 }
 
-// queryCosmwasmContract queries the cosmwasm contract given the contract address, request and response
+// QueryCosmwasmContract queries the cosmwasm contract given the contract address, request and response
 // Returns error if fails to query the contract, serialize request or deserialize response.
-func queryCosmwasmContract[T any, K any](ctx context.Context, wasmClient wasmtypes.QueryClient, contractAddress string, cosmWasmRequest T, cosmWasmResponse K) error {
+func QueryCosmwasmContract[T any, K any](ctx context.Context, wasmClient wasmtypes.QueryClient, contractAddress string, cosmWasmRequest T, cosmWasmResponse K) error {
 	// Marshal the message
 	bz, err := json.Marshal(cosmWasmRequest)
 	if err != nil {

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -100,7 +101,7 @@ func (pm *PoolsUsecaseMock) GetRoutesFromCandidates(candidateRoutes sqsdomain.Ca
 			}
 
 			// TODO: note that taker fee is force set to zero
-			routablePool, err := pools.NewRoutablePool(foundPool, candidatePool.TokenOutDenom, osmomath.ZeroDec(), pools.CosmWasmPoolsParams{
+			routablePool, err := pools.NewRoutablePool(foundPool, candidatePool.TokenOutDenom, osmomath.ZeroDec(), cosmwasmdomain.CosmWasmPoolsParams{
 				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 			})
 			if err != nil {

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -9,6 +9,7 @@ import (
 
 	"cosmossdk.io/math"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"github.com/osmosis-labs/sqs/sqsutil/datafetchers"
@@ -45,7 +46,7 @@ type poolsUseCase struct {
 	canonicalOrderBookForBaseQuoteDenom sync.Map
 	canonicalOrderbookPoolIDs           sync.Map
 
-	cosmWasmPoolsParams pools.CosmWasmPoolsParams
+	cosmWasmPoolsParams cosmwasmdomain.CosmWasmPoolsParams
 
 	aprPrefetcher      datafetchers.MapFetcher[uint64, passthroughdomain.PoolAPR]
 	poolFeesPrefetcher datafetchers.MapFetcher[uint64, passthroughdomain.PoolFee]
@@ -91,7 +92,7 @@ func NewPoolsUsecase(poolsConfig *domain.PoolsConfig, chainGRPCGatewayEndpoint s
 		pools:            sync.Map{},
 		routerRepository: routerRepository,
 
-		cosmWasmPoolsParams: pools.CosmWasmPoolsParams{
+		cosmWasmPoolsParams: cosmwasmdomain.CosmWasmPoolsParams{
 			Config: domain.CosmWasmPoolRouterConfig{
 				TransmuterCodeIDs:        transmuterCodeIDsMap,
 				AlloyedTransmuterCodeIDs: alloyedTransmuterCodeIDsMap,

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -15,6 +15,7 @@ import (
 
 	cosmwasmpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 
 	"github.com/osmosis-labs/sqs/domain"
@@ -99,7 +100,7 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 	brokenChainPool := *defaultPool
 	brokenChainPool.PoolType = poolmanagertypes.CosmWasm
 
-	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+	cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 		ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 	}
 	_, err = pools.NewRoutablePool(&brokenChainPool, denomTwo, defaultTakerFee, cosmWasmPoolsParams)
@@ -810,7 +811,7 @@ func (s *PoolsUsecaseTestSuite) TestRetainPoolIfMatchesOptions() {
 }
 
 func (s *PoolsUsecaseTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec) domain.RoutablePool {
-	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+	cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 		ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 	}
 	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolsParams)

--- a/router/usecase/pools/export_test.go
+++ b/router/usecase/pools/export_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 	cwpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 )
 
@@ -20,7 +21,7 @@ type (
 func NewRoutableCosmWasmPoolWithCustomModel(
 	pool sqsdomain.PoolI,
 	cosmwasmPool *cwpoolmodel.CosmWasmPool,
-	cosmWasmPoolsParams CosmWasmPoolsParams,
+	cosmWasmPoolsParams cosmwasmdomain.CosmWasmPoolsParams,
 	tokenOutDenom string,
 	takerFee osmomath.Dec,
 ) (domain.RoutablePool, error) {

--- a/router/usecase/pools/pool_factory.go
+++ b/router/usecase/pools/pool_factory.go
@@ -1,6 +1,7 @@
 package pools
 
 import (
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	"github.com/osmosis-labs/sqs/domain"
@@ -15,7 +16,7 @@ import (
 
 // NewRoutablePool creates a new RoutablePool.
 // Panics if pool is of invalid type or if does not contain tick data when a concentrated pool.
-func NewRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolsParams CosmWasmPoolsParams) (domain.RoutablePool, error) {
+func NewRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolsParams cosmwasmdomain.CosmWasmPoolsParams) (domain.RoutablePool, error) {
 	poolType := pool.GetType()
 	chainPool := pool.GetUnderlyingPool()
 	if poolType == poolmanagertypes.Concentrated {
@@ -89,7 +90,7 @@ func NewRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmoma
 
 // newRoutableCosmWasmPool creates a new RoutablePool for CosmWasm pools.
 // Panics if the given pool is not a cosmwasm pool or if the
-func newRoutableCosmWasmPool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolsParams CosmWasmPoolsParams) (domain.RoutablePool, error) {
+func newRoutableCosmWasmPool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmPoolsParams cosmwasmdomain.CosmWasmPoolsParams) (domain.RoutablePool, error) {
 	chainPool := pool.GetUnderlyingPool()
 	poolType := pool.GetType()
 
@@ -138,7 +139,7 @@ func newRoutableCosmWasmPool(pool sqsdomain.PoolI, tokenOutDenom string, takerFe
 func newRoutableCosmWasmPoolWithCustomModel(
 	pool sqsdomain.PoolI,
 	cosmwasmPool *cwpoolmodel.CosmWasmPool,
-	cosmWasmPoolsParams CosmWasmPoolsParams,
+	cosmWasmPoolsParams cosmwasmdomain.CosmWasmPoolsParams,
 	tokenOutDenom string,
 	takerFee osmomath.Dec,
 ) (domain.RoutablePool, error) {

--- a/router/usecase/pools/pool_factory_test.go
+++ b/router/usecase/pools/pool_factory_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 	"github.com/stretchr/testify/require"
@@ -190,7 +191,7 @@ func TestNewRoutableCosmWasmPoolWithCustomModel(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+			cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 				Config: tt.cosmWasmConfig,
 			}
 			routablePool, err := pools.NewRoutableCosmWasmPoolWithCustomModel(tt.pool, tt.cosmwasmPool, cosmWasmPoolsParams, tt.tokenOutDenom, tt.takerFee)

--- a/router/usecase/pools/routable_concentrated_pool_test.go
+++ b/router/usecase/pools/routable_concentrated_pool_test.go
@@ -7,6 +7,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
@@ -88,7 +89,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 					PoolDenoms:            []string{"foo", "bar"},
 				},
 			}
-			cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+			cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 			}
 			routablePool, err := pools.NewRoutablePool(poolWrapper, tc.TokenOutDenom, noTakerFee, cosmWasmPoolsParams)

--- a/router/usecase/pools/routable_cw_alloy_transmuter_pool_test.go
+++ b/router/usecase/pools/routable_cw_alloy_transmuter_pool_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
@@ -57,7 +58,7 @@ func (s *RoutablePoolTestSuite) SetupRoutableAlloyTransmuterPoolCustom(tokenInDe
 		TakerFee: takerFee,
 	}
 
-	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+	cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 		Config: domain.CosmWasmPoolRouterConfig{
 			AlloyedTransmuterCodeIDs: map[uint64]struct{}{
 				defaultPoolID: {},

--- a/router/usecase/pools/routable_cw_orderbook_pool_test.go
+++ b/router/usecase/pools/routable_cw_orderbook_pool_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
@@ -62,7 +63,7 @@ func (s *RoutablePoolTestSuite) SetupRoutableOrderbookPool(
 		TakerFee: takerFee,
 	}
 
-	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+	cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 		Config: domain.CosmWasmPoolRouterConfig{
 			OrderbookCodeIDs: map[uint64]struct{}{
 				cosmwasmPool.GetId(): {},

--- a/router/usecase/pools/routable_cw_pool.go
+++ b/router/usecase/pools/routable_cw_pool.go
@@ -8,6 +8,7 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/cosmwasm/msg"
@@ -39,7 +40,7 @@ type routableCosmWasmPoolImpl struct {
 }
 
 // NewRoutableCosmWasmPool returns a new routable cosmwasm pool with the given parameters.
-func NewRoutableCosmWasmPool(pool *cwpoolmodel.CosmWasmPool, balances sdk.Coins, tokenOutDenom string, takerFee osmomath.Dec, spreadFactor osmomath.Dec, cosmWasmPoolsParams CosmWasmPoolsParams) domain.RoutablePool {
+func NewRoutableCosmWasmPool(pool *cwpoolmodel.CosmWasmPool, balances sdk.Coins, tokenOutDenom string, takerFee osmomath.Dec, spreadFactor osmomath.Dec, cosmWasmPoolsParams cosmwasmdomain.CosmWasmPoolsParams) domain.RoutablePool {
 	// Initializa routable cosmwasm pool
 	routableCosmWasmPool := &routableCosmWasmPoolImpl{
 		ChainPool:     pool,
@@ -106,7 +107,7 @@ func (r *routableCosmWasmPoolImpl) calculateTokenOutByTokenIn(ctx context.Contex
 	calcMessage := msg.NewCalcOutAmtGivenInRequest(tokenIn, tokenOutDenom, r.SpreadFactor)
 
 	calcOutAmtGivenInResponse := msg.CalcOutAmtGivenInResponse{}
-	if err := queryCosmwasmContract(ctx, r.wasmClient, r.ChainPool.ContractAddress, &calcMessage, &calcOutAmtGivenInResponse); err != nil {
+	if err := cosmwasmdomain.QueryCosmwasmContract(ctx, r.wasmClient, r.ChainPool.ContractAddress, &calcMessage, &calcOutAmtGivenInResponse); err != nil {
 		return sdk.Coin{}, err
 	}
 
@@ -180,7 +181,7 @@ func (r *routableCosmWasmPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom 
 	}
 
 	response := &msg.SpotPriceQueryMsgResponse{}
-	if err := queryCosmwasmContract(ctx, r.wasmClient, r.ChainPool.ContractAddress, &request, response); err != nil {
+	if err := cosmwasmdomain.QueryCosmwasmContract(ctx, r.wasmClient, r.ChainPool.ContractAddress, &request, response); err != nil {
 		return osmomath.BigDec{}, err
 	}
 

--- a/router/usecase/pools/routable_cw_transmuter_pool_test.go
+++ b/router/usecase/pools/routable_cw_transmuter_pool_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
 
@@ -61,7 +62,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Transmuter() {
 
 			mock := &mocks.MockRoutablePool{ChainPoolModel: cosmwasmPool.AsSerializablePool(), Balances: tc.balances, PoolType: poolType}
 
-			cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+			cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 				Config: domain.CosmWasmPoolRouterConfig{
 					TransmuterCodeIDs: map[uint64]struct{}{
 						cosmwasmPool.GetCodeId(): {},

--- a/router/usecase/pools/routable_pool_test.go
+++ b/router/usecase/pools/routable_pool_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"github.com/stretchr/testify/suite"
 
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
 
@@ -94,7 +95,7 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_CFMM() {
 			s.Require().NoError(err)
 
 			mock := &mocks.MockRoutablePool{ChainPoolModel: pool, PoolType: tc.poolType}
-			cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+			cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 			}
 			routablePool, err := pools.NewRoutablePool(mock, tc.tokenOutDenom, noTakerFee, cosmWasmPoolsParams)

--- a/router/usecase/quote_test.go
+++ b/router/usecase/quote_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	"github.com/osmosis-labs/sqs/router/usecase"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
@@ -291,7 +292,7 @@ func (s *RouterTestSuite) validateRoutes(expectedRoutes []domain.SplitRoute, act
 }
 
 func (s *RouterTestSuite) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec, cosmWasmConfig domain.CosmWasmPoolRouterConfig) domain.RoutablePool {
-	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+	cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 		Config:                cosmWasmConfig,
 		ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 	}

--- a/router/usecase/routertesting/quote.go
+++ b/router/usecase/routertesting/quote.go
@@ -2,6 +2,7 @@ package routertesting
 
 import (
 	"github.com/osmosis-labs/sqs/domain"
+	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/router/usecase"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
 	"github.com/osmosis-labs/sqs/router/usecase/route"
@@ -41,7 +42,7 @@ var (
 )
 
 func (s *RouterTestHelper) newRoutablePool(pool sqsdomain.PoolI, tokenOutDenom string, takerFee osmomath.Dec) domain.RoutablePool {
-	cosmWasmPoolsParams := pools.CosmWasmPoolsParams{
+	cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 		ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 	}
 	routablePool, err := pools.NewRoutablePool(pool, tokenOutDenom, takerFee, cosmWasmPoolsParams)


### PR DESCRIPTION
Separating clean-up boilerplate from the order book plug in work stream:
https://github.com/osmosis-labs/sqs/pull/442

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Refactored codebase to enhance modularity, moving `CosmWasmPoolsParams` to a new package, `cosmwasmdomain`.
	- Improved accessibility of the `QueryCosmwasmContract` function by changing its visibility.
  
- **Bug Fixes**
	- Adjusted internal calls to ensure consistent usage of the updated `CosmWasmPoolsParams` type across various components.

- **Documentation**
	- Updated import statements to reflect changes in the package structure and type references.

- **Chores**
	- Cleaned up code to improve maintainability and clarity regarding type usage throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->