### PR TITLE
Implement fetching user's active orders query in SQS

### DIFF
--- a/domain/mocks/orderbook_grpc_client_mock.go
+++ b/domain/mocks/orderbook_grpc_client_mock.go
@@ -1,0 +1,41 @@
+package mocks
+
+import (
+	"context"
+
+	orderbookgrpcclientdomain "github.com/osmosis-labs/sqs/domain/orderbook/grpcclient"
+	orderbookplugindomain "github.com/osmosis-labs/sqs/domain/orderbook/plugin"
+)
+
+var _ orderbookgrpcclientdomain.OrderBookClient = (*OrderbookGRPCClientMock)(nil)
+
+// OrderbookGRPCClientMock is a mock struct that implements orderbookplugindomain.OrderbookGRPCClient.
+type OrderbookGRPCClientMock struct {
+	MockGetOrdersByTickCb          func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
+	MockGetActiveOrdersCb          func(ctx context.Context, contractAddress string, ownerAddress string) ([]orderbookplugindomain.Order, uint64, error)
+	MockGetTickUnrealizedCancelsCb func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookplugindomain.UnrealizedTickCancels, error)
+}
+
+func (o *OrderbookGRPCClientMock) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
+	if o.MockGetOrdersByTickCb != nil {
+		return o.MockGetOrdersByTickCb(ctx, contractAddress, tick)
+	}
+
+	return nil, nil
+}
+
+func (o *OrderbookGRPCClientMock) GetActiveOrders(ctx context.Context, contractAddress string, ownerAddress string) ([]orderbookplugindomain.Order, uint64, error) {
+	if o.MockGetActiveOrdersCb != nil {
+		return o.MockGetActiveOrdersCb(ctx, contractAddress, ownerAddress)
+	}
+
+	return nil, 0, nil
+}
+
+func (o *OrderbookGRPCClientMock) GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookplugindomain.UnrealizedTickCancels, error) {
+	if o.MockGetTickUnrealizedCancelsCb != nil {
+		return o.MockGetTickUnrealizedCancelsCb(ctx, contractAddress, tickIDs)
+	}
+
+	return nil, nil
+}

--- a/domain/mocks/orderbook_grpc_client_mock.go
+++ b/domain/mocks/orderbook_grpc_client_mock.go
@@ -13,7 +13,7 @@ var _ orderbookgrpcclientdomain.OrderBookClient = (*OrderbookGRPCClientMock)(nil
 type OrderbookGRPCClientMock struct {
 	MockGetOrdersByTickCb          func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
 	MockGetActiveOrdersCb          func(ctx context.Context, contractAddress string, ownerAddress string) ([]orderbookplugindomain.Order, uint64, error)
-	MockGetTickUnrealizedCancelsCb func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookplugindomain.UnrealizedTickCancels, error)
+	MockGetTickUnrealizedCancelsCb func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
 }
 
 func (o *OrderbookGRPCClientMock) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
@@ -32,7 +32,7 @@ func (o *OrderbookGRPCClientMock) GetActiveOrders(ctx context.Context, contractA
 	return nil, 0, nil
 }
 
-func (o *OrderbookGRPCClientMock) GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookplugindomain.UnrealizedTickCancels, error) {
+func (o *OrderbookGRPCClientMock) GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
 	if o.MockGetTickUnrealizedCancelsCb != nil {
 		return o.MockGetTickUnrealizedCancelsCb(ctx, contractAddress, tickIDs)
 	}

--- a/domain/orderbook/grpcclient/orderbook_grpc_client.go
+++ b/domain/orderbook/grpcclient/orderbook_grpc_client.go
@@ -18,7 +18,7 @@ type OrderBookClient interface {
 	GetActiveOrders(ctx context.Context, contractAddress string, ownerAddress string) ([]orderbookplugindomain.Order, uint64, error)
 
 	// GetTickUnrealizedCancels fetches unrealized cancels by tick from the orderbook contract.
-	GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookplugindomain.UnrealizedTickCancels, error)
+	GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]UnrealizedTickCancels, error)
 }
 
 // orderbookClientImpl is an implementation of OrderbookCWAPIClient.
@@ -58,7 +58,7 @@ func (o *orderbookClientImpl) GetActiveOrders(ctx context.Context, contractAddre
 }
 
 // GetTickUnrealizedCancels implements OrderbookCWAPIClient.
-func (o *orderbookClientImpl) GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookplugindomain.UnrealizedTickCancels, error) {
+func (o *orderbookClientImpl) GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]UnrealizedTickCancels, error) {
 	var unrealizedCancels unrealizedCancelsResponse
 	if err := cosmwasmdomain.QueryCosmwasmContract(ctx, o.wasmClient, contractAddress, unrealizedCancelsByTickIdRequest{UnrealizedCancels: unrealizedCancelsRequestPayload{TickIds: tickIDs}}, &unrealizedCancels); err != nil {
 		return nil, err

--- a/domain/orderbook/grpcclient/orderbook_query_payloads.go
+++ b/domain/orderbook/grpcclient/orderbook_query_payloads.go
@@ -1,6 +1,7 @@
 package orderbookgrpcclientdomain
 
 import (
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	orderbookplugindomain "github.com/osmosis-labs/sqs/domain/orderbook/plugin"
 )
 
@@ -31,7 +32,13 @@ type unrealizedCancelsByTickIdRequest struct {
 
 // unrealizedCancelsResponse is a struct that represents the response payload for the get_unrealized_cancels query.
 type unrealizedCancelsResponse struct {
-	Ticks []orderbookplugindomain.UnrealizedTickCancels `json:"ticks"`
+	Ticks []UnrealizedTickCancels `json:"ticks"`
+}
+
+// UnrealizedTickCancels is a struct that represents the response payload from orderbook for unnrealized cancels by tick.
+type UnrealizedTickCancels struct {
+	TickID                 int64                             `json:"tick_id"`
+	UnrealizedCancelsState orderbookdomain.UnrealizedCancels `json:"unrealized_cancels"`
 }
 
 // ordersByOwner is a struct that represents the request payload for the active_orders query.

--- a/domain/orderbook/grpcclient/orderbook_query_payloads.go
+++ b/domain/orderbook/grpcclient/orderbook_query_payloads.go
@@ -1,7 +1,6 @@
 package orderbookgrpcclientdomain
 
 import (
-	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	orderbookplugindomain "github.com/osmosis-labs/sqs/domain/orderbook/plugin"
 )
 
@@ -30,13 +29,23 @@ type unrealizedCancelsByTickIdRequest struct {
 	UnrealizedCancels unrealizedCancelsRequestPayload `json:"get_unrealized_cancels"`
 }
 
-// unrealizedCancelsTickPayload is a struct that represents the response payload for an individual tick of the unrealized_cancels query.
-type unrealizedCancelsTickPayload struct {
-	TickID                 int64                             `json:"tick_id"`
-	UnrealizedCancelsState orderbookdomain.UnrealizedCancels `json:"unrealized_cancels"`
-}
-
 // unrealizedCancelsResponse is a struct that represents the response payload for the get_unrealized_cancels query.
 type unrealizedCancelsResponse struct {
-	Ticks []unrealizedCancelsTickPayload `json:"ticks"`
+	Ticks []orderbookplugindomain.UnrealizedTickCancels `json:"ticks"`
+}
+
+// ordersByOwner is a struct that represents the request payload for the active_orders query.
+type ordersByOwner struct {
+	Owner string `json:"owner"`
+}
+
+// activeOrdersRequest is a struct that represents the payload for the active_orders query.
+type activeOrdersRequest struct {
+	OrdersByOwner ordersByOwner `json:"orders_by_owner"`
+}
+
+// activeOrdersResponse is a struct that represents the response payload for the active_orders query.
+type activeOrdersResponse struct {
+	Orders []orderbookplugindomain.Order `json:"orders"`
+	Count  uint64                        `json:"count"`
 }

--- a/domain/orderbook/plugin/orderbook_tick.go
+++ b/domain/orderbook/plugin/orderbook_tick.go
@@ -1,9 +1,0 @@
-package orderbookplugindomain
-
-import orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
-
-// UnrealizedTickCancels is a struct that represents the response payload from orderbook for unnrealized cancels by tick.
-type UnrealizedTickCancels struct {
-	TickID                 int64                             `json:"tick_id"`
-	UnrealizedCancelsState orderbookdomain.UnrealizedCancels `json:"unrealized_cancels"`
-}

--- a/domain/orderbook/plugin/orderbook_tick.go
+++ b/domain/orderbook/plugin/orderbook_tick.go
@@ -1,0 +1,9 @@
+package orderbookplugindomain
+
+import orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+
+// UnrealizedTickCancels is a struct that represents the response payload from orderbook for unnrealized cancels by tick.
+type UnrealizedTickCancels struct {
+	TickID                 int64                             `json:"tick_id"`
+	UnrealizedCancelsState orderbookdomain.UnrealizedCancels `json:"unrealized_cancels"`
+}


### PR DESCRIPTION
This PR introduces a new `GetActiveOrders` method for fetching active orders by owner from the orderbook contract. 

Additionally refactors response returned by `GetTickUnrealizedCancels` and adds `OrderbookGRPCClientMock`.