### PR TITLE
fix: no routes for this trade

### DIFF
--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -110,7 +110,7 @@ func (c candidateRouteFinder) FindCandidateRoutes(tokenIn sdk.Coin, tokenOutDeno
 		rankedPools := denomData.SortedPools
 
 		if len(rankedPools) == 0 {
-			return sqsdomain.CandidateRoutes{}, nil
+			c.logger.Debug("no pools found for denom in candidate route search", zap.String("denom", currenTokenInDenom))
 		}
 
 		for i := 0; i < len(rankedPools) && len(routes) < options.MaxRoutes; i++ {

--- a/tokens/usecase/pricing/worker/pricing_worker_test.go
+++ b/tokens/usecase/pricing/worker/pricing_worker_test.go
@@ -220,7 +220,8 @@ func (s *PricingWorkerTestSuite) TestGetPrices_Chain_FindUnsupportedTokens() {
 	// 1 more was found on June 10 when adding alloyed code id to config.
 	//
 	// On August 21, 2024: 23 unsupported tokens - likely added liquidity to some pools with the tokens.
-	s.Require().Equal(23, zeroPriceCounter)
+	// On August 27, 2024: 20 unsupported tokens - same reason as above.
+	s.Require().Equal(20, zeroPriceCounter)
 }
 
 func (s *PricingWorkerTestSuite) ValidatePrices(initialDenoms map[string]struct{}, expectedQuoteDenom string, prices map[string]map[string]osmomath.BigDec) {


### PR DESCRIPTION
This commit addresses the issue observed on FE showing the error "No routes for this trade". The changes allow the route search loop continue even the denom data is unavailable for the denom of pool in the route being searched. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved logging for candidate route finding, providing better debugging information when no pools are found.
- **Tests**
	- Updated test case to reflect changes in the expected number of unsupported tokens, enhancing test accuracy and relevance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->