### PR TITLE
fix: change CL and orderbook tick iteration exit condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ## Unreleased
 
 - Orderbook plugin
+- Change tick iteration exit condition in CL in orderbook from zero to smallest Dec (18 decimals).
 
 ## v25.9.0
 

--- a/ingest/usecase/plugins/orderbookfiller/orderbook_cw_client.go
+++ b/ingest/usecase/plugins/orderbookfiller/orderbook_cw_client.go
@@ -16,7 +16,7 @@ type orderbookCWAPIClient struct {
 
 var _ orderbookplugindomain.OrderbookCWAPIClient = (*orderbookCWAPIClient)(nil)
 
-//ordersByTick is a struct that represents the request payload for the orders_by_tick query.
+// ordersByTick is a struct that represents the request payload for the orders_by_tick query.
 type ordersByTick struct {
 	Tick int64 `json:"tick_id"`
 }

--- a/router/usecase/pools/routable_concentrated_pool.go
+++ b/router/usecase/pools/routable_concentrated_pool.go
@@ -21,7 +21,7 @@ import (
 )
 
 var _ domain.RoutablePool = &routableConcentratedPoolImpl{}
-var zeroBigDec = osmomath.ZeroBigDec()
+var smallestDec = osmomath.BigDecFromDec(osmomath.SmallestDec())
 
 type routableConcentratedPoolImpl struct {
 	ChainPool     *concentratedmodel.Pool "json:\"cl_pool\""
@@ -130,7 +130,7 @@ func (r *routableConcentratedPoolImpl) CalculateTokenOutByTokenIn(ctx context.Co
 	}
 
 	// Initialize the swap strategy.
-	swapStrategy := swapstrategy.New(isZeroForOne, zeroBigDec, &storetypes.KVStoreKey{}, concentratedPool.SpreadFactor)
+	swapStrategy := swapstrategy.New(isZeroForOne, smallestDec, &storetypes.KVStoreKey{}, concentratedPool.SpreadFactor)
 
 	var (
 		// Swap state

--- a/router/usecase/pools/routable_cw_orderbook_pool.go
+++ b/router/usecase/pools/routable_cw_orderbook_pool.go
@@ -102,7 +102,7 @@ func (r *routableOrderbookPoolImpl) CalculateTokenOutByTokenIn(ctx context.Conte
 	}
 
 	// ASSUMPTION: Ticks are ordered
-	for amountInRemaining.GT(zeroBigDec) {
+	for amountInRemaining.GT(smallestDec) {
 		// Order has run out of ticks to iterate
 		if tickIdx >= len(r.OrderbookData.Ticks) || tickIdx < 0 {
 			return sdk.Coin{}, domain.OrderbookNotEnoughLiquidityToCompleteSwapError{PoolId: r.GetId(), AmountIn: tokenIn.String()}


### PR DESCRIPTION
While working on the fill bot, I've observed issues where the system would fail due to "not enough liquidity" due to attempting to over-consume dust.

Recalled that in CL we have a smallest dec exit condition rather than zero. Applying the same change here helped fix the problem
https://github.com/osmosis-labs/osmosis/blob/c8140e68fe30c81996925f1b490bcc1944d60cdb/x/concentrated-liquidity/swaps.go#L601

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the orderbook plugin for improved precision in handling tick data by adjusting the iteration exit condition.
	- Updated the loop condition in the token swap calculations to allow processing of smaller amounts of tokens, potentially improving liquidity handling.
  
- **Bug Fixes**
	- Corrected minor formatting issues in comments for better readability, ensuring clarity in the orderbook client code.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->