### PR TITLE
ci: backport label ci

### DIFF
--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v41.0.0
+        uses: tj-actions/changed-files@v45
 
       - name: Check required labels
         # Skip this step and return success result for markdown only changes

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -1,0 +1,31 @@
+name: required labels
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+    branches:
+      - "v25.x"
+
+jobs:
+  backport_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v41.0.0
+
+      - name: Check required labels
+        # Skip this step and return success result for markdown only changes
+        if: |
+          steps.changed-files.outputs.any_changed == 'true' ||
+          steps.changed-files.outputs.any_deleted == 'true' ||
+          steps.changed-files.outputs.any_modified == 'true'
+        uses: mheap/github-action-required-labels@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
+        with: #Require one of the following labels
+          mode: exactly
+          count: 1
+          labels: "A:backport/v26.x"

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -27,6 +27,13 @@ jobs:
           mode: exactly
           count: 1
           labels: "A:backport/v26.x"
+      
+      - name: Debug changed files
+        run: |
+          echo "Any changed: ${{ steps.changed-files.outputs.any_changed }}"
+          echo "Any deleted: ${{ steps.changed-files.outputs.any_deleted }}"
+          echo "Any modified: ${{ steps.changed-files.outputs.any_modified }}"
+          echo "All changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
     
       - name: Fail if label is missing
         if: failure()

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -27,15 +27,3 @@ jobs:
           mode: exactly
           count: 1
           labels: "A:backport/v26.x"
-      
-      - name: Debug changed files
-        run: |
-          echo "Any changed: ${{ steps.changed-files.outputs.any_changed }}"
-          echo "Any deleted: ${{ steps.changed-files.outputs.any_deleted }}"
-          echo "Any modified: ${{ steps.changed-files.outputs.any_modified }}"
-          echo "All changed files: ${{ steps.changed-files.outputs.all_changed_files }}"
-    
-      - name: Fail if label is missing
-        if: failure()
-        run: exit 1
-

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -5,6 +5,9 @@ on:
     types: [opened, labeled, unlabeled, synchronize]
     branches:
       - "v25.x"
+  push:
+    branches:
+      - "**"
 
 jobs:
   backport_labels:

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -5,9 +5,6 @@ on:
     types: [opened, labeled, unlabeled, synchronize]
     branches:
       - "v25.x"
-  push:
-    branches:
-      - "**"
 
 jobs:
   backport_labels:
@@ -32,3 +29,8 @@ jobs:
           mode: exactly
           count: 1
           labels: "A:backport/v26.x"
+    
+      - name: Fail if label is missing
+        if: failure()
+        run: exit 1
+

--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -23,8 +23,6 @@ jobs:
           steps.changed-files.outputs.any_deleted == 'true' ||
           steps.changed-files.outputs.any_modified == 'true'
         uses: mheap/github-action-required-labels@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_PAT }}
         with: #Require one of the following labels
           mode: exactly
           count: 1

--- a/tokens/usecase/export_test.go
+++ b/tokens/usecase/export_test.go
@@ -20,7 +20,7 @@ func (t *tokensUseCase) SetCoingeckoIDs(key string, value any) {
 	t.coingeckoIds.Store(key, value)
 }
 
-// SetLastFetchHash is a test helper to set last fetch hash
+// SetLastFetchHash is a test helper to set last fetch hash.
 func (f *ChainRegistryHTTPFetcher) SetLastFetchHash(value string) {
 	f.lastFetchHash = value
 }


### PR DESCRIPTION
Add a CI to block PRs if backport label is not applied

Tested in this PR by removing the label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **New Features**
	- Introduced a new GitHub Actions workflow to ensure required labels are applied to pull requests in the "v25.x" branch.
	- The workflow enforces the presence of the "A:backport/v26.x" label for successful pull request processing.
- **Style**
	- Minor cosmetic change to improve comment consistency within the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->