### PR TITLE
Skip order books for "in given out" API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - Apply taker fee and spread factor for fill bot amount estimation
 - Reduce fill bot slippage bound by one ulp
 - Fallback to filling each message individually.
+- Add router and candidate route search options to disable route cache
 
 ## v25.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## v25.12.0
+
+- Add router and candidate route search options to disable route cache
+
 ## v25.11.0
 
 - Fix concurrency bug in data fetcher prefetching.
 - Fix error response status codes in /quote and /custom-direct-quote
-- Add router and candidate route search options to disable route cache
 
 ## v25.10.0
 

--- a/README.md
+++ b/README.md
@@ -520,17 +520,6 @@ Unless specified by using the parameter `pricingSource`, the [GET /tokens/prices
 
 Internally, the Coingecko pricing source looks for the price quote in the its pricing cache and return it if it exists. Otherwise, it fetches the price from the Coingecko API endpoint and store it in the cache with an expiration time specified in the config.json file.
 
-### Caching
-
-We perform caching of routes to avoid having to recompute them on every request.
-
-There is a configuration parameter that enables the route cache to be updated every X blocks.
-However, that is an experimental feature. See the configuration section for details.
-
-The router also caches the routes when it computes it for the first time for a given token in and token out denom.
-As of now, the cache is cleared at the end of very block. We should investigate only clearing pool data but persisting
-the routes for longer while allowing for manual updates and invalidation.
-
 ### Configuration
 
 The router has several configuration parameters that are set via `app.toml`.

--- a/docs/architecture/routing.md
+++ b/docs/architecture/routing.md
@@ -34,6 +34,25 @@ is consumed by a single route as opposed to performing partial split routing ove
 4. Keep "Max Splittable Routes" and attempt to determine an optimal quote split across them
     - If the split quote is more optimal, return that. Otherwise, return the best single direct quote.
 
+## Route Cache
+
+We perform caching of routes to avoid having to recompute them on every request.
+
+The caches are configured via TTL in the config. There is also a boolean config to enable it.
+
+We have two types of route caches:
+
+1. **Candidate route**
+
+This cache aims to contain `router.max-routes` number of unranked routes between token in and token out denom.
+
+2. **Ranked route**
+
+This cache aims to contain top `router.max-split-routes` that are ranked by token out amount across all top candidate routes. Only the top `router.max-split-routes` are written to cache.
+
+For a given token in and out denom, this cache is written with the granularity of order of magnitude of token in because
+the top routes can drastically vary as the token in amount changes due to varying pool liquidities.
+
 ## Pool Filtering - Min Liquidity Capitalization
 
 Osmosis chain consists of many pools where some of them are low liquidity.

--- a/domain/cache/cache.go
+++ b/domain/cache/cache.go
@@ -74,3 +74,10 @@ func (c *Cache) Delete(key string) {
 
 	delete(c.data, key)
 }
+
+// Len returns the number of entries in the cache
+func (c *Cache) Len() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return len(c.data)
+}

--- a/domain/candidate_routes.go
+++ b/domain/candidate_routes.go
@@ -13,6 +13,9 @@ type CandidateRouteSearchOptions struct {
 	MaxPoolsPerRoute int
 	// MinPoolLiquidityCap is the minimum liquidity cap for a pool to be considered.
 	MinPoolLiquidityCap uint64
+	// DisableCache specifies if route cache should be disbled.
+	// If true, the candidate route cache is neither read nor written to.
+	DisableCache bool
 }
 
 // CandidateRouteSearcher is the interface for finding candidate routes.

--- a/domain/candidate_routes.go
+++ b/domain/candidate_routes.go
@@ -5,6 +5,10 @@ import (
 	"github.com/osmosis-labs/sqs/sqsdomain"
 )
 
+// CandidateRoutePoolFiltrerCb defines a candidate route pool filter
+// that takes in a pool and returns true if the pool should be skipped.
+type CandidateRoutePoolFiltrerCb func(*sqsdomain.PoolWrapper) bool
+
 // CandidateRouteSearchOptions represents the options for finding candidate routes.
 type CandidateRouteSearchOptions struct {
 	// MaxRoutes is the maximum number of routes to find.
@@ -16,7 +20,48 @@ type CandidateRouteSearchOptions struct {
 	// DisableCache specifies if route cache should be disbled.
 	// If true, the candidate route cache is neither read nor written to.
 	DisableCache bool
+
+	// PoolFiltersAnyOf are the callbacks that take in a pool, returning
+	// true if the candidate route algorithm should ignore a pool matching a certain condition.
+	// If at least one of the callbacks in-slice returns true, the ShouldSkipPool function will
+	// also return true.
+	PoolFiltersAnyOf []CandidateRoutePoolFiltrerCb
 }
+
+// ShouldSkipPool returns true if the candidate route algorithm should skip
+// a given pool by matching at least one of the pool filters
+func (c CandidateRouteSearchOptions) ShouldSkipPool(pool *sqsdomain.PoolWrapper) bool {
+	for _, filter := range c.PoolFiltersAnyOf {
+		if filter(pool) {
+			return true
+		}
+	}
+	return false
+}
+
+// CandidateRoutePoolIDFilterOptionCb encapsulates the pool IDs that should be skipped by the candidate route
+// algorithm, exposing an API to determine whether the given pool mathes any of the pool IDs that
+// should be skipped.
+type CandidateRoutePoolIDFilterOptionCb struct {
+	PoolIDsToSkip map[uint64]struct{}
+}
+
+// ShouldSkipPool returns true of the given pool has ID that is present in c.PoolIDsToSkip
+func (c CandidateRoutePoolIDFilterOptionCb) ShouldSkipPool(pool *sqsdomain.PoolWrapper) bool {
+	poolID := pool.GetId()
+	_, ok := c.PoolIDsToSkip[poolID]
+	return ok
+}
+
+var (
+	// ShouldSkipOrderbookPool skips orderbook pools
+	// by returning true if pool.SQSModel.CosmWasmPoolModel is not nil
+	// and pool.SQSModel.CosmWasmPoolModel.IsOrderbook() returns true.
+	ShouldSkipOrderbookPool CandidateRoutePoolFiltrerCb = func(pool *sqsdomain.PoolWrapper) bool {
+		cosmWasmPoolModel := pool.SQSModel.CosmWasmPoolModel
+		return cosmWasmPoolModel != nil && cosmWasmPoolModel.IsOrderbook()
+	}
+)
 
 // CandidateRouteSearcher is the interface for finding candidate routes.
 type CandidateRouteSearcher interface {

--- a/domain/candidate_routes_test.go
+++ b/domain/candidate_routes_test.go
@@ -1,0 +1,136 @@
+package domain_test
+
+import (
+	"testing"
+
+	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/domain/mocks"
+	"github.com/osmosis-labs/sqs/sqsdomain"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
+	"github.com/stretchr/testify/require"
+)
+
+// This test validates the ShouldSkipPool() method of the candidate route search
+// options by registering two filters:
+// 1. PoolID filter
+// 2. Orderbook filter.
+//
+// It then validates that if at least one of the filters is matched, ShouldSkipPool()
+// would return true
+func TestCandidateRouteSearchOptions_ShouldSkipPool(t *testing.T) {
+
+	const (
+		defaultPoolID = uint64(1)
+	)
+
+	var (
+		defaultNonOrderBookPool = sqsdomain.PoolWrapper{
+			ChainModel: &mocks.ChainPoolMock{
+				ID: defaultPoolID,
+			},
+		}
+
+		// instruments the given pool with orderbook data, returning new copy.
+		withOrderBookPool = func(pool sqsdomain.PoolWrapper) sqsdomain.PoolWrapper {
+			pool.SQSModel = sqsdomain.SQSPool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+
+						Orderbook: &cosmwasmpool.OrderbookData{},
+					},
+				},
+			}
+			return pool
+		}
+
+		// instruments the given pool with a new id returning new copy
+		withPoolID = func(pool sqsdomain.PoolWrapper, newPoolID uint64) sqsdomain.PoolWrapper {
+			pool.ChainModel = &mocks.ChainPoolMock{
+				ID: newPoolID,
+			}
+			return pool
+		}
+
+		defaultOrderbookPool = withPoolID(withOrderBookPool(defaultNonOrderBookPool), defaultPoolID+1)
+	)
+
+	tests := []struct {
+		name string
+
+		poolIDsToFilter map[uint64]struct{}
+
+		poolToTest sqsdomain.PoolWrapper
+
+		expectedShouldSkip bool
+	}{
+		{
+			name: "non orderbook pool, not filtered -> returns false",
+
+			poolToTest: defaultNonOrderBookPool,
+
+			expectedShouldSkip: false,
+		},
+
+		{
+			name: "non orderbook pool, filtered by id -> returns true",
+
+			poolToTest: defaultNonOrderBookPool,
+
+			poolIDsToFilter: map[uint64]struct{}{
+				defaultPoolID: {},
+			},
+
+			expectedShouldSkip: true,
+		},
+
+		{
+			name: "order book pool -> returns true",
+
+			poolToTest: defaultOrderbookPool,
+
+			expectedShouldSkip: true,
+		},
+		{
+			name: "both filters match -> return true",
+
+			poolToTest: defaultOrderbookPool,
+
+			poolIDsToFilter: map[uint64]struct{}{
+				defaultOrderbookPool.GetId(): {},
+			},
+
+			expectedShouldSkip: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Set up pool ID filter
+			poolIDFilter := domain.CandidateRoutePoolIDFilterOptionCb{
+				PoolIDsToSkip: tc.poolIDsToFilter,
+			}
+
+			// Initialize options with 2 filters:
+			// 1. By pool ID
+			// 2. All order books.
+			opts := domain.CandidateRouteSearchOptions{
+				PoolFiltersAnyOf: []domain.CandidateRoutePoolFiltrerCb{
+					poolIDFilter.ShouldSkipPool,
+					domain.ShouldSkipOrderbookPool,
+				},
+			}
+
+			// System under test.
+			shouldSkip := opts.ShouldSkipPool(&tc.poolToTest)
+
+			// Validate result.
+			require.Equal(t, tc.expectedShouldSkip, shouldSkip)
+		})
+	}
+}

--- a/domain/router.go
+++ b/domain/router.go
@@ -151,6 +151,9 @@ type RouterOptions struct {
 	// The number of milliseconds to cache candidate routes for before expiry.
 	CandidateRouteCacheExpirySeconds int
 	RankedRouteCacheExpirySeconds    int
+	// DisableCache flag controlling whether candidate route and ranked route caches should be disabled.
+	// If true, neither of the caches is read or written to.
+	DisableCache bool
 }
 
 // DefaultRouterOptions defines the default options for the router
@@ -190,6 +193,13 @@ func WithDisableSplitRoutes() RouterOption {
 func WithMaxSplitRoutes(maxSplitRoutes int) RouterOption {
 	return func(o *RouterOptions) {
 		o.MaxSplitRoutes = maxSplitRoutes
+	}
+}
+
+// WithDisableCache configures the options to disable cache.
+func WithDisableCache() RouterOption {
+	return func(o *RouterOptions) {
+		o.DisableCache = true
 	}
 }
 

--- a/domain/router.go
+++ b/domain/router.go
@@ -154,6 +154,11 @@ type RouterOptions struct {
 	// DisableCache flag controlling whether candidate route and ranked route caches should be disabled.
 	// If true, neither of the caches is read or written to.
 	DisableCache bool
+	// CandidateRoutesPoolFiltersAnyOf are the callbacks that take in a pool, returning
+	// true if the candidate route algorithm should ignore a pool matching a certain condition.
+	// If at least one of the callbacks in-slice returns true, the ShouldSkipPool function will
+	// also return true.
+	CandidateRoutesPoolFiltersAnyOf []CandidateRoutePoolFiltrerCb
 }
 
 // DefaultRouterOptions defines the default options for the router
@@ -200,6 +205,15 @@ func WithMaxSplitRoutes(maxSplitRoutes int) RouterOption {
 func WithDisableCache() RouterOption {
 	return func(o *RouterOptions) {
 		o.DisableCache = true
+	}
+}
+
+// WithCandidateRoutesPoolFiltersAnyOf configures the router options with the candidate routes pool filters.
+// If at least one of the callbacks in-slice returns true, for a specific pool, that pool would be ignored
+// in the candidate route search.
+func WithCandidateRoutesPoolFiltersAnyOf(filters ...CandidateRoutePoolFiltrerCb) RouterOption {
+	return func(o *RouterOptions) {
+		o.CandidateRoutesPoolFiltersAnyOf = filters
 	}
 }
 

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -58,7 +58,6 @@ func (c candidateRouteFinder) FindCandidateRoutes(tokenIn sdk.Coin, tokenOutDeno
 	if len(denomData.CanonicalOrderbooks) > 0 {
 		canonicalOrderbook, ok := denomData.CanonicalOrderbooks[tokenOutDenom]
 		if ok {
-
 			shouldSkipCanonicalOrderbook := false
 			// Filter the canonical orderbook pool using the pool filters.
 			for _, filter := range options.PoolFiltersAnyOf {

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -58,19 +58,34 @@ func (c candidateRouteFinder) FindCandidateRoutes(tokenIn sdk.Coin, tokenOutDeno
 	if len(denomData.CanonicalOrderbooks) > 0 {
 		canonicalOrderbook, ok := denomData.CanonicalOrderbooks[tokenOutDenom]
 		if ok {
-			// Add the canonical orderbook as a route.
-			routes = append(routes, candidateRouteWrapper{
-				IsCanonicalOrderboolRoute: true,
-				Pools: []candidatePoolWrapper{
-					{
-						CandidatePool: sqsdomain.CandidatePool{
-							ID:            canonicalOrderbook.GetId(),
-							TokenOutDenom: tokenOutDenom,
+
+			shouldSkipCanonicalOrderbook := false
+			// Filter the canonical orderbook pool using the pool filters.
+			for _, filter := range options.PoolFiltersAnyOf {
+				// nolint: forcetypeassert
+				canonicalOrderbookPoolWrapper := (canonicalOrderbook).(*sqsdomain.PoolWrapper)
+				if filter(canonicalOrderbookPoolWrapper) {
+					shouldSkipCanonicalOrderbook = true
+					break
+				}
+			}
+
+			if !shouldSkipCanonicalOrderbook {
+				// Add the canonical orderbook as a route.
+				routes = append(routes, candidateRouteWrapper{
+					IsCanonicalOrderboolRoute: true,
+					Pools: []candidatePoolWrapper{
+						{
+							CandidatePool: sqsdomain.CandidatePool{
+								ID:            canonicalOrderbook.GetId(),
+								TokenOutDenom: tokenOutDenom,
+							},
+							PoolDenoms: canonicalOrderbook.GetSQSPoolModel().PoolDenoms,
 						},
-						PoolDenoms: canonicalOrderbook.GetSQSPoolModel().PoolDenoms,
 					},
-				},
-			})
+				})
+			}
+
 			visited[canonicalOrderbook.GetId()] = struct{}{}
 		}
 	}

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -109,6 +109,13 @@ func (c candidateRouteFinder) FindCandidateRoutes(tokenIn sdk.Coin, tokenOutDeno
 				continue
 			}
 
+			// If the option is configured to skip a given pool
+			// We mark it as visited and continue.
+			if options.ShouldSkipPool(pool) {
+				visited[poolID] = struct{}{}
+				continue
+			}
+
 			if pool.GetLiquidityCap().Uint64() < options.MinPoolLiquidityCap {
 				visited[poolID] = struct{}{}
 				// Skip pools that have less liquidity than the minimum required.

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -129,6 +129,7 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 		RankedRouteCacheExpirySeconds:    r.defaultConfig.RankedRouteCacheExpirySeconds,
 		MaxSplitRoutes:                   r.defaultConfig.MaxSplitRoutes,
 		DisableCache:                     !r.defaultConfig.RouteCacheEnabled,
+		CandidateRoutesPoolFiltersAnyOf:  []domain.CandidateRoutePoolFiltrerCb{},
 	}
 	// Apply options
 	for _, opt := range opts {
@@ -392,6 +393,7 @@ func (r *routerUseCaseImpl) computeAndRankRoutesByDirectQuote(ctx context.Contex
 		MaxPoolsPerRoute:    routingOptions.MaxPoolsPerRoute,
 		MinPoolLiquidityCap: routingOptions.MinPoolLiquidityCap,
 		DisableCache:        routingOptions.DisableCache,
+		PoolFiltersAnyOf:    routingOptions.CandidateRoutesPoolFiltersAnyOf,
 	}
 
 	// If top routes are not present in cache, retrieve unranked candidate routes

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -223,6 +223,17 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 // GetOptimalQuoteInGivenOut returns an optimal quote through the pools for the exact amount out token swap method.
 // Underlying implementation is the same as GetOptimalQuote, but the returned quote is wrapped in a quoteExactAmountOut.
 func (r *routerUseCaseImpl) GetOptimalQuoteInGivenOut(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, opts ...domain.RouterOption) (domain.Quote, error) {
+
+	// Disable cache and add orderbook pool filter
+	// So that order-book pools are not used in the candidate route search.
+	// The reason is that order-book contract does not implement the MsgSwapExactAmountOut API.
+	// The reason we disable cache is so that the exluded candidate routes do not interfere with the main
+	// "out given in" API.
+	opts = append(opts,
+		domain.WithDisableCache(),
+		domain.WithCandidateRoutesPoolFiltersAnyOf(domain.ShouldSkipOrderbookPool),
+	)
+
 	quote, err := r.GetOptimalQuote(ctx, tokenIn, tokenOutDenom, opts...)
 	if err != nil {
 		return nil, err

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -223,7 +223,6 @@ func (r *routerUseCaseImpl) GetOptimalQuote(ctx context.Context, tokenIn sdk.Coi
 // GetOptimalQuoteInGivenOut returns an optimal quote through the pools for the exact amount out token swap method.
 // Underlying implementation is the same as GetOptimalQuote, but the returned quote is wrapped in a quoteExactAmountOut.
 func (r *routerUseCaseImpl) GetOptimalQuoteInGivenOut(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, opts ...domain.RouterOption) (domain.Quote, error) {
-
 	// Disable cache and add orderbook pool filter
 	// So that order-book pools are not used in the candidate route search.
 	// The reason is that order-book contract does not implement the MsgSwapExactAmountOut API.


### PR DESCRIPTION
## Context

Order book contract does not implement `MsgSwapExactAmountOut` API. As a result, all quotes returned by SQS that have order book pools in the route fail.

As a work around, we introduce the ability to provide a routing parameter to exclude order books from the candidate routes. Additionally, we introduce a parameter to disable cache.

Both of the parameters are enable for the "in given out" `/quote` method.

The motivation for disabling cache is to avoid interfering with the cache that is meant for "out given in".

The long-term solution is to implement MsgSwapExactAmountOut into the order books.


## Performance

### No Cache

This is the profile under load:
![image](https://github.com/user-attachments/assets/c4ff45bb-ba6f-43b6-b86a-66a997d7924c)

As expected, the candidate route search is now dominating the CPU time due to the cache being disabled.

This is a snapshot of the load test:
![image](https://github.com/user-attachments/assets/12149f85-88c8-4530-ad40-d47c500d0604)

### With Cache

With the cache enabled, we see the candidate route search data nonexistent:
![image](https://github.com/user-attachments/assets/fea3b7b0-9bf4-4496-ad58-3864f92c2d71)

![image](https://github.com/user-attachments/assets/64749cd0-9420-4d08-a5dd-1a289e89880b)

Tail latency is 5x slower while average latency is 23x is slower. The RPS at 100 user load is more than 5x worse too

## Alternative Solution

Given the performance regressions, we may consider a separate solution - a separate cache for "in given out". However, we might run into other constraints such as RAM on the nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced routing options to disable route caching, providing users with enhanced control over routing behavior.
	- Added candidate route filtering capabilities to refine the route selection process.

- **Documentation**
	- Updated the changelog to reflect the new version and feature enhancements.
	- Revised architectural documentation to include details on the new route cache mechanism.

- **Bug Fixes**
	- Improved logic in the route-finding algorithm to ensure accurate filtering of pools based on user-defined criteria.

- **Tests**
	- Enhanced test coverage for candidate route filtering and cache management scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->