### PR TITLE
fix: consistently return formatted json response with status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - Apply taker fee and spread factor for fill bot amount estimation
 - Reduce fill bot slippage bound by one ulp
 - Fallback to filling each message individually.
+- "in given out" for /custom-direct-quote
+- Fix response status codes in /quote and /custom-direct-quote
 
 ## v25.9.0
 

--- a/router/delivery/http/router_handler.go
+++ b/router/delivery/http/router_handler.go
@@ -86,12 +86,12 @@ func (a *RouterHandler) GetOptimalQuote(c echo.Context) (err error) {
 
 	var req types.GetQuoteRequest
 	if err := UnmarshalRequest(c, &req); err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
 	}
 
 	// Validate the request
 	if err := req.Validate(); err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
 	}
 
 	var (
@@ -107,7 +107,7 @@ func (a *RouterHandler) GetOptimalQuote(c echo.Context) (err error) {
 
 	chainDenoms, err := mvc.ValidateChainDenomsQueryParam(c, a.TUsecase, []string{tokenIn.Denom, tokenOutDenom})
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
 	}
 
 	// Update coins token in denom it case it was translated from human to chain.
@@ -127,7 +127,7 @@ func (a *RouterHandler) GetOptimalQuote(c echo.Context) (err error) {
 	}
 
 	if err != nil {
-		return err
+		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
 	}
 
 	scalingFactor := oneDec
@@ -137,7 +137,7 @@ func (a *RouterHandler) GetOptimalQuote(c echo.Context) (err error) {
 
 	_, _, err = quote.PrepareResult(ctx, scalingFactor, a.logger)
 	if err != nil {
-		return err
+		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
 	}
 
 	span.SetAttributes(attribute.Stringer("token_out", quote.GetAmountOut()))
@@ -179,12 +179,12 @@ func (a *RouterHandler) GetDirectCustomQuote(c echo.Context) (err error) {
 
 	var req types.GetDirectCustomQuoteRequest
 	if err := UnmarshalRequest(c, &req); err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
 	}
 
 	// Validate the request
 	if err := req.Validate(); err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
 	}
 
 	var (
@@ -202,7 +202,7 @@ func (a *RouterHandler) GetDirectCustomQuote(c echo.Context) (err error) {
 	// Apply human denoms conversion if required.
 	chainDenoms, err := mvc.ValidateChainDenomsQueryParam(c, a.TUsecase, append([]string{tokenIn.Denom}, tokenOutDenom...))
 	if err != nil {
-		return err
+		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
 	}
 
 	// Update coins token in denom it case it was translated from human to chain.

--- a/router/delivery/http/router_handler_test.go
+++ b/router/delivery/http/router_handler_test.go
@@ -144,6 +144,7 @@ func (s *RouterHandlerSuite) TestGetOptimalQuote() {
 			err := tc.handler.GetOptimalQuote(c)
 
 			if tc.expectedError {
+				// Note: in case of error, we expect err to be nil but the status code to be non-200
 				s.Assert().Nil(err)
 				s.Assert().Equal(tc.expectedStatusCode, rec.Code)
 				s.Assert().JSONEq(tc.expectedResponse, rec.Body.String())
@@ -344,6 +345,7 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 			err := tc.handler.GetDirectCustomQuote(c)
 
 			if tc.expectedError {
+				// Note: in case of error, we expect err to be nil but the status code to be non-200
 				s.Assert().Nil(err)
 				s.Assert().Equal(tc.expectedStatusCode, rec.Code)
 				s.Assert().Equal(

--- a/router/delivery/http/router_handler_test.go
+++ b/router/delivery/http/router_handler_test.go
@@ -2,7 +2,6 @@ package http_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -13,7 +12,6 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	routerdelivery "github.com/osmosis-labs/sqs/router/delivery/http"
-	routertypes "github.com/osmosis-labs/sqs/router/types"
 	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
 	"github.com/stretchr/testify/suite"
 )
@@ -45,7 +43,7 @@ func (s *RouterHandlerSuite) TestGetOptimalQuote() {
 		handler            *routerdelivery.RouterHandler
 		expectedStatusCode int
 		expectedResponse   string
-		expectedError      error
+		expectedError      bool
 	}{
 		{
 			name: "valid exact in request",
@@ -69,7 +67,6 @@ func (s *RouterHandlerSuite) TestGetOptimalQuote() {
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedResponse:   s.MustReadFile("../../usecase/routertesting/parsing/quote_amount_in_response.json"),
-			expectedError:      nil,
 		},
 		{
 			name: "valid exact out request",
@@ -93,7 +90,6 @@ func (s *RouterHandlerSuite) TestGetOptimalQuote() {
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedResponse:   s.MustReadFile("../../usecase/routertesting/parsing/quote_amount_out_response.json"),
-			expectedError:      nil,
 		},
 		{
 			name: "invalid swap method request",
@@ -103,9 +99,9 @@ func (s *RouterHandlerSuite) TestGetOptimalQuote() {
 				"singleRoute":    "true",
 				"applyExponents": "true",
 			},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"message": "swap method is invalid - must be either swap exact amount in or swap exact amount out"}`,
-			expectedError:      routertypes.ErrSwapMethodNotValid,
+			expectedError:      true,
 		},
 		{
 			name: "invalid tokenIn format",
@@ -115,9 +111,9 @@ func (s *RouterHandlerSuite) TestGetOptimalQuote() {
 				"singleRoute":    "true",
 				"applyExponents": "true",
 			},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"message": "tokenIn is invalid - must be in the format amountDenom"}`,
-			expectedError:      routertypes.ErrTokenInNotValid,
+			expectedError:      true,
 		},
 		{
 			name: "invalid tokenOut format",
@@ -127,9 +123,9 @@ func (s *RouterHandlerSuite) TestGetOptimalQuote() {
 				"singleRoute":    "true",
 				"applyExponents": "true",
 			},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"message": "tokenOut is invalid - must be in the format amountDenom"}`,
-			expectedError:      routertypes.ErrTokenOutNotValid,
+			expectedError:      true,
 		},
 	}
 	for _, tc := range testcases {
@@ -147,9 +143,8 @@ func (s *RouterHandlerSuite) TestGetOptimalQuote() {
 
 			err := tc.handler.GetOptimalQuote(c)
 
-			if tc.expectedError != nil {
-				s.Assert().Error(err)
-				s.Assert().Equal(tc.expectedError, err)
+			if tc.expectedError {
+				s.Assert().Nil(err)
 				s.Assert().Equal(tc.expectedStatusCode, rec.Code)
 				s.Assert().JSONEq(tc.expectedResponse, rec.Body.String())
 				return
@@ -178,7 +173,7 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 		handler            *routerdelivery.RouterHandler
 		expectedStatusCode int
 		expectedResponse   string
-		expectedError      error
+		expectedError      bool
 	}{
 		{
 			name: "valid exact in request",
@@ -202,7 +197,6 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedResponse:   s.MustReadFile("../../usecase/routertesting/parsing/quote_amount_in_response.json"),
-			expectedError:      nil,
 		},
 		{
 			name: "valid exact out request",
@@ -226,7 +220,6 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedResponse:   s.MustReadFile("../../usecase/routertesting/parsing/quote_amount_out_response.json"),
-			expectedError:      nil,
 		},
 		{
 			name: "valid exact out request: apply human denom",
@@ -253,7 +246,6 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 			},
 			expectedStatusCode: http.StatusOK,
 			expectedResponse:   s.MustReadFile("../../usecase/routertesting/parsing/quote_amount_out_response.json"),
-			expectedError:      nil,
 		},
 		{
 			name: "not valid exact out request: apply human denom",
@@ -278,9 +270,9 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 					},
 				},
 			},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"message":"denom is not a valid chain denom (usdc)"}`,
-			expectedError:      fmt.Errorf("denom is not a valid chain denom (%s)", "usdc"),
+			expectedError:      true,
 		},
 		{
 			name: "invalid swap method request",
@@ -292,9 +284,9 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 				"poolID":         "10",
 				"applyExponents": "true",
 			},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"message":"swap method is invalid - must be either swap exact amount in or swap exact amount out"}`,
-			expectedError:      routertypes.ErrSwapMethodNotValid,
+			expectedError:      true,
 		},
 		{
 			name: "invalid pools request",
@@ -306,9 +298,9 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 				"poolID":         "string,5",
 				"applyExponents": "true",
 			},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"message":"pool ID must be integer"}`,
-			expectedError:      routertypes.ErrPoolIDNotValid,
+			expectedError:      true,
 		},
 		{
 			name: "invalid tokenIn format",
@@ -318,9 +310,9 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 				"singleRoute":    "true",
 				"applyExponents": "true",
 			},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"message":"tokenIn is invalid - must be in the format amountDenom"}`,
-			expectedError:      routertypes.ErrTokenInNotValid,
+			expectedError:      true,
 		},
 		{
 			name: "invalid tokenOut format",
@@ -330,9 +322,9 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 				"singleRoute":    "true",
 				"applyExponents": "true",
 			},
-			expectedStatusCode: http.StatusInternalServerError,
+			expectedStatusCode: http.StatusBadRequest,
 			expectedResponse:   `{"message":"tokenOut is invalid - must be in the format amountDenom"}`,
-			expectedError:      routertypes.ErrTokenOutNotValid,
+			expectedError:      true,
 		},
 	}
 
@@ -351,9 +343,8 @@ func (s *RouterHandlerSuite) TestGetDirectCustomQuote() {
 
 			err := tc.handler.GetDirectCustomQuote(c)
 
-			if tc.expectedError != nil {
-				s.Assert().Error(err)
-				s.Assert().Equal(tc.expectedError, err)
+			if tc.expectedError {
+				s.Assert().Nil(err)
 				s.Assert().Equal(tc.expectedStatusCode, rec.Code)
 				s.Assert().Equal(
 					strings.TrimSpace(tc.expectedResponse),

--- a/router/types/get_direct_custom_quote_request.go
+++ b/router/types/get_direct_custom_quote_request.go
@@ -23,13 +23,11 @@ type GetDirectCustomQuoteRequest struct {
 
 // UnmarshalHTTPRequest unmarshals the HTTP request to GetDirectCustomQuoteRequest.
 // It returns an error if the request is invalid.
-// NOTE: Currently method for some cases returns an error, while for others
-// it returns a response error. This is not consistent and should be fixed.
 func (r *GetDirectCustomQuoteRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	var err error
 	r.ApplyExponents, err = domain.ParseBooleanQueryParam(c, "applyExponents")
 	if err != nil {
-		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
+		return err
 	}
 
 	if tokenIn := c.QueryParam("tokenIn"); tokenIn != "" {

--- a/router/types/get_quote_request.go
+++ b/router/types/get_quote_request.go
@@ -29,7 +29,7 @@ func (r *GetQuoteRequest) UnmarshalHTTPRequest(c echo.Context) error {
 
 	r.ApplyExponents, err = domain.ParseBooleanQueryParam(c, "applyExponents")
 	if err != nil {
-		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
+		return err
 	}
 
 	if tokenIn := c.QueryParam("tokenIn"); tokenIn != "" {

--- a/router/types/get_quote_request.go
+++ b/router/types/get_quote_request.go
@@ -20,13 +20,11 @@ type GetQuoteRequest struct {
 
 // UnmarshalHTTPRequest unmarshals the HTTP request to GetQuoteRequest.
 // It returns an error if the request is invalid.
-// NOTE: Currently method for some cases returns an error, while for others
-// it returns a response error. This is not consistent and should be fixed.
 func (r *GetQuoteRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	var err error
 	r.SingleRoute, err = domain.ParseBooleanQueryParam(c, "singleRoute")
 	if err != nil {
-		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
+		return err
 	}
 
 	r.ApplyExponents, err = domain.ParseBooleanQueryParam(c, "applyExponents")


### PR DESCRIPTION
This PR is a follow up to "in given out" refactor to consistently return HTTP status codes as json responses.

Without these,  the HTTP API responses lack context about the error details.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved API documentation for the `/custom-direct-quote` endpoint for better clarity.
- **Bug Fixes**
	- Corrected response status codes for the `/quote` and `/custom-direct-quote` endpoints to ensure proper API behavior.
	- Enhanced error handling for `GetOptimalQuote` and `GetDirectCustomQuote` methods to provide structured JSON responses on errors.
- **Refactor**
	- Simplified error handling in the `GetDirectCustomQuoteRequest` and `GetQuoteRequest` methods to ensure consistent error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->