### PR TITLE
fix: concurrency bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## v25.11.0
+
+- Fix concurrency bug in data fetcher prefetching.
+
 ## v25.10.0
 
 - Orderbook plugin

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -208,7 +208,6 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 	// Iniitialize data fetcher for pool APRs
 	fetchPoolAPRsCallback := datafetchers.GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient, logger)
 	var aprFetcher datafetchers.MapFetcher[uint64, passthroughdomain.PoolAPR] = datafetchers.NewMapFetcher(fetchPoolAPRsCallback, time.Minute*time.Duration(passthroughConfig.APRFetchIntervalMinutes))
-
 	// Register the APR fetcher with the passthrough use case
 	poolsUseCase.RegisterAPRFetcher(aprFetcher)
 

--- a/config.json
+++ b/config.json
@@ -51,7 +51,7 @@
             148,
             254
         ],
-        "alloyed-transmuter-code-ids": [814, 867],
+        "alloyed-transmuter-code-ids": [814, 86, 996],
         "orderbook-code-ids": [885],
         "general-cosmwasm-code-ids": [
             503,
@@ -73,7 +73,7 @@
         "worker-min-pool-liquidity-cap": 1
     },
     "passthrough":{
-        "numia-url": "https://public-osmosis-api.numia.xyz",
+        "numia-url": "https://public-osmosis-api.numia.dev",
         "timeseries-url": "https://stage-proxy-data-api.osmosis-labs.workers.dev",
         "apr-fetch-interval-minutes": 5,
         "pool-fees-fetch-interval-minutes": 5

--- a/sqsutil/datafetchers/map_prefetch_test.go
+++ b/sqsutil/datafetchers/map_prefetch_test.go
@@ -19,7 +19,7 @@ func TestMapIntervalFetcher_GetByKey(t *testing.T) {
 	updateFn := func() (map[int]string, error) {
 		if didFetchOnce.Load() {
 			// Intentionally block the update function to simulate a slow update
-			time.Sleep(10 * time.Second)
+			time.Sleep(5 * time.Second)
 		}
 
 		didFetchOnce.Store(true)
@@ -32,11 +32,10 @@ func TestMapIntervalFetcher_GetByKey(t *testing.T) {
 	}
 
 	// Create a new MapIntervalFetcher with a short interval
-	interval := 50 * time.Millisecond
+	interval := 2 * time.Second
 	fetcher := datafetchers.NewMapFetcher(updateFn, interval)
 
-	// Wait until the first result is fetched
-	fetcher.WaitUntilFirstResult()
+	time.Sleep(1 * time.Second)
 
 	// Test getting a valid key
 	value, lastFetch, isStale, err := fetcher.GetByKey(1)
@@ -52,8 +51,8 @@ func TestMapIntervalFetcher_GetByKey(t *testing.T) {
 	assert.False(t, isStale)
 	assert.NotZero(t, lastFetch)
 
-	// Wait for more than 2x the interval to ensure data becomes stale
-	time.Sleep(200 * time.Millisecond)
+	// Wait for more than the interval to ensure data becomes stale
+	time.Sleep(3 * time.Second)
 
 	// Test getting a key after data should be stale
 	value, lastFetch, isStale, err = fetcher.GetByKey(2)

--- a/sqsutil/datafetchers/prefetch_test.go
+++ b/sqsutil/datafetchers/prefetch_test.go
@@ -18,25 +18,17 @@ func TestWaitUntilFirstResult(t *testing.T) {
 		return 42, nil
 	}
 
-	start := time.Now()
 	p := NewIntervalFetcher(updateFn, 1*time.Second)
 	v, timestamp, err := p.Get()
 	require.Error(t, err)
 	require.Equal(t, 0, v)
 	require.Equal(t, time.Time{}, timestamp)
 
-	p.WaitUntilFirstResult()
-	waitTimeFinished := time.Now()
-	elapsedSinceStart := waitTimeFinished.Sub(start)
-	requireTimeDurationInRange(t, elapsedSinceStart, 2*time.Second, 3*time.Second)
+	time.Sleep(2 * time.Second)
 
 	v, timestamp, err = p.Get()
 	require.NoError(t, err)
 	require.Equal(t, v, 42)
-	elapsedSinceStart = time.Since(start)
-	requireTimeDurationInRange(t, elapsedSinceStart, 2*time.Second, 3*time.Second)
-	getVsWaitTime := timestamp.Sub(waitTimeFinished)
-	requireTimeDurationInRange(t, getVsWaitTime, -50*time.Millisecond, 50*time.Millisecond)
 }
 
 func requireTimeDurationInRange(t *testing.T, d time.Duration, min time.Duration, max time.Duration) {

--- a/tokens/usecase/pricing/worker/pricing_worker_test.go
+++ b/tokens/usecase/pricing/worker/pricing_worker_test.go
@@ -219,7 +219,7 @@ func (s *PricingWorkerTestSuite) TestGetPrices_Chain_FindUnsupportedTokens() {
 	// 6 more tokens were found to be unsupported on May 29th.
 	// 1 more was found on June 10 when adding alloyed code id to config.
 	//
-	// On August 20, 2024: 23 unsupported tokens - likely added liquidity to some pools with the tokens.
+	// On August 20, 2024: 24 unsupported tokens - likely added liquidity to some pools with the tokens.
 	s.Require().Equal(24, zeroPriceCounter)
 }
 

--- a/tokens/usecase/pricing/worker/pricing_worker_test.go
+++ b/tokens/usecase/pricing/worker/pricing_worker_test.go
@@ -219,8 +219,8 @@ func (s *PricingWorkerTestSuite) TestGetPrices_Chain_FindUnsupportedTokens() {
 	// 6 more tokens were found to be unsupported on May 29th.
 	// 1 more was found on June 10 when adding alloyed code id to config.
 	//
-	// On July 20, 2024: 23 unsupported tokens - likely added liquidity to some pools with the tokens.
-	s.Require().Equal(23, zeroPriceCounter)
+	// On August 20, 2024: 23 unsupported tokens - likely added liquidity to some pools with the tokens.
+	s.Require().Equal(24, zeroPriceCounter)
 }
 
 func (s *PricingWorkerTestSuite) ValidatePrices(initialDenoms map[string]struct{}, expectedQuoteDenom string, prices map[string]map[string]osmomath.BigDec) {

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
@@ -283,6 +284,9 @@ func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quot
 						err = fmt.Errorf("panic in GetPrices: %v", r)
 					}
 				}()
+
+				ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+				defer cancel()
 
 				prices, err := t.getPricesForBaseDenom(ctx, baseDenom, quoteDenoms, pricingSourceType, opts...)
 				if err != nil {

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
@@ -284,9 +283,6 @@ func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quot
 						err = fmt.Errorf("panic in GetPrices: %v", r)
 					}
 				}()
-
-				ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-				defer cancel()
 
 				prices, err := t.getPricesForBaseDenom(ctx, baseDenom, quoteDenoms, pricingSourceType, opts...)
 				if err != nil {


### PR DESCRIPTION
There was a concurrency bug in the synchronization mechanism between `WaitUntilFirstResult` and `prefetch` that would cause a deadlock.

`WaitUntilFirstResult` is a convenience method for test and has little practical usecase. As a result, to fix the issue, it was removed.

## Testing

- Updated unit tests
- Manually tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved handling of concurrent data fetching, enhancing reliability and stability.
	- Configuration updates for the alloyed transmuter identifiers and API endpoint.

- **Bug Fixes**
	- Resolved concurrency bug affecting data fetcher prefetching.

- **Tests**
	- Updated tests to reflect new expected outcomes and enhance simulation of data fetching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->