### PR TITLE
test(e2e): reduce pool capitalization flakiness

### DIFF
--- a/tests/coingecko_service.py
+++ b/tests/coingecko_service.py
@@ -4,9 +4,13 @@ COINGECKO_URL = "https://prices.osmosis.zone/api/v3/simple/price"
 USD_CURRENCY = "usd"
 
 class CoingeckoService:
+    cache = {}
 
     # Given the coingecko id, call the coingecko API endpoint and return its token price
     def get_token_price(self, coingecko_id):
+        if coingecko_id in self.cache:
+            return self.cache[coingecko_id]
+
         # Set the query parameters
         params = {
             "ids": coingecko_id,
@@ -18,4 +22,8 @@ class CoingeckoService:
             raise Exception(f"Error fetching price from coingecko: {response.text}")
 
         response_json = response.json()
-        return response_json.get(coingecko_id, {}).get(USD_CURRENCY, None)
+        price =  response_json.get(coingecko_id, {}).get(USD_CURRENCY, None)
+        
+        self.cache[coingecko_id] = price
+
+        return price


### PR DESCRIPTION
Reduces pool capitalization flakiness by:
- Increasing min liquidity cap threshold to 100K
- Adding alloyed pool IDs to exclusion since broken on Numia side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a caching mechanism for token price retrieval, improving response times and reducing API calls.
  
- **Bug Fixes**
	- Adjusted the minimum liquidity capitalization threshold in tests to enhance reliability.
	- Updated conditions for skipping tests based on pool liquidity to ensure only suitable pools are evaluated.

- **Chores**
	- Expanded the list of problematic pool IDs to exclude specific pools from testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->