### PR TITLE
fix: dynamic min liquidity band config issue

### DIFF
--- a/config.json
+++ b/config.json
@@ -21,7 +21,7 @@
       "dynamic-min-liquidity-cap-filters-desc": [
         {
             "min-tokens-capitalization": 1000000,
-            "filter-value": 75000
+            "filter-value": 40000
         },
         {
             "min-tokens-capitalization": 250000,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/931b0f5e-3b87-476d-bebd-00f463c5e734)

This was a config issue.

Context of the failure: we failed to find routes for stBAND

It was observed that the failure stemmed from mispricing the major stBAND pool (note there is just one)

The pricing happens in the background here:
https://github.com/osmosis-labs/sqs/blob/4fbb8cddb6f8dec9f74b22347e96a9514892aadf/ingest/usecase/ingest_usecase.go#L165-L171


We observed that the first `UpdatePricesSync` would compute the price correctly but the second would fail.

The reason we have 2 calls for price computations is because:
1. Prices pool liquidity capitalization for better pool ranking
2. Utilizes the pool liquidity capitalization to recompute better prices

Since the first call to prices did not have information about total pool liquidity capitalization across all pools, the dynamic min liquidity feature was unused.

However, the second one relied on it. At that stage, the min pool liquidity capitalization between USDC and stBAND would be > $1m per
![image](https://github.com/user-attachments/assets/e1a1e583-6ed6-4837-8c28-b804b7d9c09d)

This translates to min pool liquidity cap filter of $75.

However, BAND is the only other token that leads to stBAND through pools 1581, 626

As a result, we would filter out the only pools that can access stBAND from another token (BAND).

By lowering the filter value to 40K, we know that pool 626 would be included. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Adjusted the liquidity filtering criteria, allowing for a broader range of liquidity scenarios in the application.
- **Bug Fixes**
	- Corrected the minimum liquidity cap filter value to enhance accuracy in liquidity management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->