### PR TITLE
fix: bug in skipping Numia errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - Orderbook plugin
 - Change tick iteration exit condition in CL in orderbook from zero to smallest Dec (18 decimals).
 - Add rounding direction to the order book
+- Fix bug in skipping Numia API response errors 
 
 ## v25.9.0
 

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -206,20 +206,16 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 	// Iniitialize data fetcher for pool APRs
 	fetchPoolAPRsCallback := datafetchers.GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient, logger)
 	var aprFetcher datafetchers.MapFetcher[uint64, passthroughdomain.PoolAPR] = datafetchers.NewMapFetcher(fetchPoolAPRsCallback, time.Minute*time.Duration(passthroughConfig.APRFetchIntervalMinutes))
-	aprFetcher.WaitUntilFirstResult()
 
 	// Register the APR fetcher with the passthrough use case
-	passthroughUseCase.RegisterAPRFetcher(aprFetcher)
 	poolsUseCase.RegisterAPRFetcher(aprFetcher)
 
 	// Initialize data fetcher for pool fees
 	timeseriesHTTPClient := passthroughdomain.NewTimeSeriesHTTPClient(passthroughConfig.TimeseriesURL)
 	fetchPoolFeesCallback := datafetchers.GetFetchPoolPoolFeesFromTimeseries(timeseriesHTTPClient, logger)
 	poolFeesFetcher := datafetchers.NewMapFetcher(fetchPoolFeesCallback, time.Minute*time.Duration(passthroughConfig.PoolFeesFetchIntervalMinutes))
-	poolFeesFetcher.WaitUntilFirstResult()
 
 	// Register the pool fees fetcher with the passthrough use case
-	passthroughUseCase.RegisterPoolFeesFetcher(poolFeesFetcher)
 	poolsUseCase.RegisterPoolFeesFetcher(poolFeesFetcher)
 
 	// Start grpc ingest server if enabled

--- a/passthrough/usecase/passthrough_usecase.go
+++ b/passthrough/usecase/passthrough_usecase.go
@@ -14,7 +14,6 @@ import (
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/log"
-	"github.com/osmosis-labs/sqs/sqsutil/datafetchers"
 )
 
 type passthroughUseCase struct {
@@ -24,10 +23,6 @@ type passthroughUseCase struct {
 	defaultQuoteDenom     string
 	liquidityPricer       domain.LiquidityPricer
 	passthroughGRPCClient passthroughdomain.PassthroughGRPCClient
-
-	aprPrefetcher datafetchers.Fetcher[map[uint64]passthroughdomain.PoolAPR]
-
-	poolFeesPrefetcher datafetchers.Fetcher[map[uint64]passthroughdomain.PoolFee]
 
 	logger log.Logger
 }
@@ -390,16 +385,6 @@ func (p *passthroughUseCase) GetPortfolioAssets(ctx context.Context, address str
 	}
 
 	return finalResult, nil
-}
-
-// RegisterAPRFetcher registers the APR fetcher for the passthrough use case.
-func (p *passthroughUseCase) RegisterAPRFetcher(aprFetcher datafetchers.Fetcher[map[uint64]passthroughdomain.PoolAPR]) {
-	p.aprPrefetcher = aprFetcher
-}
-
-// RegisterPoolFeesFetcher registers the pool fees fetcher for the passthrough use case.
-func (p *passthroughUseCase) RegisterPoolFeesFetcher(poolFeesFetcher datafetchers.Fetcher[map[uint64]passthroughdomain.PoolFee]) {
-	p.poolFeesPrefetcher = poolFeesFetcher
 }
 
 // computeCapitalizationForCoins instruments the coins with their liquiditiy capitalization values.

--- a/sqsutil/datafetchers/map_prefetch.go
+++ b/sqsutil/datafetchers/map_prefetch.go
@@ -23,7 +23,7 @@ type MapIntervalFetcher[K comparable, V any] struct {
 var _ MapFetcher[uint64, uint64] = (*MapIntervalFetcher[uint64, uint64])(nil)
 
 // NewMapFetcher returns a new MapIntervalFetcher.
-func NewMapFetcher[K comparable, V any](updateFn func() map[K]V, interval time.Duration) *MapIntervalFetcher[K, V] {
+func NewMapFetcher[K comparable, V any](updateFn func() (map[K]V, error), interval time.Duration) *MapIntervalFetcher[K, V] {
 	return &MapIntervalFetcher[K, V]{
 		IntervalFetcher: NewIntervalFetcher(updateFn, interval),
 	}

--- a/sqsutil/datafetchers/map_prefetch_test.go
+++ b/sqsutil/datafetchers/map_prefetch_test.go
@@ -16,7 +16,7 @@ func TestMapIntervalFetcher_GetByKey(t *testing.T) {
 	didFetchOnce := atomic.Bool{}
 
 	// Define the update function
-	updateFn := func() map[int]string {
+	updateFn := func() (map[int]string, error) {
 		if didFetchOnce.Load() {
 			// Intentionally block the update function to simulate a slow update
 			time.Sleep(10 * time.Second)
@@ -28,7 +28,7 @@ func TestMapIntervalFetcher_GetByKey(t *testing.T) {
 			1: "one",
 			2: "two",
 			3: "three",
-		}
+		}, nil
 	}
 
 	// Create a new MapIntervalFetcher with a short interval

--- a/sqsutil/datafetchers/numia_apr_fetcher.go
+++ b/sqsutil/datafetchers/numia_apr_fetcher.go
@@ -12,8 +12,8 @@ import (
 // GetFetchPoolAPRsFromNumiaCb returns a callback to fetch pool APRs from Numia.
 // It increments the error counter if the pool APRs fetching fails.
 // It returns a callback function that returns the pool APRs on success.
-func GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClient, logger log.Logger) func() map[uint64]passthroughdomain.PoolAPR {
-	return func() map[uint64]passthroughdomain.PoolAPR {
+func GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClient, logger log.Logger) func() (map[uint64]passthroughdomain.PoolAPR, error) {
+	return func() (map[uint64]passthroughdomain.PoolAPR, error) {
 		// Fetch pool APRs from the passthrough grpc client
 		poolAPRs, err := numiaHTTPClient.GetPoolAPRsRange()
 		if err != nil {
@@ -21,6 +21,7 @@ func GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClie
 
 			// Increment the error counter
 			domain.SQSPassthroughNumiaAPRsFetchErrorCounter.Inc()
+			return nil, err
 		}
 
 		// Convert to map
@@ -29,15 +30,15 @@ func GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClie
 			poolAPRsMap[poolAPR.PoolID] = poolAPR
 		}
 
-		return poolAPRsMap
+		return poolAPRsMap, nil
 	}
 }
 
 // GetFetchPoolPoolFeesFromTimeseries returns a callback to fetch pool fees from timeseries data stack.
 // It increments the error counter if the pool fees fetching fails.
 // It returns a callback function that returns the pool fees on success.
-func GetFetchPoolPoolFeesFromTimeseries(timeseriesHTTPClient passthroughdomain.TimeSeriesHTTPClient, logger log.Logger) func() map[uint64]passthroughdomain.PoolFee {
-	return func() map[uint64]passthroughdomain.PoolFee {
+func GetFetchPoolPoolFeesFromTimeseries(timeseriesHTTPClient passthroughdomain.TimeSeriesHTTPClient, logger log.Logger) func() (map[uint64]passthroughdomain.PoolFee, error) {
+	return func() (map[uint64]passthroughdomain.PoolFee, error) {
 		// Fetch pool APRs from the passthrough grpc client
 		poolFees, err := timeseriesHTTPClient.GetPoolFees()
 		if err != nil {
@@ -45,6 +46,8 @@ func GetFetchPoolPoolFeesFromTimeseries(timeseriesHTTPClient passthroughdomain.T
 
 			// Increment the error counter
 			domain.SQSPassthroughTimeseriesPoolFeesFetchErrorCounter.Inc()
+
+			return nil, err
 		}
 
 		poolFeesMap := make(map[uint64]passthroughdomain.PoolFee, len(poolFees.Data))
@@ -60,6 +63,6 @@ func GetFetchPoolPoolFeesFromTimeseries(timeseriesHTTPClient passthroughdomain.T
 			poolFeesMap[poolID] = poolFee
 		}
 
-		return poolFeesMap
+		return poolFeesMap, nil
 	}
 }

--- a/sqsutil/datafetchers/prefetch.go
+++ b/sqsutil/datafetchers/prefetch.go
@@ -17,7 +17,7 @@ type Fetcher[T any] interface {
 // and provides a method to get the latest value.
 // NOTE: It may return stale data if the update function takes longer than the interval.
 type IntervalFetcher[T any] struct {
-	updateFn  func() T
+	updateFn  func() (T, error)
 	interval  time.Duration
 	hasClosed bool
 
@@ -29,7 +29,7 @@ type IntervalFetcher[T any] struct {
 	mutex                 sync.RWMutex
 }
 
-func NewIntervalFetcher[T any](updateFn func() T, interval time.Duration) *IntervalFetcher[T] {
+func NewIntervalFetcher[T any](updateFn func() (T, error), interval time.Duration) *IntervalFetcher[T] {
 	if interval <= 0 {
 		panic("interval must be greater than 0")
 	}
@@ -54,7 +54,11 @@ func (p *IntervalFetcher[T]) startTimer() {
 }
 
 func (p *IntervalFetcher[T]) prefetch() {
-	newValue := p.updateFn()
+	newValue, err := p.updateFn()
+	if err != nil {
+		return
+	}
+
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
 

--- a/sqsutil/datafetchers/prefetch.go
+++ b/sqsutil/datafetchers/prefetch.go
@@ -56,6 +56,8 @@ func (p *IntervalFetcher[T]) startTimer() {
 func (p *IntervalFetcher[T]) prefetch() {
 	newValue, err := p.updateFn()
 	if err != nil {
+		// By silently skipping the error, the values would become stale,
+		// signaling that to the client.
 		return
 	}
 

--- a/sqsutil/datafetchers/prefetch_test.go
+++ b/sqsutil/datafetchers/prefetch_test.go
@@ -13,9 +13,9 @@ import (
 // The test also checks that the WaitUntilFirstResult method blocks for the expected duration,
 // and does not block for too long.
 func TestWaitUntilFirstResult(t *testing.T) {
-	updateFn := func() int {
+	updateFn := func() (int, error) {
 		time.Sleep(2 * time.Second)
-		return 42
+		return 42, nil
 	}
 
 	start := time.Now()


### PR DESCRIPTION
There was an SQS production incident due to Numia downtime. Despite SQS [having a mechanism to silently skip and ignore errors](https://github.com/osmosis-labs/sqs/blob/155f32489707fef76c55ebfe652cdd3541279aa8/pools/usecase/pools_usecase.go#L571-L581), a code bug caused a panic in an edge case in the fetching mechanism.

Additionally, at start-up, SQS would block waiting to receive the result.

The improvement here is twofold:
1. Fix code bug to handle Numia error and prevent the unexpected panic
2. Remove the blocking behavior when fetching Numia data during restart. 

## Data Dog Logs

These are the logs that have uncovered the issue.

![image](https://github.com/user-attachments/assets/7522bb98-4081-4fc2-97a3-9aa5790430b1)

https://us5.datadoghq.com/logs?query=-status%3A%28warn%20OR%20notice%20OR%20info%20OR%20ok%29%20service%3Asqs&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1723428479706&to_ts=1723430120759&live=false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for API responses, enhancing system reliability.
  
- **New Features**
  - Introduced error handling in data-fetching functions, allowing for better management of fetch failures.
  
- **Refactor**
  - Simplified fetcher initialization by altering registration processes.
  - Adjusted method signatures across various components to return error values, improving robustness.

- **Tests**
  - Updated test cases to reflect new error handling mechanisms, ensuring comprehensive testing of functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->