### PR TITLE
fix: rename tenderming to tendermint

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -103,7 +103,7 @@ func main() {
 		}()
 	}
 
-	chainClient, err := client.NewClient(config.ChainID, config.ChainTendermingRPCEndpoint)
+	chainClient, err := client.NewClient(config.ChainID, config.ChainTendermintRPCEndpoint)
 	if err != nil {
 		panic(err)
 	}

--- a/app/sqs_config.go
+++ b/app/sqs_config.go
@@ -13,7 +13,7 @@ var DefaultConfig = domain.Config{
 	LoggerIsProduction: true,
 	LoggerLevel:        "info",
 
-	ChainTendermingRPCEndpoint: "http://localhost:26657",
+	ChainTendermintRPCEndpoint: "http://localhost:26657",
 	ChainGRPCGatewayEndpoint:   "http://localhost:9090",
 	ChainID:                    "osmosis-1",
 	ChainRegistryAssetsFileURL: "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/generated/frontend/assetlist.json",

--- a/domain/config.go
+++ b/domain/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	LoggerIsProduction bool   `mapstructure:"logger-is-production"`
 	LoggerLevel        string `mapstructure:"logger-level"`
 
-	ChainTendermingRPCEndpoint string `mapstructure:"grpc-tendermint-rpc-endpoint"`
+	ChainTendermintRPCEndpoint string `mapstructure:"grpc-tendermint-rpc-endpoint"`
 	ChainGRPCGatewayEndpoint   string `mapstructure:"grpc-gateway-endpoint"`
 	ChainID                    string `mapstructure:"chain-id"`
 
@@ -69,7 +69,7 @@ var (
 		LoggerFilename:             "sqs.log",
 		LoggerIsProduction:         false,
 		LoggerLevel:                "info",
-		ChainTendermingRPCEndpoint: "http://localhost:26657",
+		ChainTendermintRPCEndpoint: "http://localhost:26657",
 		ChainGRPCGatewayEndpoint:   "localhost:9090",
 		ChainID:                    "osmosis-1",
 		ChainRegistryAssetsFileURL: "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/generated/frontend/assetlist.json",

--- a/system/delivery/http/system_http_handler.go
+++ b/system/delivery/http/system_http_handler.go
@@ -55,7 +55,7 @@ const (
 func NewSystemHandler(e *echo.Echo, config domain.Config, logger log.Logger, us mvc.ChainInfoUsecase) {
 	handler := &SystemHandler{
 		logger:      logger,
-		grpcAddress: config.ChainTendermingRPCEndpoint,
+		grpcAddress: config.ChainTendermintRPCEndpoint,
 		CIUsecase:   us,
 		config:      config,
 	}


### PR DESCRIPTION
### Description

- rename misspelled config option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected typographical errors in configuration parameter names related to the Tendermint RPC endpoint, enhancing connection reliability.
	- Ensured accurate assignment of configuration fields in system handlers, improving gRPC communication functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->