### PR TITLE
SQS-375 | Unit test createFormattedLimitOrder

### DIFF
--- a/.swaggo
+++ b/.swaggo
@@ -1,0 +1,5 @@
+// Swagger overrides file
+// @link https://github.com/swaggo/swag?tab=readme-ov-file#use-global-overrides-to-support-a-custom-type
+
+// Replace all Dec with string 
+replace osmomath.Dec string

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ generate-mocks: mockery
 	bin/mockery --config mockery.yaml
 
 swagger-gen:
-	$(HOME)/go/bin/swag init -g app/main.go
+	$(HOME)/go/bin/swag init -g app/main.go --pd --overridesFile ./.swaggo
 
 run:
 	go run -ldflags="-X github.com/osmosis-labs/sqs/version=${VERSION}" app/*.go  --config config.json

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,44 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/passthrough/active-orders": {
+            "get": {
+                "description": "The returned data represents all active orders for all orderbooks available for the specified address.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Returns all active orderbook orders associated with the given address.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Osmo wallet address",
+                        "name": "userOsmoAddress",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of active orders for all available orderboooks for the given address",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Response error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Response error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ResponseError"
+                        }
+                    }
+                }
+            }
+        },
         "/passthrough/portfolio-assets/{address}": {
             "get": {
                 "description": "The returned data represents the potfolio asset breakdown by category for the specified address.",
@@ -35,13 +73,13 @@ const docTemplate = `{
                     "200": {
                         "description": "Portfolio assets by-category and capitalization of the entire account value",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult"
                         }
                     },
                     "500": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     }
                 }
@@ -113,7 +151,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Canonical Orderbook Pool ID for the given base and quote",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.CanonicalOrderBooksResult"
                         }
                     }
                 }
@@ -436,6 +474,14 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.ResponseError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Token": {
             "type": "object",
             "properties": {
@@ -461,6 +507,159 @@ const docTemplate = `{
                 "symbol": {
                     "description": "HumanDenom is the human readable denom, e.g. atom",
                     "type": "string"
+                }
+            }
+        },
+        "github_com_cosmos_cosmos-sdk_types.Coin": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "$ref": "#/definitions/types.Int"
+                },
+                "denom": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.Asset": {
+            "type": "object",
+            "properties": {
+                "symbol": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder": {
+            "type": "object",
+            "properties": {
+                "base_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "claim_bounty": {
+                    "type": "string"
+                },
+                "etas": {
+                    "type": "string"
+                },
+                "order_direction": {
+                    "type": "string"
+                },
+                "order_id": {
+                    "type": "integer"
+                },
+                "orderbookAddress": {
+                    "type": "string"
+                },
+                "output": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "percentClaimed": {
+                    "type": "string"
+                },
+                "percentFilled": {
+                    "type": "string"
+                },
+                "placed_at": {
+                    "type": "integer"
+                },
+                "placed_quantity": {
+                    "type": "string"
+                },
+                "placed_tx": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "quote_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus"
+                },
+                "tick_id": {
+                    "type": "integer"
+                },
+                "totalFilled": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus": {
+            "type": "string",
+            "enum": [
+                "open",
+                "partiallyFilled",
+                "filled",
+                "fullyClaimed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "StatusOpen",
+                "StatusPartiallyFilled",
+                "StatusFilled",
+                "StatusFullyClaimed",
+                "StatusCancelled"
+            ]
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult": {
+            "type": "object",
+            "properties": {
+                "cap_value": {
+                    "type": "string"
+                },
+                "coin": {
+                    "$ref": "#/definitions/github_com_cosmos_cosmos-sdk_types.Coin"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult": {
+            "type": "object",
+            "properties": {
+                "account_coins_result": {
+                    "description": "AccountCoinsResult represents coins only from user balances (contrary to TotalValueCap).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult"
+                    }
+                },
+                "capitalization": {
+                    "description": "Capitalization represents the total value of the assets in the portfolio.\nincludes capitalization of user balances, value in locks, bonding or unbonding\nas well as the concentrated positions.",
+                    "type": "string"
+                },
+                "is_best_effort": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult": {
+            "type": "object",
+            "properties": {
+                "categories": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult"
+                    }
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse": {
+            "type": "object",
+            "properties": {
+                "is_best_effort": {
+                    "type": "boolean"
+                },
+                "orders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder"
+                    }
                 }
             }
         },
@@ -508,6 +707,9 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "types.Int": {
+            "type": "object"
         }
     }
 }`

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6,6 +6,44 @@
         "version": "1.0"
     },
     "paths": {
+        "/passthrough/active-orders": {
+            "get": {
+                "description": "The returned data represents all active orders for all orderbooks available for the specified address.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Returns all active orderbook orders associated with the given address.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Osmo wallet address",
+                        "name": "userOsmoAddress",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of active orders for all available orderboooks for the given address",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Response error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Response error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ResponseError"
+                        }
+                    }
+                }
+            }
+        },
         "/passthrough/portfolio-assets/{address}": {
             "get": {
                 "description": "The returned data represents the potfolio asset breakdown by category for the specified address.",
@@ -26,13 +64,13 @@
                     "200": {
                         "description": "Portfolio assets by-category and capitalization of the entire account value",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult"
                         }
                     },
                     "500": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     }
                 }
@@ -104,7 +142,7 @@
                     "200": {
                         "description": "Canonical Orderbook Pool ID for the given base and quote",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.CanonicalOrderBooksResult"
                         }
                     }
                 }
@@ -427,6 +465,14 @@
                 }
             }
         },
+        "domain.ResponseError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Token": {
             "type": "object",
             "properties": {
@@ -452,6 +498,159 @@
                 "symbol": {
                     "description": "HumanDenom is the human readable denom, e.g. atom",
                     "type": "string"
+                }
+            }
+        },
+        "github_com_cosmos_cosmos-sdk_types.Coin": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "$ref": "#/definitions/types.Int"
+                },
+                "denom": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.Asset": {
+            "type": "object",
+            "properties": {
+                "symbol": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder": {
+            "type": "object",
+            "properties": {
+                "base_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "claim_bounty": {
+                    "type": "string"
+                },
+                "etas": {
+                    "type": "string"
+                },
+                "order_direction": {
+                    "type": "string"
+                },
+                "order_id": {
+                    "type": "integer"
+                },
+                "orderbookAddress": {
+                    "type": "string"
+                },
+                "output": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "percentClaimed": {
+                    "type": "string"
+                },
+                "percentFilled": {
+                    "type": "string"
+                },
+                "placed_at": {
+                    "type": "integer"
+                },
+                "placed_quantity": {
+                    "type": "string"
+                },
+                "placed_tx": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "quote_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus"
+                },
+                "tick_id": {
+                    "type": "integer"
+                },
+                "totalFilled": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus": {
+            "type": "string",
+            "enum": [
+                "open",
+                "partiallyFilled",
+                "filled",
+                "fullyClaimed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "StatusOpen",
+                "StatusPartiallyFilled",
+                "StatusFilled",
+                "StatusFullyClaimed",
+                "StatusCancelled"
+            ]
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult": {
+            "type": "object",
+            "properties": {
+                "cap_value": {
+                    "type": "string"
+                },
+                "coin": {
+                    "$ref": "#/definitions/github_com_cosmos_cosmos-sdk_types.Coin"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult": {
+            "type": "object",
+            "properties": {
+                "account_coins_result": {
+                    "description": "AccountCoinsResult represents coins only from user balances (contrary to TotalValueCap).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult"
+                    }
+                },
+                "capitalization": {
+                    "description": "Capitalization represents the total value of the assets in the portfolio.\nincludes capitalization of user balances, value in locks, bonding or unbonding\nas well as the concentrated positions.",
+                    "type": "string"
+                },
+                "is_best_effort": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult": {
+            "type": "object",
+            "properties": {
+                "categories": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult"
+                    }
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse": {
+            "type": "object",
+            "properties": {
+                "is_best_effort": {
+                    "type": "boolean"
+                },
+                "orders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder"
+                    }
                 }
             }
         },
@@ -499,6 +698,9 @@
                     }
                 }
             }
+        },
+        "types.Int": {
+            "type": "object"
         }
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -10,6 +10,11 @@ definitions:
       quote:
         type: string
     type: object
+  domain.ResponseError:
+    properties:
+      message:
+        type: string
+    type: object
   domain.Token:
     properties:
       coinMinimalDenom:
@@ -29,6 +34,113 @@ definitions:
       symbol:
         description: HumanDenom is the human readable denom, e.g. atom
         type: string
+    type: object
+  github_com_cosmos_cosmos-sdk_types.Coin:
+    properties:
+      amount:
+        $ref: '#/definitions/types.Int'
+      denom:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.Asset:
+    properties:
+      symbol:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder:
+    properties:
+      base_asset:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset'
+      claim_bounty:
+        type: string
+      etas:
+        type: string
+      order_direction:
+        type: string
+      order_id:
+        type: integer
+      orderbookAddress:
+        type: string
+      output:
+        type: string
+      owner:
+        type: string
+      percentClaimed:
+        type: string
+      percentFilled:
+        type: string
+      placed_at:
+        type: integer
+      placed_quantity:
+        type: string
+      placed_tx:
+        type: string
+      price:
+        type: string
+      quantity:
+        type: string
+      quote_asset:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset'
+      status:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus'
+      tick_id:
+        type: integer
+      totalFilled:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus:
+    enum:
+    - open
+    - partiallyFilled
+    - filled
+    - fullyClaimed
+    - cancelled
+    type: string
+    x-enum-varnames:
+    - StatusOpen
+    - StatusPartiallyFilled
+    - StatusFilled
+    - StatusFullyClaimed
+    - StatusCancelled
+  github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult:
+    properties:
+      cap_value:
+        type: string
+      coin:
+        $ref: '#/definitions/github_com_cosmos_cosmos-sdk_types.Coin'
+    type: object
+  github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult:
+    properties:
+      account_coins_result:
+        description: AccountCoinsResult represents coins only from user balances (contrary
+          to TotalValueCap).
+        items:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult'
+        type: array
+      capitalization:
+        description: |-
+          Capitalization represents the total value of the assets in the portfolio.
+          includes capitalization of user balances, value in locks, bonding or unbonding
+          as well as the concentrated positions.
+        type: string
+      is_best_effort:
+        type: boolean
+    type: object
+  github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult:
+    properties:
+      categories:
+        additionalProperties:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult'
+        type: object
+    type: object
+  github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse:
+    properties:
+      is_best_effort:
+        type: boolean
+      orders:
+        items:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder'
+        type: array
     type: object
   sqsdomain.CandidatePool:
     properties:
@@ -59,11 +171,40 @@ definitions:
           type: object
         type: object
     type: object
+  types.Int:
+    type: object
 info:
   contact: {}
   title: Osmosis Sidecar Query Server Example API
   version: "1.0"
 paths:
+  /passthrough/active-orders:
+    get:
+      description: The returned data represents all active orders for all orderbooks
+        available for the specified address.
+      parameters:
+      - description: Osmo wallet address
+        in: query
+        name: userOsmoAddress
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of active orders for all available orderboooks for the
+            given address
+          schema:
+            $ref: '#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse'
+        "400":
+          description: Response error
+          schema:
+            $ref: '#/definitions/domain.ResponseError'
+        "500":
+          description: Response error
+          schema:
+            $ref: '#/definitions/domain.ResponseError'
+      summary: Returns all active orderbook orders associated with the given address.
   /passthrough/portfolio-assets/{address}:
     get:
       description: The returned data represents the potfolio asset breakdown by category
@@ -81,11 +222,11 @@ paths:
           description: Portfolio assets by-category and capitalization of the entire
             account value
           schema:
-            type: struct
+            $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult'
         "500":
           description: Response error
           schema:
-            type: struct
+            $ref: '#/definitions/domain.ResponseError'
       summary: Returns portfolio assets associated with the given address by category.
   /pools:
     get:
@@ -138,7 +279,7 @@ paths:
         "200":
           description: Canonical Orderbook Pool ID for the given base and quote
           schema:
-            type: struct
+            $ref: '#/definitions/domain.CanonicalOrderBooksResult'
       summary: Get canonical orderbook pool ID for the given base and quote.
   /pools/canonical-orderbooks:
     get:

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -17,6 +17,13 @@ var (
 	ErrBadParamInput = errors.New("given Param is not valid")
 )
 
+var (
+	ErrBaseDenomNotValid       = errors.New("base denom is empty")
+	ErrQuoteDenomNotValid      = errors.New("quote denom is empty")
+	ErrPoolIDNotValid          = errors.New("pool ID is zero")
+	ErrContractAddressNotValid = errors.New("contract address is empty")
+)
+
 // GetStatusCode returbs status code given error
 func GetStatusCode(err error) int {
 	if err == nil {

--- a/domain/mocks/orderbook_grpc_client_mock.go
+++ b/domain/mocks/orderbook_grpc_client_mock.go
@@ -12,33 +12,33 @@ var _ orderbookgrpcclientdomain.OrderBookClient = (*OrderbookGRPCClientMock)(nil
 
 // OrderbookGRPCClientMock is a mock struct that implements orderbookplugindomain.OrderbookGRPCClient.
 type OrderbookGRPCClientMock struct {
-	MockGetOrdersByTickCb          func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
-	MockGetActiveOrdersCb          func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error)
-	MockGetTickUnrealizedCancelsCb func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
-	FetchTickUnrealizedCancelsCb   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
-	MockQueryTicksCb               func(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error)
-	FetchTicksCb                   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error)
+	GetOrdersByTickCb            func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
+	GetActiveOrdersCb            func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error)
+	GetTickUnrealizedCancelsCb   func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
+	FetchTickUnrealizedCancelsCb func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
+	MockQueryTicksCb             func(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error)
+	FetchTicksCb                 func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error)
 }
 
 func (o *OrderbookGRPCClientMock) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
-	if o.MockGetOrdersByTickCb != nil {
-		return o.MockGetOrdersByTickCb(ctx, contractAddress, tick)
+	if o.GetOrdersByTickCb != nil {
+		return o.GetOrdersByTickCb(ctx, contractAddress, tick)
 	}
 
 	return nil, nil
 }
 
 func (o *OrderbookGRPCClientMock) GetActiveOrders(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error) {
-	if o.MockGetActiveOrdersCb != nil {
-		return o.MockGetActiveOrdersCb(ctx, contractAddress, ownerAddress)
+	if o.GetActiveOrdersCb != nil {
+		return o.GetActiveOrdersCb(ctx, contractAddress, ownerAddress)
 	}
 
 	return nil, 0, nil
 }
 
 func (o *OrderbookGRPCClientMock) GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
-	if o.MockGetTickUnrealizedCancelsCb != nil {
-		return o.MockGetTickUnrealizedCancelsCb(ctx, contractAddress, tickIDs)
+	if o.GetTickUnrealizedCancelsCb != nil {
+		return o.GetTickUnrealizedCancelsCb(ctx, contractAddress, tickIDs)
 	}
 
 	return nil, nil

--- a/domain/mocks/orderbook_grpc_client_mock.go
+++ b/domain/mocks/orderbook_grpc_client_mock.go
@@ -15,7 +15,9 @@ type OrderbookGRPCClientMock struct {
 	MockGetOrdersByTickCb          func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
 	MockGetActiveOrdersCb          func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error)
 	MockGetTickUnrealizedCancelsCb func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
+	FetchTickUnrealizedCancelsCb   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
 	MockQueryTicksCb               func(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error)
+	FetchTicksCb                   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error)
 }
 
 func (o *OrderbookGRPCClientMock) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
@@ -42,9 +44,25 @@ func (o *OrderbookGRPCClientMock) GetTickUnrealizedCancels(ctx context.Context, 
 	return nil, nil
 }
 
+func (o *OrderbookGRPCClientMock) FetchTickUnrealizedCancels(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+	if o.FetchTickUnrealizedCancelsCb != nil {
+		return o.FetchTickUnrealizedCancelsCb(ctx, chunkSize, contractAddress, tickIDs)
+	}
+
+	return nil, nil
+}
+
 func (o *OrderbookGRPCClientMock) QueryTicks(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error) {
 	if o.MockQueryTicksCb != nil {
 		return o.MockQueryTicksCb(ctx, contractAddress, ticks)
+	}
+
+	return nil, nil
+}
+
+func (o *OrderbookGRPCClientMock) FetchTicks(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+	if o.FetchTicksCb != nil {
+		return o.FetchTicksCb(ctx, chunkSize, contractAddress, tickIDs)
 	}
 
 	return nil, nil

--- a/domain/mocks/orderbook_repository_mock.go
+++ b/domain/mocks/orderbook_repository_mock.go
@@ -1,0 +1,48 @@
+package mocks
+
+import (
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+)
+
+var _ orderbookdomain.OrderBookRepository = &OrderbookRepositoryMock{}
+
+// OrderbookRepositoryMock is a mock implementation of the OrderBookRepository interface.
+type OrderbookRepositoryMock struct {
+	StoreTicksFunc  func(poolID uint64, ticksMap map[int64]orderbookdomain.OrderbookTick)
+	GetAllTicksFunc func(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool)
+	GetTicksFunc    func(poolID uint64, tickIDs []int64) (map[int64]orderbookdomain.OrderbookTick, error)
+	GetTickByIDFunc func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool)
+}
+
+// StoreTicks implements OrderBookRepository.
+func (m *OrderbookRepositoryMock) StoreTicks(poolID uint64, ticksMap map[int64]orderbookdomain.OrderbookTick) {
+	if m.StoreTicksFunc != nil {
+		m.StoreTicksFunc(poolID, ticksMap)
+		return
+	}
+	panic("StoreTicks not implemented")
+}
+
+// GetAllTicks implements OrderBookRepository.
+func (m *OrderbookRepositoryMock) GetAllTicks(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool) {
+	if m.GetAllTicksFunc != nil {
+		return m.GetAllTicksFunc(poolID)
+	}
+	panic("GetAllTicks not implemented")
+}
+
+// GetTicks implements OrderBookRepository.
+func (m *OrderbookRepositoryMock) GetTicks(poolID uint64, tickIDs []int64) (map[int64]orderbookdomain.OrderbookTick, error) {
+	if m.GetTicksFunc != nil {
+		return m.GetTicksFunc(poolID, tickIDs)
+	}
+	panic("GetTicks not implemented")
+}
+
+// GetTickByID implements OrderBookRepository.
+func (m *OrderbookRepositoryMock) GetTickByID(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+	if m.GetTickByIDFunc != nil {
+		return m.GetTickByIDFunc(poolID, tickID)
+	}
+	panic("GetTickByID not implemented")
+}

--- a/domain/mocks/orderbook_usecase_mock.go
+++ b/domain/mocks/orderbook_usecase_mock.go
@@ -1,0 +1,39 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/osmosis-labs/sqs/domain/mvc"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/sqsdomain"
+)
+
+var _ mvc.OrderBookUsecase = &OrderbookUsecaseMock{}
+
+// OrderbookUsecaseMock is a mock implementation of the RouterUsecase interface
+type OrderbookUsecaseMock struct {
+	ProcessPoolFunc     func(ctx context.Context, pool sqsdomain.PoolI) error
+	GetAllTicksFunc     func(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool)
+	GetActiveOrdersFunc func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
+}
+
+func (m *OrderbookUsecaseMock) ProcessPool(ctx context.Context, pool sqsdomain.PoolI) error {
+	if m.ProcessPoolFunc != nil {
+		return m.ProcessPoolFunc(ctx, pool)
+	}
+	panic("unimplemented")
+}
+
+func (m *OrderbookUsecaseMock) GetAllTicks(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool) {
+	if m.GetAllTicksFunc != nil {
+		return m.GetAllTicksFunc(poolID)
+	}
+	panic("unimplemented")
+}
+
+func (m *OrderbookUsecaseMock) GetActiveOrders(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+	if m.GetActiveOrdersFunc != nil {
+		return m.GetActiveOrdersFunc(ctx, address)
+	}
+	panic("unimplemented")
+}

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -19,15 +19,16 @@ import (
 var _ mvc.PoolsUsecase = &PoolsUsecaseMock{}
 
 type PoolsUsecaseMock struct {
-	GetAllPoolsFunc             func() ([]sqsdomain.PoolI, error)
-	GetPoolsFunc                func(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, error)
-	StorePoolsFunc              func(pools []sqsdomain.PoolI) error
-	GetRoutesFromCandidatesFunc func(candidateRoutes sqsdomain.CandidateRoutes, tokenInDenom, tokenOutDenom string) ([]route.RouteImpl, error)
-	GetTickModelMapFunc         func(poolIDs []uint64) (map[uint64]*sqsdomain.TickModel, error)
-	GetPoolFunc                 func(poolID uint64) (sqsdomain.PoolI, error)
-	GetPoolSpotPriceFunc        func(ctx context.Context, poolID uint64, takerFee osmomath.Dec, quoteAsset, baseAsset string) (osmomath.BigDec, error)
-	GetCosmWasmPoolConfigFunc   func() domain.CosmWasmPoolRouterConfig
-	CalcExitCFMMPoolFunc        func(poolID uint64, exitingShares osmomath.Int) (sdk.Coins, error)
+	GetAllPoolsFunc                     func() ([]sqsdomain.PoolI, error)
+	GetPoolsFunc                        func(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, error)
+	StorePoolsFunc                      func(pools []sqsdomain.PoolI) error
+	GetRoutesFromCandidatesFunc         func(candidateRoutes sqsdomain.CandidateRoutes, tokenInDenom, tokenOutDenom string) ([]route.RouteImpl, error)
+	GetTickModelMapFunc                 func(poolIDs []uint64) (map[uint64]*sqsdomain.TickModel, error)
+	GetPoolFunc                         func(poolID uint64) (sqsdomain.PoolI, error)
+	GetPoolSpotPriceFunc                func(ctx context.Context, poolID uint64, takerFee osmomath.Dec, quoteAsset, baseAsset string) (osmomath.BigDec, error)
+	GetCosmWasmPoolConfigFunc           func() domain.CosmWasmPoolRouterConfig
+	CalcExitCFMMPoolFunc                func(poolID uint64, exitingShares osmomath.Int) (sdk.Coins, error)
+	GetAllCanonicalOrderbookPoolIDsFunc func() ([]domain.CanonicalOrderBooksResult, error)
 
 	Pools        []sqsdomain.PoolI
 	TickModelMap map[uint64]*sqsdomain.TickModel
@@ -40,6 +41,9 @@ func (pm *PoolsUsecaseMock) IsCanonicalOrderbookPool(poolID uint64) bool {
 
 // GetAllCanonicalOrderbookPoolIDs implements mvc.PoolsUsecase.
 func (pm *PoolsUsecaseMock) GetAllCanonicalOrderbookPoolIDs() ([]domain.CanonicalOrderBooksResult, error) {
+	if pm.GetAllCanonicalOrderbookPoolIDsFunc != nil {
+		return pm.GetAllCanonicalOrderbookPoolIDsFunc()
+	}
 	panic("unimplemented")
 }
 

--- a/domain/orderbook/order.go
+++ b/domain/orderbook/order.go
@@ -3,6 +3,8 @@ package orderbookdomain
 import (
 	"fmt"
 	"strconv"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
 // OrderStatus represents the status of an order.
@@ -71,23 +73,23 @@ type Asset struct {
 }
 
 type LimitOrder struct {
-	TickId           int64       `json:"tick_id"`
-	OrderId          int64       `json:"order_id"`
-	OrderDirection   string      `json:"order_direction"`
-	Owner            string      `json:"owner"`
-	Quantity         int64       `json:"quantity"`
-	Etas             string      `json:"etas"`
-	ClaimBounty      string      `json:"claim_bounty"`
-	PlacedQuantity   int64       `json:"placed_quantity"`
-	PlacedAt         int64       `json:"placed_at"`
-	Price            string      `json:"price"`
-	PercentClaimed   string      `json:"percentClaimed"`
-	TotalFilled      int64       `json:"totalFilled"`
-	PercentFilled    string      `json:"percentFilled"`
-	OrderbookAddress string      `json:"orderbookAddress"`
-	Status           OrderStatus `json:"status"`
-	Output           string      `json:"output"`
-	QuoteAsset       Asset       `json:"quote_asset"`
-	BaseAsset        Asset       `json:"base_asset"`
-	PlacedTx         *string     `json:"placed_tx,omitempty"`
+	TickId           int64        `json:"tick_id"`
+	OrderId          int64        `json:"order_id"`
+	OrderDirection   string       `json:"order_direction"`
+	Owner            string       `json:"owner"`
+	Quantity         osmomath.Dec `json:"quantity"`
+	Etas             string       `json:"etas"`
+	ClaimBounty      string       `json:"claim_bounty"`
+	PlacedQuantity   osmomath.Dec `json:"placed_quantity"`
+	PlacedAt         int64        `json:"placed_at"`
+	Price            osmomath.Dec `json:"price"`
+	PercentClaimed   osmomath.Dec `json:"percentClaimed"`
+	TotalFilled      osmomath.Dec `json:"totalFilled"`
+	PercentFilled    osmomath.Dec `json:"percentFilled"`
+	OrderbookAddress string       `json:"orderbookAddress"`
+	Status           OrderStatus  `json:"status"`
+	Output           osmomath.Dec `json:"output"`
+	QuoteAsset       Asset        `json:"quote_asset"`
+	BaseAsset        Asset        `json:"base_asset"`
+	PlacedTx         *string      `json:"placed_tx,omitempty"`
 }

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -67,6 +67,23 @@ type CanonicalOrderBooksResult struct {
 	ContractAddress string `json:"contract_address"`
 }
 
+// Validate validates the canonical orderbook result.
+func (c CanonicalOrderBooksResult) Validate() error {
+	if c.Base == "" {
+		return ErrBaseDenomNotValid
+	}
+	if c.Quote == "" {
+		return ErrQuoteDenomNotValid
+	}
+	if c.PoolID == 0 {
+		return ErrPoolIDNotValid
+	}
+	if c.ContractAddress == "" {
+		return ErrContractAddressNotValid
+	}
+	return nil
+}
+
 type PoolsOptions struct {
 	MinPoolLiquidityCap  uint64
 	PoolIDFilter         []uint64

--- a/orderbook/types/errors.go
+++ b/orderbook/types/errors.go
@@ -1,0 +1,133 @@
+package types
+
+import "fmt"
+
+// TickForOrderbookNotFoundError represents an error when a tick is not found for a given orderbook.
+type TickForOrderbookNotFoundError struct {
+	OrderbookAddress string
+	TickID           int64
+}
+
+// Error implements the error interface.
+func (e TickForOrderbookNotFoundError) Error() string {
+	return fmt.Sprintf("tick not found %s, %d", e.OrderbookAddress, e.TickID)
+}
+
+// ParsingQuantityError represents an error that occurs while parsing the quantity field.
+type ParsingQuantityError struct {
+	Quantity string
+	Err      error
+}
+
+// Error implements the error interface.
+func (e ParsingQuantityError) Error() string {
+	return fmt.Sprintf("error parsing quantity %s: %v", e.Quantity, e.Err)
+}
+
+// ParsingPlacedQuantityError represents an error that occurs while parsing the placed quantity field.
+type ParsingPlacedQuantityError struct {
+	PlacedQuantity string
+	Err            error
+}
+
+// Error implements the error interface.
+func (e ParsingPlacedQuantityError) Error() string {
+	return fmt.Sprintf("error parsing placed quantity %s: %v", e.PlacedQuantity, e.Err)
+}
+
+// InvalidPlacedQuantityError represents an error when the placed quantity is invalid.
+type InvalidPlacedQuantityError struct {
+	PlacedQuantity int64
+}
+
+// Error implements the error interface.
+func (e InvalidPlacedQuantityError) Error() string {
+	return fmt.Sprintf("placed quantity is 0 or negative: %d", e.PlacedQuantity)
+}
+
+// GettingSpotPriceScalingFactorError represents an error that occurs while getting the spot price scaling factor.
+type GettingSpotPriceScalingFactorError struct {
+	BaseDenom  string
+	QuoteDenom string
+	Err        error
+}
+
+// Error implements the error interface.
+func (e GettingSpotPriceScalingFactorError) Error() string {
+	return fmt.Sprintf("error getting spot price scaling factor for base denom %s and quote denom %s: %v", e.BaseDenom, e.QuoteDenom, e.Err)
+}
+
+// ParsingTickValuesError represents an error that occurs while parsing the tick values.
+type ParsingTickValuesError struct {
+	Field string
+	Err   error
+}
+
+// Error implements the error interface.
+func (e ParsingTickValuesError) Error() string {
+	return fmt.Sprintf("error parsing tick values for field %s: %v", e.Field, e.Err)
+}
+
+// ParsingUnrealizedCancelsError represents an error that occurs while parsing the unrealized cancels.
+type ParsingUnrealizedCancelsError struct {
+	Field string
+	Err   error
+}
+
+// Error implements the error interface.
+func (e ParsingUnrealizedCancelsError) Error() string {
+	return fmt.Sprintf("error parsing unrealized cancels for field %s: %v", e.Field, e.Err)
+}
+
+// ParsingEtasError represents an error that occurs while parsing the ETAs field.
+type ParsingEtasError struct {
+	Etas string
+	Err  error
+}
+
+// Error implements the error interface.
+func (e ParsingEtasError) Error() string {
+	return fmt.Sprintf("error parsing etas %s: %v", e.Etas, e.Err)
+}
+
+// CalculatingPercentFilledError represents an error that occurs while calculating the percent filled.
+type CalculatingPercentFilledError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e CalculatingPercentFilledError) Error() string {
+	return fmt.Sprintf("error calculating percent filled: %v", e.Err)
+}
+
+// MappingOrderStatusError represents an error that occurs while mapping the order status.
+type MappingOrderStatusError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e MappingOrderStatusError) Error() string {
+	return fmt.Sprintf("error mapping order status: %v", e.Err)
+}
+
+// ConvertingTickToPriceError represents an error that occurs while converting a tick to a price.
+type ConvertingTickToPriceError struct {
+	TickID int64
+	Err    error
+}
+
+// Error implements the error interface.
+func (e ConvertingTickToPriceError) Error() string {
+	return fmt.Sprintf("error converting tick ID %d to price: %v", e.TickID, e.Err)
+}
+
+// ParsingPlacedAtError represents an error that occurs while parsing the placed_at field.
+type ParsingPlacedAtError struct {
+	PlacedAt string
+	Err      error
+}
+
+// Error implements the error interface.
+func (e ParsingPlacedAtError) Error() string {
+	return fmt.Sprintf("error parsing placed_at %s: %v", e.PlacedAt, e.Err)
+}

--- a/orderbook/types/errors.go
+++ b/orderbook/types/errors.go
@@ -185,3 +185,36 @@ type TickIDMismatchError struct {
 func (e TickIDMismatchError) Error() string {
 	return fmt.Sprintf("tick id mismatch when fetching tick states %d %d", e.ExpectedID, e.ActualID)
 }
+
+// FailedGetAllCanonicalOrderbookPoolIDsError represents an error when failing to get all canonical orderbook pool IDs.
+type FailedGetAllCanonicalOrderbookPoolIDsError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e FailedGetAllCanonicalOrderbookPoolIDsError) Error() string {
+	return fmt.Sprintf("failed to get all canonical orderbook pool IDs: %v", e.Err)
+}
+
+// FailedToGetActiveOrdersError is returned when the retrieval of active orders fails.
+type FailedToGetActiveOrdersError struct {
+	ContractAddress string
+	OwnerAddress    string
+	Err             error
+}
+
+// Error implements the error interface.
+func (e FailedToGetActiveOrdersError) Error() string {
+	return fmt.Sprintf("failed to get active orders for contract: %s and owner: %s: %v", e.ContractAddress, e.OwnerAddress, e.Err)
+}
+
+// FailedToGetMetadataError is returned when getting token metadata fails.
+type FailedToGetMetadataError struct {
+	TokenDenom string
+	Err        error
+}
+
+// Error implements the error interface.
+func (e FailedToGetMetadataError) Error() string {
+	return fmt.Sprintf("failed to get metadata for token denom: %s: %v", e.TokenDenom, e.Err)
+}

--- a/orderbook/types/errors.go
+++ b/orderbook/types/errors.go
@@ -131,3 +131,63 @@ type ParsingPlacedAtError struct {
 func (e ParsingPlacedAtError) Error() string {
 	return fmt.Sprintf("error parsing placed_at %s: %v", e.PlacedAt, e.Err)
 }
+
+// PoolNilError represents an error when the pool is nil.
+type PoolNilError struct{}
+
+func (e PoolNilError) Error() string {
+	return "pool is nil when processing order book"
+}
+
+// CosmWasmPoolModelNilError represents an error when the CosmWasmPoolModel is nil.
+type CosmWasmPoolModelNilError struct{}
+
+func (e CosmWasmPoolModelNilError) Error() string {
+	return "cw pool model is nil when processing order book"
+}
+
+// NotAnOrderbookPoolError represents an error when the pool is not an orderbook pool.
+type NotAnOrderbookPoolError struct {
+	PoolID uint64
+}
+
+func (e NotAnOrderbookPoolError) Error() string {
+	return fmt.Sprintf("pool is not an orderbook pool %d", e.PoolID)
+}
+
+// FailedToCastPoolModelError represents an error when the pool model cannot be cast to a CosmWasmPool.
+type FailedToCastPoolModelError struct{}
+
+func (e FailedToCastPoolModelError) Error() string {
+	return "failed to cast pool model to CosmWasmPool"
+}
+
+// FetchTicksError represents an error when fetching ticks fails.
+type FetchTicksError struct {
+	ContractAddress string
+	Err             error
+}
+
+func (e FetchTicksError) Error() string {
+	return fmt.Sprintf("failed to fetch ticks for pool %s: %v", e.ContractAddress, e.Err)
+}
+
+// FetchUnrealizedCancelsError represents an error when fetching unrealized cancels fails.
+type FetchUnrealizedCancelsError struct {
+	ContractAddress string
+	Err             error
+}
+
+func (e FetchUnrealizedCancelsError) Error() string {
+	return fmt.Sprintf("failed to fetch unrealized cancels for pool %s: %v", e.ContractAddress, e.Err)
+}
+
+// TickIDMismatchError represents an error when there is a mismatch between tick IDs.
+type TickIDMismatchError struct {
+	ExpectedID int64
+	ActualID   int64
+}
+
+func (e TickIDMismatchError) Error() string {
+	return fmt.Sprintf("tick id mismatch when fetching tick states %d %d", e.ExpectedID, e.ActualID)
+}

--- a/orderbook/types/errors.go
+++ b/orderbook/types/errors.go
@@ -1,6 +1,10 @@
 package types
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+)
 
 // TickForOrderbookNotFoundError represents an error when a tick is not found for a given orderbook.
 type TickForOrderbookNotFoundError struct {
@@ -37,7 +41,7 @@ func (e ParsingPlacedQuantityError) Error() string {
 
 // InvalidPlacedQuantityError represents an error when the placed quantity is invalid.
 type InvalidPlacedQuantityError struct {
-	PlacedQuantity int64
+	PlacedQuantity osmomath.Dec
 }
 
 // Error implements the error interface.
@@ -88,16 +92,6 @@ type ParsingEtasError struct {
 // Error implements the error interface.
 func (e ParsingEtasError) Error() string {
 	return fmt.Sprintf("error parsing etas %s: %v", e.Etas, e.Err)
-}
-
-// CalculatingPercentFilledError represents an error that occurs while calculating the percent filled.
-type CalculatingPercentFilledError struct {
-	Err error
-}
-
-// Error implements the error interface.
-func (e CalculatingPercentFilledError) Error() string {
-	return fmt.Sprintf("error calculating percent filled: %v", e.Err)
 }
 
 // MappingOrderStatusError represents an error that occurs while mapping the order status.

--- a/orderbook/types/get_orders_request.go
+++ b/orderbook/types/get_orders_request.go
@@ -1,47 +1,40 @@
 package types
 
 import (
+	"fmt"
 	"sort"
-	"strconv"
 
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/labstack/echo/v4"
+)
+
+var (
+	// ErrUserOsmoAddressInvalid is generic error returned when the user address is invalid.
+	ErrUserOsmoAddressInvalid = fmt.Errorf("userOsmoAddress is not valid osmo address")
+
+	ErrInternalError = fmt.Errorf("internal error")
 )
 
 // GetActiveOrdersRequest represents get orders request for the /pools/all-orders endpoint.
 type GetActiveOrdersRequest struct {
 	UserOsmoAddress string
-	Limit           int
-	Cursor          int
 }
 
 // UnmarshalHTTPRequest unmarshals the HTTP request to GetActiveOrdersRequest.
 func (r *GetActiveOrdersRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	r.UserOsmoAddress = c.QueryParam("userOsmoAddress")
-
-	if limit := c.QueryParam("limit"); limit != "" {
-		i, err := strconv.Atoi(limit)
-		if err != nil {
-			return err
-		}
-		r.Limit = i
-	}
-
-	if cursor := c.QueryParam("cursor"); cursor != "" {
-		i, err := strconv.Atoi(cursor)
-		if err != nil {
-			return err
-		}
-		r.Cursor = i
-	}
-
 	return nil
 }
 
 // Validate validates the GetActiveOrdersRequest.
-// TODO: implement validation rules
 func (r *GetActiveOrdersRequest) Validate() error {
+	_, err := sdk.AccAddressFromBech32(r.UserOsmoAddress)
+	if err != nil {
+		return ErrUserOsmoAddressInvalid
+	}
 	return nil
 }
 

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -1,0 +1,16 @@
+package orderbookusecase
+
+import (
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+)
+
+// OrderBookEntry is an alias of orderBookEntry for testing purposes
+func (o *orderbookUseCaseImpl) CreateFormattedLimitOrder(
+	poolID uint64,
+	order orderbookdomain.Order,
+	quoteAsset orderbookdomain.Asset,
+	baseAsset orderbookdomain.Asset,
+	orderbookAddress string,
+) (orderbookdomain.LimitOrder, error) {
+	return o.createFormattedLimitOrder(poolID, order, quoteAsset, baseAsset, orderbookAddress)
+}

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 // OrderBookEntry is an alias of orderBookEntry for testing purposes
-func (o *orderbookUseCaseImpl) CreateFormattedLimitOrder(
+func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	poolID uint64,
 	order orderbookdomain.Order,
 	quoteAsset orderbookdomain.Asset,

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -1,10 +1,12 @@
 package orderbookusecase
 
 import (
+	"context"
+	"github.com/osmosis-labs/sqs/domain"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 )
 
-// OrderBookEntry is an alias of orderBookEntry for testing purposes
+// CreateFormattedLimitOrder is an alias of createFormattedLimitOrder for testing purposes
 func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	poolID uint64,
 	order orderbookdomain.Order,
@@ -13,4 +15,9 @@ func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	orderbookAddress string,
 ) (orderbookdomain.LimitOrder, error) {
 	return o.createFormattedLimitOrder(poolID, order, quoteAsset, baseAsset, orderbookAddress)
+}
+
+// ProcessOrderBookActiveOrders is an alias of processOrderBookActiveOrders for testing purposes
+func (o *OrderbookUseCaseImpl) ProcessOrderBookActiveOrders(ctx context.Context, orderBook domain.CanonicalOrderBooksResult, ownerAddress string) ([]orderbookdomain.LimitOrder, bool, error) {
+	return o.processOrderBookActiveOrders(ctx, orderBook, ownerAddress)
 }

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -15,6 +15,7 @@ import (
 	orderbookgrpcclientdomain "github.com/osmosis-labs/sqs/domain/orderbook/grpcclient"
 	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/orderbook/telemetry"
+	"github.com/osmosis-labs/sqs/orderbook/types"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"go.uber.org/zap"
 
@@ -262,16 +263,21 @@ func (o *orderbookUseCaseImpl) createFormattedLimitOrder(
 	tickForOrder, ok := o.orderbookRepository.GetTickByID(poolID, order.TickId)
 	if !ok {
 		telemetry.GetTickByIDNotFoundCounter.Inc()
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("tick not found %s, %d", orderbookAddress, order.TickId)
+		return orderbookdomain.LimitOrder{}, types.TickForOrderbookNotFoundError{
+			OrderbookAddress: orderbookAddress,
+			TickID:           order.TickId,
+		}
 	}
 
 	tickState := tickForOrder.TickState
 	unrealizedCancels := tickForOrder.UnrealizedCancels
 
-	// Parse quantity as int64
 	quantity, err := strconv.ParseInt(order.Quantity, 10, 64)
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing quantity: %w", err)
+		return orderbookdomain.LimitOrder{}, types.ParsingQuantityError{
+			Quantity: order.Quantity,
+			Err:      err,
+		}
 	}
 
 	// Convert quantity to decimal for the calculations
@@ -279,16 +285,22 @@ func (o *orderbookUseCaseImpl) createFormattedLimitOrder(
 
 	placedQuantity, err := strconv.ParseInt(order.PlacedQuantity, 10, 64)
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing placed quantity: %w", err)
+		return orderbookdomain.LimitOrder{}, types.ParsingPlacedQuantityError{
+			PlacedQuantity: order.PlacedQuantity,
+			Err:            err,
+		}
 	}
 
 	if placedQuantity == 0 || placedQuantity < 0 {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("placed quantity is 0 or negative")
+		return orderbookdomain.LimitOrder{}, types.InvalidPlacedQuantityError{PlacedQuantity: placedQuantity}
 	}
 
 	placedQuantityDec, err := osmomath.NewDecFromStr(order.PlacedQuantity)
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing placed quantity: %w", err)
+		return orderbookdomain.LimitOrder{}, types.ParsingPlacedQuantityError{
+			PlacedQuantity: order.PlacedQuantity,
+			Err:            err,
+		}
 	}
 
 	// Calculate percent claimed
@@ -297,7 +309,11 @@ func (o *orderbookUseCaseImpl) createFormattedLimitOrder(
 	// Calculate normalization factor for price
 	normalizationFactor, err := o.tokensUsecease.GetSpotPriceScalingFactorByDenom(baseAsset.Symbol, quoteAsset.Symbol)
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("error getting spot price scaling factor: %w", err)
+		return orderbookdomain.LimitOrder{}, types.GettingSpotPriceScalingFactorError{
+			BaseDenom:  baseAsset.Symbol,
+			QuoteDenom: quoteAsset.Symbol,
+			Err:        err,
+		}
 	}
 
 	// Determine tick values and unrealized cancels based on order direction
@@ -305,30 +321,44 @@ func (o *orderbookUseCaseImpl) createFormattedLimitOrder(
 	if order.OrderDirection == "bid" {
 		tickEtas, err = strconv.ParseInt(tickState.BidValues.EffectiveTotalAmountSwapped, 10, 64)
 		if err != nil {
-			return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing bid effective total amount swapped: %w", err)
+			return orderbookdomain.LimitOrder{}, types.ParsingTickValuesError{
+				Field: "EffectiveTotalAmountSwapped (bid)",
+				Err:   err,
+			}
 		}
 
 		tickUnrealizedCancelled, err = strconv.ParseInt(unrealizedCancels.BidUnrealizedCancels.String(), 10, 64)
 		if err != nil {
-			return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing bid unrealized cancels: %w", err)
+			return orderbookdomain.LimitOrder{}, types.ParsingUnrealizedCancelsError{
+				Field: "BidUnrealizedCancels",
+				Err:   err,
+			}
 		}
 	} else {
 		tickEtas, err = strconv.ParseInt(tickState.AskValues.EffectiveTotalAmountSwapped, 10, 64)
 		if err != nil {
-			return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing ask effective total amount swapped: %w", err)
+			return orderbookdomain.LimitOrder{}, types.ParsingTickValuesError{
+				Field: "EffectiveTotalAmountSwapped (ask)",
+				Err:   err,
+			}
 		}
 
 		tickUnrealizedCancelled, err = strconv.ParseInt(unrealizedCancels.AskUnrealizedCancels.String(), 10, 64)
 		if err != nil {
-			return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing ask unrealized cancels: %w", err)
+			return orderbookdomain.LimitOrder{}, types.ParsingUnrealizedCancelsError{
+				Field: "AskUnrealizedCancels",
+				Err:   err,
+			}
 		}
 	}
 
 	// Calculate total ETAs and total filled
-
 	etas, err := strconv.ParseInt(order.Etas, 10, 64)
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing etas: %w", err)
+		return orderbookdomain.LimitOrder{}, types.ParsingEtasError{
+			Etas: order.Etas,
+			Err:  err,
+		}
 	}
 
 	tickTotalEtas := tickEtas + tickUnrealizedCancelled
@@ -341,19 +371,19 @@ func (o *orderbookUseCaseImpl) createFormattedLimitOrder(
 	// Calculate percent filled using
 	percentFilled, err := osmomath.NewDecFromStr(strconv.FormatFloat(math.Min(float64(totalFilled)/float64(placedQuantity), 1), 'f', -1, 64))
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("error calculating percent filled: %w", err)
+		return orderbookdomain.LimitOrder{}, types.CalculatingPercentFilledError{Err: err}
 	}
 
 	// Determine order status based on percent filled
 	status, err := order.Status(percentFilled.MustFloat64())
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("mapping order status: %w", err)
+		return orderbookdomain.LimitOrder{}, types.MappingOrderStatusError{Err: err}
 	}
 
 	// Calculate price based on tick ID
 	price, err := clmath.TickToPrice(order.TickId)
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("converting tick to price: %w", err)
+		return orderbookdomain.LimitOrder{}, types.ConvertingTickToPriceError{TickID: order.TickId, Err: err}
 	}
 
 	// Calculate output based on order direction
@@ -370,7 +400,10 @@ func (o *orderbookUseCaseImpl) createFormattedLimitOrder(
 	// Convert placed_at to a nano second timestamp
 	placedAt, err := strconv.ParseInt(order.PlacedAt, 10, 64)
 	if err != nil {
-		return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing placed_at: %w", err)
+		return orderbookdomain.LimitOrder{}, types.ParsingPlacedAtError{
+			PlacedAt: order.PlacedAt,
+			Err:      err,
+		}
 	}
 	placedAt = time.Unix(0, placedAt).Unix()
 

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -255,6 +255,10 @@ func (o *OrderbookUseCaseImpl) processOrderBookActiveOrders(ctx context.Context,
 	return results, isBestEffort, nil
 }
 
+// ZeroDec is a zero decimal value.
+// It is defined in a global space to avoid creating a new instance every time.
+var zeroDec = osmomath.ZeroDec()
+
 // createFormattedLimitOrder creates a limit order from the orderbook order.
 func (o *OrderbookUseCaseImpl) createFormattedLimitOrder(
 	poolID uint64,
@@ -291,20 +295,12 @@ func (o *OrderbookUseCaseImpl) createFormattedLimitOrder(
 		}
 	}
 
-	if zero := osmomath.NewDec(0); placedQuantity.Equal(zero) || placedQuantity.LT(zero) {
+	if placedQuantity.Equal(zeroDec) || placedQuantity.LT(zeroDec) {
 		return orderbookdomain.LimitOrder{}, types.InvalidPlacedQuantityError{PlacedQuantity: placedQuantity}
 	}
 
-	placedQuantityDec, err := osmomath.NewDecFromStr(order.PlacedQuantity)
-	if err != nil {
-		return orderbookdomain.LimitOrder{}, types.ParsingPlacedQuantityError{
-			PlacedQuantity: order.PlacedQuantity,
-			Err:            err,
-		}
-	}
-
 	// Calculate percent claimed
-	percentClaimed := placedQuantityDec.Sub(quantity).Quo(placedQuantityDec)
+	percentClaimed := placedQuantity.Sub(quantity).Quo(placedQuantity)
 
 	// Calculate normalization factor for price
 	normalizationFactor, err := o.tokensUsecease.GetSpotPriceScalingFactorByDenom(baseAsset.Symbol, quoteAsset.Symbol)
@@ -317,9 +313,9 @@ func (o *OrderbookUseCaseImpl) createFormattedLimitOrder(
 	}
 
 	// Determine tick values and unrealized cancels based on order direction
-	var tickEtas, tickUnrealizedCancelled int64
+	var tickEtas, tickUnrealizedCancelled osmomath.Dec
 	if order.OrderDirection == "bid" {
-		tickEtas, err = strconv.ParseInt(tickState.BidValues.EffectiveTotalAmountSwapped, 10, 64)
+		tickEtas, err = osmomath.NewDecFromStr(tickState.BidValues.EffectiveTotalAmountSwapped)
 		if err != nil {
 			return orderbookdomain.LimitOrder{}, types.ParsingTickValuesError{
 				Field: "EffectiveTotalAmountSwapped (bid)",
@@ -327,15 +323,16 @@ func (o *OrderbookUseCaseImpl) createFormattedLimitOrder(
 			}
 		}
 
-		tickUnrealizedCancelled, err = strconv.ParseInt(unrealizedCancels.BidUnrealizedCancels.String(), 10, 64)
-		if err != nil {
+		if unrealizedCancels.BidUnrealizedCancels.IsNil() {
 			return orderbookdomain.LimitOrder{}, types.ParsingUnrealizedCancelsError{
 				Field: "BidUnrealizedCancels",
-				Err:   err,
+				Err:   fmt.Errorf("nil value for bid unrealized cancels"),
 			}
 		}
+
+		tickUnrealizedCancelled = osmomath.NewDecFromInt(unrealizedCancels.BidUnrealizedCancels)
 	} else {
-		tickEtas, err = strconv.ParseInt(tickState.AskValues.EffectiveTotalAmountSwapped, 10, 64)
+		tickEtas, err = osmomath.NewDecFromStr(tickState.AskValues.EffectiveTotalAmountSwapped)
 		if err != nil {
 			return orderbookdomain.LimitOrder{}, types.ParsingTickValuesError{
 				Field: "EffectiveTotalAmountSwapped (ask)",
@@ -343,17 +340,18 @@ func (o *OrderbookUseCaseImpl) createFormattedLimitOrder(
 			}
 		}
 
-		tickUnrealizedCancelled, err = strconv.ParseInt(unrealizedCancels.AskUnrealizedCancels.String(), 10, 64)
-		if err != nil {
+		if unrealizedCancels.AskUnrealizedCancels.IsNil() {
 			return orderbookdomain.LimitOrder{}, types.ParsingUnrealizedCancelsError{
 				Field: "AskUnrealizedCancels",
-				Err:   err,
+				Err:   fmt.Errorf("nil value for ask unrealized cancels"),
 			}
 		}
+
+		tickUnrealizedCancelled = osmomath.NewDecFromInt(unrealizedCancels.AskUnrealizedCancels)
 	}
 
 	// Calculate total ETAs and total filled
-	etas, err := strconv.ParseInt(order.Etas, 10, 64)
+	etas, err := osmomath.NewDecFromStr(order.Etas)
 	if err != nil {
 		return orderbookdomain.LimitOrder{}, types.ParsingEtasError{
 			Etas: order.Etas,
@@ -361,10 +359,10 @@ func (o *OrderbookUseCaseImpl) createFormattedLimitOrder(
 		}
 	}
 
-	tickTotalEtas := tickEtas + tickUnrealizedCancelled
+	tickTotalEtas := tickEtas.Add(tickUnrealizedCancelled)
 
 	totalFilled := osmomath.MaxDec(
-		osmomath.NewDec(tickTotalEtas).Sub(osmomath.NewDec(etas).Sub(placedQuantity.Sub(quantity))),
+		tickTotalEtas.Sub(etas.Sub(placedQuantity.Sub(quantity))),
 		osmomath.ZeroDec(),
 	)
 
@@ -389,9 +387,9 @@ func (o *OrderbookUseCaseImpl) createFormattedLimitOrder(
 	// Calculate output based on order direction
 	var output osmomath.Dec
 	if order.OrderDirection == "bid" {
-		output = placedQuantityDec.Quo(price.Dec())
+		output = placedQuantity.Quo(price.Dec())
 	} else {
-		output = placedQuantityDec.Mul(price.Dec())
+		output = placedQuantity.Mul(price.Dec())
 	}
 
 	// Calculate normalized price

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -45,7 +45,7 @@ func New(
 	poolsUsecease mvc.PoolsUsecase,
 	tokensUsecease mvc.TokensUsecase,
 	logger log.Logger,
-) mvc.OrderBookUsecase {
+) *orderbookUseCaseImpl {
 	return &orderbookUseCaseImpl{
 		orderbookRepository: orderbookRepository,
 		orderBookClient:     orderBookClient,

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -282,6 +282,10 @@ func (o *orderbookUseCaseImpl) createFormattedLimitOrder(
 		return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing placed quantity: %w", err)
 	}
 
+	if placedQuantity == 0 || placedQuantity < 0 {
+		return orderbookdomain.LimitOrder{}, fmt.Errorf("placed quantity is 0 or negative")
+	}
+
 	placedQuantityDec, err := osmomath.NewDecFromStr(order.PlacedQuantity)
 	if err != nil {
 		return orderbookdomain.LimitOrder{}, fmt.Errorf("error parsing placed quantity: %w", err)

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -2,6 +2,7 @@ package orderbookusecase_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -248,6 +249,19 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 		}
 	}
 
+	// Creates a new osmomath.Dec from a string
+	// Panics if the string is invalid
+	newDecFromStr := func(str string) osmomath.Dec {
+		dec, err := osmomath.NewDecFromStr(str)
+		s.Require().NoError(err)
+		return dec
+	}
+
+	// Generates a string that overflows when converting to osmomath.Dec
+	overflowDecStr := func() string {
+		return "9223372036854775808" + strings.Repeat("0", 100000)
+	}
+
 	testCases := []struct {
 		name          string
 		poolID        uint64
@@ -283,7 +297,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 		{
 			name: "overflow in quantity",
 			order: orderbookdomain.Order{
-				Quantity:       "9223372036854775808", // overflow value for int64
+				Quantity:       overflowDecStr(),
 				PlacedQuantity: "1500",
 				Etas:           "500",
 				ClaimBounty:    "10",
@@ -308,7 +322,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			name: "overflow in placed quantity",
 			order: orderbookdomain.Order{
 				Quantity:       "1000",
-				PlacedQuantity: "9223372036854775808", // overflow value for int64
+				PlacedQuantity: overflowDecStr(),
 				Etas:           "500",
 				ClaimBounty:    "10",
 			},
@@ -476,18 +490,18 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderId:          1,
 				OrderDirection:   "bid",
 				Owner:            "owner1",
-				Quantity:         1000,
+				Quantity:         osmomath.NewDec(1000),
 				Etas:             "500",
 				ClaimBounty:      "10",
-				PlacedQuantity:   1500,
+				PlacedQuantity:   osmomath.NewDec(1500),
 				PlacedAt:         1634,
-				Price:            "1.000001000000000000",
-				PercentClaimed:   "0.333333333333333333",
-				TotalFilled:      600,
-				PercentFilled:    "0.400000000000000000",
+				Price:            newDecFromStr("1.000001000000000000"),
+				PercentClaimed:   newDecFromStr("0.333333333333333333"),
+				TotalFilled:      newDecFromStr("600"),
+				PercentFilled:    newDecFromStr("0.400000000000000000"),
 				OrderbookAddress: "someOrderbookAddress",
 				Status:           "partiallyFilled",
-				Output:           "1499.998500001499998500",
+				Output:           newDecFromStr("1499.998500001499998500"),
 				QuoteAsset:       orderbookdomain.Asset{Symbol: "ATOM", Decimals: 6},
 				BaseAsset:        orderbookdomain.Asset{Symbol: "OSMO", Decimals: 6},
 			},

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
-	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app/apptesting"
@@ -25,8 +24,36 @@ func TestOrderbookUsecaseTestSuite(t *testing.T) {
 }
 
 func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
+	getTickByIDFunc := func(effectiveTotalAmountSwapped string, unrealizedCancels int64, direction string) func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+		return func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+			tickValues := orderbookdomain.TickValues{
+				EffectiveTotalAmountSwapped: effectiveTotalAmountSwapped,
+			}
+
+			tick := orderbookdomain.OrderbookTick{
+				TickState:         orderbookdomain.TickState{},
+				UnrealizedCancels: orderbookdomain.UnrealizedCancels{},
+			}
+
+			if direction == "bid" {
+				tick.TickState.BidValues = tickValues
+				if unrealizedCancels != 0 {
+					tick.UnrealizedCancels.BidUnrealizedCancels = osmomath.NewInt(unrealizedCancels)
+				}
+			} else {
+				tick.TickState.AskValues = tickValues
+				if unrealizedCancels != 0 {
+					tick.UnrealizedCancels.AskUnrealizedCancels = osmomath.NewInt(unrealizedCancels)
+				}
+			}
+
+			return tick, true
+		}
+	}
+
 	testCases := []struct {
 		name          string
+		poolID        uint64
 		order         orderbookdomain.Order
 		quoteAsset    orderbookdomain.Asset
 		baseAsset     orderbookdomain.Asset
@@ -42,11 +69,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			expectedError: "tick not found",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						Tick: &cosmwasmpool.OrderbookTick{
-							TickId: tickID,
-						},
-					}, false
+					return orderbookdomain.OrderbookTick{}, false
 				}
 			},
 		},
@@ -57,13 +80,20 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			},
 			expectedError: "error parsing quantity",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						Tick: &cosmwasmpool.OrderbookTick{
-							TickId: tickID,
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("6431", 935, "ask")
+			},
+		},
+		{
+			name: "overflow in quantity",
+			order: orderbookdomain.Order{
+				Quantity:       "9223372036854775808", // overflow value for int64
+				PlacedQuantity: "1500",
+				Etas:           "500",
+				ClaimBounty:    "10",
+			},
+			expectedError: "error parsing quantity",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
 			},
 		},
 		{
@@ -74,30 +104,42 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			},
 			expectedError: "error parsing placed quantity",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						Tick: &cosmwasmpool.OrderbookTick{
-							TickId: tickID,
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("813", 1331, "bid")
+			},
+		},
+		{
+			name: "overflow in placed quantity",
+			order: orderbookdomain.Order{
+				Quantity:       "1000",
+				PlacedQuantity: "9223372036854775808", // overflow value for int64
+				Etas:           "500",
+				ClaimBounty:    "10",
+			},
+			expectedError: "error parsing placed quantity",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
+			},
+		},
+		{
+			name: "placed quantity is zero",
+			order: orderbookdomain.Order{
+				Quantity:       "1000",
+				PlacedQuantity: "0", // division by zero
+			},
+			expectedError: "placed quantity is 0 or negative",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("813", 1331, "bid")
 			},
 		},
 		{
 			name: "error getting spot price scaling factor",
 			order: orderbookdomain.Order{
-				Quantity:       "1000",
-				PlacedQuantity: "1500",
+				Quantity:       "931",
+				PlacedQuantity: "183",
 			},
 			expectedError: "error getting spot price scaling factor",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						Tick: &cosmwasmpool.OrderbookTick{
-							TickId: tickID,
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("130", 13, "ask")
 				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
 					return osmomath.Dec{}, assert.AnError // Simulate an error
 				}
@@ -106,44 +148,49 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 		{
 			name: "error parsing bid effective total amount swapped",
 			order: orderbookdomain.Order{
-				Quantity:       "1000",
-				PlacedQuantity: "1500",
+				Quantity:       "136",
+				PlacedQuantity: "131",
 				OrderDirection: "bid",
 			},
 			expectedError: "error parsing bid effective total amount swapped",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						TickState: orderbookdomain.TickState{
-							BidValues: orderbookdomain.TickValues{
-								EffectiveTotalAmountSwapped: "invalid", // Invalid value
-							},
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("invalid", 13, "bid")
+			},
+		},
+		{
+			name: "error parsing ask effective total amount swapped",
+			order: orderbookdomain.Order{
+				Quantity:       "136",
+				PlacedQuantity: "131",
+				OrderDirection: "ask",
+			},
+			expectedError: "error parsing ask effective total amount swapped",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("invalid", 1, "ask")
 			},
 		},
 		{
 			name: "error parsing bid unrealized cancels",
 			order: orderbookdomain.Order{
-				Quantity:       "1000",
-				PlacedQuantity: "1500",
+				Quantity:       "103",
+				PlacedQuantity: "153",
 				OrderDirection: "bid",
 			},
 			expectedError: "error parsing bid unrealized cancels",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						TickState: orderbookdomain.TickState{
-							BidValues: orderbookdomain.TickValues{
-								EffectiveTotalAmountSwapped: "100",
-							},
-						},
-						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
-							// Empty is invalid value
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("15", 0, "bid")
+			},
+		},
+		{
+			name: "error parsing ask unrealized cancels",
+			order: orderbookdomain.Order{
+				Quantity:       "133",
+				PlacedQuantity: "313",
+				OrderDirection: "ask",
+			},
+			expectedError: "error parsing ask unrealized cancels",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("13", 0, "ask")
 			},
 		},
 		{
@@ -156,18 +203,21 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			},
 			expectedError: "error parsing etas",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						TickState: orderbookdomain.TickState{
-							BidValues: orderbookdomain.TickValues{
-								EffectiveTotalAmountSwapped: "100",
-							},
-						},
-						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
-							BidUnrealizedCancels: osmomath.NewInt(100),
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("386", 830, "bid")
+			},
+		},
+		{
+			name: "overflow in etas",
+			order: orderbookdomain.Order{
+				Quantity:       "13500",
+				PlacedQuantity: "33500",
+				OrderDirection: "bid",
+				Etas:           "9223372036854775808", // overflow value for int64
+				ClaimBounty:    "10",
+			},
+			expectedError: "error parsing etas",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
 			},
 		},
 		{
@@ -181,18 +231,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			},
 			expectedError: "converting tick to price",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						TickState: orderbookdomain.TickState{
-							AskValues: orderbookdomain.TickValues{
-								EffectiveTotalAmountSwapped: "100",
-							},
-						},
-						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
-							AskUnrealizedCancels: osmomath.NewInt(100),
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("190", 150, "ask")
 			},
 		},
 		{
@@ -207,18 +246,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			},
 			expectedError: "error parsing placed_at",
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						TickState: orderbookdomain.TickState{
-							AskValues: orderbookdomain.TickValues{
-								EffectiveTotalAmountSwapped: "100",
-							},
-						},
-						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
-							AskUnrealizedCancels: osmomath.NewInt(100),
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("100", 100, "ask")
 				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
 					return osmomath.NewDec(10), nil
 				}
@@ -240,18 +268,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			quoteAsset: orderbookdomain.Asset{Symbol: "ATOM", Decimals: 6},
 			baseAsset:  orderbookdomain.Asset{Symbol: "OSMO", Decimals: 6},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{
-						TickState: orderbookdomain.TickState{
-							BidValues: orderbookdomain.TickValues{
-								EffectiveTotalAmountSwapped: "500",
-							},
-						},
-						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
-							BidUnrealizedCancels: osmomath.NewInt(100),
-						},
-					}, true
-				}
+				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
 				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
 					return osmomath.NewDec(1), nil
 				}
@@ -299,7 +316,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			)
 
 			// Call the method under test
-			result, err := usecase.CreateFormattedLimitOrder(1, tc.order, tc.quoteAsset, tc.baseAsset, "someOrderbookAddress")
+			result, err := usecase.CreateFormattedLimitOrder(tc.poolID, tc.order, tc.quoteAsset, tc.baseAsset, "someOrderbookAddress")
 
 			// Assert the results
 			if tc.expectedError != "" {

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -9,6 +9,7 @@ import (
 	cltypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/orderbook/types"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -58,7 +59,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 		quoteAsset    orderbookdomain.Asset
 		baseAsset     orderbookdomain.Asset
 		setupMocks    func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock)
-		expectedError string
+		expectedError error
 		expectedOrder orderbookdomain.LimitOrder
 	}{
 		{
@@ -66,7 +67,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			order: orderbookdomain.Order{
 				TickId: 99, // Non-existent tick ID
 			},
-			expectedError: "tick not found",
+			expectedError: &types.TickForOrderbookNotFoundError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
 					return orderbookdomain.OrderbookTick{}, false
@@ -78,7 +79,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			order: orderbookdomain.Order{
 				Quantity: "invalid", // Invalid quantity
 			},
-			expectedError: "error parsing quantity",
+			expectedError: &types.ParsingQuantityError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("6431", 935, "ask")
 			},
@@ -91,7 +92,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "500",
 				ClaimBounty:    "10",
 			},
-			expectedError: "error parsing quantity",
+			expectedError: &types.ParsingQuantityError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
 			},
@@ -102,7 +103,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Quantity:       "1000",
 				PlacedQuantity: "invalid", // Invalid placed quantity
 			},
-			expectedError: "error parsing placed quantity",
+			expectedError: &types.ParsingPlacedQuantityError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("813", 1331, "bid")
 			},
@@ -115,7 +116,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "500",
 				ClaimBounty:    "10",
 			},
-			expectedError: "error parsing placed quantity",
+			expectedError: &types.ParsingPlacedQuantityError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
 			},
@@ -126,7 +127,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Quantity:       "1000",
 				PlacedQuantity: "0", // division by zero
 			},
-			expectedError: "placed quantity is 0 or negative",
+			expectedError: &types.InvalidPlacedQuantityError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("813", 1331, "bid")
 			},
@@ -137,7 +138,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Quantity:       "931",
 				PlacedQuantity: "183",
 			},
-			expectedError: "error getting spot price scaling factor",
+			expectedError: &types.GettingSpotPriceScalingFactorError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("130", 13, "ask")
 				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
@@ -152,7 +153,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "131",
 				OrderDirection: "bid",
 			},
-			expectedError: "error parsing bid effective total amount swapped",
+			expectedError: &types.ParsingTickValuesError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("invalid", 13, "bid")
 			},
@@ -164,7 +165,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "131",
 				OrderDirection: "ask",
 			},
-			expectedError: "error parsing ask effective total amount swapped",
+			expectedError: &types.ParsingTickValuesError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("invalid", 1, "ask")
 			},
@@ -176,7 +177,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "153",
 				OrderDirection: "bid",
 			},
-			expectedError: "error parsing bid unrealized cancels",
+			expectedError: &types.ParsingUnrealizedCancelsError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("15", 0, "bid")
 			},
@@ -188,7 +189,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "313",
 				OrderDirection: "ask",
 			},
-			expectedError: "error parsing ask unrealized cancels",
+			expectedError: &types.ParsingUnrealizedCancelsError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("13", 0, "ask")
 			},
@@ -201,7 +202,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderDirection: "bid",
 				Etas:           "invalid", // Invalid ETAs
 			},
-			expectedError: "error parsing etas",
+			expectedError: &types.ParsingEtasError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("386", 830, "bid")
 			},
@@ -215,7 +216,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "9223372036854775808", // overflow value for int64
 				ClaimBounty:    "10",
 			},
-			expectedError: "error parsing etas",
+			expectedError: &types.ParsingEtasError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
 			},
@@ -229,7 +230,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderDirection: "ask",
 				Etas:           "100",
 			},
-			expectedError: "converting tick to price",
+			expectedError: &types.ConvertingTickToPriceError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("190", 150, "ask")
 			},
@@ -244,7 +245,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "100",
 				PlacedAt:       "invalid", // Invalid timestamp
 			},
-			expectedError: "error parsing placed_at",
+			expectedError: &types.ParsingPlacedAtError{},
 			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
 				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("100", 100, "ask")
 				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
@@ -273,7 +274,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 					return osmomath.NewDec(1), nil
 				}
 			},
-			expectedError: "",
+			expectedError: nil,
 			expectedOrder: orderbookdomain.LimitOrder{
 				TickId:           1,
 				OrderId:          1,
@@ -319,9 +320,9 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			result, err := usecase.CreateFormattedLimitOrder(tc.poolID, tc.order, tc.quoteAsset, tc.baseAsset, "someOrderbookAddress")
 
 			// Assert the results
-			if tc.expectedError != "" {
+			if tc.expectedError != nil {
 				s.Assert().Error(err)
-				s.Assert().Contains(err.Error(), tc.expectedError)
+				s.Assert().ErrorAs(err, tc.expectedError)
 			} else {
 				s.Assert().NoError(err)
 				s.Assert().Equal(tc.expectedOrder, result)

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -423,7 +423,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Quantity:       "13500",
 				PlacedQuantity: "33500",
 				OrderDirection: "bid",
-				Etas:           "9223372036854775808", // overflow value for int64
+				Etas:           overflowDecStr(), // overflow value for ETAs
 				ClaimBounty:    "10",
 			},
 			expectedError: &types.ParsingEtasError{},

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -1,0 +1,314 @@
+package orderbookusecase_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+
+	cltypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
+	"github.com/osmosis-labs/sqs/domain/mocks"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/osmosis/v25/app/apptesting"
+)
+
+type OrderbookUsecaseTestSuite struct {
+	apptesting.ConcentratedKeeperTestHelper
+}
+
+func TestOrderbookUsecaseTestSuite(t *testing.T) {
+	suite.Run(t, new(OrderbookUsecaseTestSuite))
+}
+
+func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
+	testCases := []struct {
+		name          string
+		order         orderbookdomain.Order
+		quoteAsset    orderbookdomain.Asset
+		baseAsset     orderbookdomain.Asset
+		setupMocks    func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock)
+		expectedError string
+		expectedOrder orderbookdomain.LimitOrder
+	}{
+		{
+			name: "tick not found",
+			order: orderbookdomain.Order{
+				TickId: 99, // Non-existent tick ID
+			},
+			expectedError: "tick not found",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						Tick: &cosmwasmpool.OrderbookTick{
+							TickId: tickID,
+						},
+					}, false
+				}
+			},
+		},
+		{
+			name: "error parsing quantity",
+			order: orderbookdomain.Order{
+				Quantity: "invalid", // Invalid quantity
+			},
+			expectedError: "error parsing quantity",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						Tick: &cosmwasmpool.OrderbookTick{
+							TickId: tickID,
+						},
+					}, true
+				}
+			},
+		},
+		{
+			name: "error parsing placed quantity",
+			order: orderbookdomain.Order{
+				Quantity:       "1000",
+				PlacedQuantity: "invalid", // Invalid placed quantity
+			},
+			expectedError: "error parsing placed quantity",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						Tick: &cosmwasmpool.OrderbookTick{
+							TickId: tickID,
+						},
+					}, true
+				}
+			},
+		},
+		{
+			name: "error getting spot price scaling factor",
+			order: orderbookdomain.Order{
+				Quantity:       "1000",
+				PlacedQuantity: "1500",
+			},
+			expectedError: "error getting spot price scaling factor",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						Tick: &cosmwasmpool.OrderbookTick{
+							TickId: tickID,
+						},
+					}, true
+				}
+				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
+					return osmomath.Dec{}, assert.AnError // Simulate an error
+				}
+			},
+		},
+		{
+			name: "error parsing bid effective total amount swapped",
+			order: orderbookdomain.Order{
+				Quantity:       "1000",
+				PlacedQuantity: "1500",
+				OrderDirection: "bid",
+			},
+			expectedError: "error parsing bid effective total amount swapped",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						TickState: orderbookdomain.TickState{
+							BidValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "invalid", // Invalid value
+							},
+						},
+					}, true
+				}
+			},
+		},
+		{
+			name: "error parsing bid unrealized cancels",
+			order: orderbookdomain.Order{
+				Quantity:       "1000",
+				PlacedQuantity: "1500",
+				OrderDirection: "bid",
+			},
+			expectedError: "error parsing bid unrealized cancels",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						TickState: orderbookdomain.TickState{
+							BidValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "100",
+							},
+						},
+						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
+							// Empty is invalid value
+						},
+					}, true
+				}
+			},
+		},
+		{
+			name: "error parsing etas",
+			order: orderbookdomain.Order{
+				Quantity:       "1000",
+				PlacedQuantity: "1500",
+				OrderDirection: "bid",
+				Etas:           "invalid", // Invalid ETAs
+			},
+			expectedError: "error parsing etas",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						TickState: orderbookdomain.TickState{
+							BidValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "100",
+							},
+						},
+						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
+							BidUnrealizedCancels: osmomath.NewInt(100),
+						},
+					}, true
+				}
+			},
+		},
+		{
+			name: "error converting tick to price",
+			order: orderbookdomain.Order{
+				TickId:         cltypes.MinCurrentTickV2 - 1, // Invalid tick ID
+				Quantity:       "1000",
+				PlacedQuantity: "1500",
+				OrderDirection: "ask",
+				Etas:           "100",
+			},
+			expectedError: "converting tick to price",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						TickState: orderbookdomain.TickState{
+							AskValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "100",
+							},
+						},
+						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
+							AskUnrealizedCancels: osmomath.NewInt(100),
+						},
+					}, true
+				}
+			},
+		},
+		{
+			name: "error parsing placed_at",
+			order: orderbookdomain.Order{
+				TickId:         1,
+				Quantity:       "1000",
+				PlacedQuantity: "1500",
+				OrderDirection: "ask",
+				Etas:           "100",
+				PlacedAt:       "invalid", // Invalid timestamp
+			},
+			expectedError: "error parsing placed_at",
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						TickState: orderbookdomain.TickState{
+							AskValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "100",
+							},
+						},
+						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
+							AskUnrealizedCancels: osmomath.NewInt(100),
+						},
+					}, true
+				}
+				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
+					return osmomath.NewDec(10), nil
+				}
+			},
+		},
+		{
+			name: "successful order processing",
+			order: orderbookdomain.Order{
+				TickId:         1,
+				OrderId:        1,
+				OrderDirection: "bid",
+				Owner:          "owner1",
+				Quantity:       "1000",
+				PlacedQuantity: "1500",
+				Etas:           "500",
+				ClaimBounty:    "10",
+				PlacedAt:       "1634764800000",
+			},
+			quoteAsset: orderbookdomain.Asset{Symbol: "ATOM", Decimals: 6},
+			baseAsset:  orderbookdomain.Asset{Symbol: "OSMO", Decimals: 6},
+			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
+				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					return orderbookdomain.OrderbookTick{
+						TickState: orderbookdomain.TickState{
+							BidValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "500",
+							},
+						},
+						UnrealizedCancels: orderbookdomain.UnrealizedCancels{
+							BidUnrealizedCancels: osmomath.NewInt(100),
+						},
+					}, true
+				}
+				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
+					return osmomath.NewDec(1), nil
+				}
+			},
+			expectedError: "",
+			expectedOrder: orderbookdomain.LimitOrder{
+				TickId:           1,
+				OrderId:          1,
+				OrderDirection:   "bid",
+				Owner:            "owner1",
+				Quantity:         1000,
+				Etas:             "500",
+				ClaimBounty:      "10",
+				PlacedQuantity:   1500,
+				PlacedAt:         1634,
+				Price:            "1.000001000000000000",
+				PercentClaimed:   "0.333333333333333333",
+				TotalFilled:      600,
+				PercentFilled:    "0.400000000000000000",
+				OrderbookAddress: "someOrderbookAddress",
+				Status:           "partiallyFilled",
+				Output:           "1499.998500001499998500",
+				QuoteAsset:       orderbookdomain.Asset{Symbol: "ATOM", Decimals: 6},
+				BaseAsset:        orderbookdomain.Asset{Symbol: "OSMO", Decimals: 6},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create instances of the mocks
+			orderbookRepo := mocks.OrderbookRepositoryMock{}
+			tokensUsecase := mocks.TokensUsecaseMock{}
+
+			// Setup the mocks according to the test case
+			tc.setupMocks(&orderbookRepo, &tokensUsecase)
+
+			// Initialize the use case with the mocks
+			usecase := orderbookusecase.New(
+				&orderbookRepo,
+				nil,
+				nil,
+				&tokensUsecase,
+				nil,
+			)
+
+			// Call the method under test
+			result, err := usecase.CreateFormattedLimitOrder(1, tc.order, tc.quoteAsset, tc.baseAsset, "someOrderbookAddress")
+
+			// Assert the results
+			if tc.expectedError != "" {
+				s.Assert().Error(err)
+				s.Assert().Contains(err.Error(), tc.expectedError)
+			} else {
+				s.Assert().NoError(err)
+				s.Assert().Equal(tc.expectedOrder, result)
+			}
+		})
+	}
+}

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -1,16 +1,24 @@
 package orderbookusecase_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/osmosis-labs/sqs/sqsdomain"
+
+	cwpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
+
 	cltypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	orderbookgrpcclientdomain "github.com/osmosis-labs/sqs/domain/orderbook/grpcclient"
 	"github.com/osmosis-labs/sqs/orderbook/types"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app/apptesting"
@@ -24,6 +32,194 @@ func TestOrderbookUsecaseTestSuite(t *testing.T) {
 	suite.Run(t, new(OrderbookUsecaseTestSuite))
 }
 
+func (s *OrderbookUsecaseTestSuite) TestProcessPool() {
+	withContractInfo := func(pool *mocks.MockRoutablePool) *mocks.MockRoutablePool {
+		pool.CosmWasmPoolModel.ContractInfo = cosmwasmpool.ContractInfo{
+			Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+			Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+		}
+		return pool
+	}
+
+	withTicks := func(pool *mocks.MockRoutablePool, ticks []cosmwasmpool.OrderbookTick) *mocks.MockRoutablePool {
+		pool.CosmWasmPoolModel.Data = cosmwasmpool.CosmWasmPoolData{
+			Orderbook: &cosmwasmpool.OrderbookData{
+				Ticks: ticks,
+			},
+		}
+
+		return pool
+	}
+
+	withChainModel := func(pool *mocks.MockRoutablePool, chainPoolModel poolmanagertypes.PoolI) *mocks.MockRoutablePool {
+		pool.ChainPoolModel = chainPoolModel
+		return pool
+	}
+
+	pool := func() *mocks.MockRoutablePool {
+		return &mocks.MockRoutablePool{
+			CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{},
+		}
+	}
+
+	poolWithTicks := func() *mocks.MockRoutablePool {
+		return withTicks(withContractInfo(pool()), []cosmwasmpool.OrderbookTick{{TickId: 1}})
+	}
+
+	poolWithChainModel := func() *mocks.MockRoutablePool {
+		return withChainModel(poolWithTicks(), &cwpoolmodel.CosmWasmPool{})
+	}
+
+	testCases := []struct {
+		name          string
+		pool          sqsdomain.PoolI
+		setupMocks    func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock)
+		expectedError error
+	}{
+		{
+			name:          "pool is nil",
+			pool:          nil,
+			expectedError: &types.PoolNilError{},
+		},
+		{
+			name: "cosmWasmPoolModel is nil",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: nil,
+			},
+			expectedError: &types.CosmWasmPoolModelNilError{},
+		},
+		{
+			name: "pool is not an orderbook pool",
+			pool: &mocks.MockRoutablePool{
+				ID:                1,
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{},
+			},
+			expectedError: &types.NotAnOrderbookPoolError{},
+		},
+		{
+			name:          "orderbook pool has no ticks, nothing to process",
+			pool:          withTicks(withContractInfo(pool()), []cosmwasmpool.OrderbookTick{}),
+			expectedError: nil,
+		},
+		{
+			name: "failed to cast pool model to CosmWasmPool",
+			pool: withChainModel(poolWithTicks(), &mocks.ChainPoolMock{
+				ID:   1,
+				Type: poolmanagertypes.Balancer,
+			}),
+			expectedError: &types.FailedToCastPoolModelError{},
+		},
+		{
+			name: "failed to fetch ticks for pool",
+			pool: poolWithChainModel(),
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return nil, assert.AnError
+				}
+			},
+			expectedError: &types.FetchTicksError{},
+		},
+		{
+			name: "failed to fetch unrealized cancels for pool",
+			pool: poolWithChainModel(),
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return nil, assert.AnError
+				}
+			},
+			expectedError: &types.FetchUnrealizedCancelsError{},
+		},
+		{
+			name: "tick ID mismatch when fetching unrealized ticks",
+			pool: poolWithChainModel(),
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 1},
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{TickID: 2}, // Mismatch
+					}, nil
+				}
+			},
+			expectedError: &types.TickIDMismatchError{},
+		},
+		{
+			name: "tick ID mismatch when fetching tick states",
+			pool: poolWithChainModel(),
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 2}, // Mismatched TickID
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{TickID: 1},
+					}, nil
+				}
+			},
+			expectedError: &types.TickIDMismatchError{},
+		},
+		{
+			name: "successful pool processing",
+			pool: poolWithChainModel(),
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 1, TickState: orderbookdomain.TickState{
+							BidValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "100",
+							},
+						}},
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{
+							TickID: 1,
+							UnrealizedCancelsState: orderbookdomain.UnrealizedCancels{
+								BidUnrealizedCancels: osmomath.NewInt(100),
+							},
+						},
+					}, nil
+				}
+				repository.StoreTicksFunc = func(poolID uint64, ticksMap map[int64]orderbookdomain.OrderbookTick) {
+					// Assume ticks are correctly stored, no need for implementation here
+				}
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create instances of the mocks
+			repository := mocks.OrderbookRepositoryMock{}
+			tokensUsecase := mocks.TokensUsecaseMock{}
+			client := mocks.OrderbookGRPCClientMock{}
+
+			// Setup the mocks according to the test case
+			usecase := orderbookusecase.New(&repository, &client, nil, &tokensUsecase, nil)
+			if tc.setupMocks != nil {
+				tc.setupMocks(usecase, &client, &repository)
+			}
+
+			// Call the method under test
+			err := usecase.ProcessPool(context.Background(), tc.pool)
+
+			// Assert the results
+			if tc.expectedError != nil {
+				s.Assert().Error(err)
+				s.Assert().ErrorAs(err, tc.expectedError)
+			} else {
+				s.Assert().NoError(err)
+			}
+		})
+	}
+}
 func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 	getTickByIDFunc := func(effectiveTotalAmountSwapped string, unrealizedCancels int64, direction string) func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
 		return func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -2,35 +2,52 @@ package orderbookusecase_test
 
 import (
 	"context"
+	"errors"
+	"sort"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/osmosis-labs/sqs/sqsdomain"
-
 	cwpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
+	"github.com/osmosis-labs/sqs/log"
+	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	cltypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
+	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	orderbookgrpcclientdomain "github.com/osmosis-labs/sqs/domain/orderbook/grpcclient"
 	"github.com/osmosis-labs/sqs/orderbook/types"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
+	"github.com/osmosis-labs/sqs/orderbook/usecase/orderbooktesting"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
-	"github.com/osmosis-labs/osmosis/v25/app/apptesting"
 )
 
+// OrderbookUsecaseTestSuite is a test suite for the orderbook usecase
 type OrderbookUsecaseTestSuite struct {
-	apptesting.ConcentratedKeeperTestHelper
+	orderbooktesting.OrderbookTestHelper
 }
 
+// SetupTest sets up the test suite
 func TestOrderbookUsecaseTestSuite(t *testing.T) {
 	suite.Run(t, new(OrderbookUsecaseTestSuite))
+}
+
+func (s *OrderbookUsecaseTestSuite) GetSpotPriceScalingFactorByDenomFunc(v int64, err error) func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
+	return func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
+		return osmomath.NewDec(v), err
+	}
+}
+
+func (s *OrderbookUsecaseTestSuite) getTickByIDFunc(tick orderbookdomain.OrderbookTick, ok bool) func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+	return func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+		return tick, ok
+	}
 }
 
 func (s *OrderbookUsecaseTestSuite) TestProcessPool() {
@@ -199,11 +216,11 @@ func (s *OrderbookUsecaseTestSuite) TestProcessPool() {
 		s.Run(tc.name, func() {
 			// Create instances of the mocks
 			repository := mocks.OrderbookRepositoryMock{}
-			tokensUsecase := mocks.TokensUsecaseMock{}
+			tokensusecase := mocks.TokensUsecaseMock{}
 			client := mocks.OrderbookGRPCClientMock{}
 
 			// Setup the mocks according to the test case
-			usecase := orderbookusecase.New(&repository, &client, nil, &tokensUsecase, nil)
+			usecase := orderbookusecase.New(&repository, &client, nil, &tokensusecase, nil)
 			if tc.setupMocks != nil {
 				tc.setupMocks(usecase, &client, &repository)
 			}
@@ -221,42 +238,378 @@ func (s *OrderbookUsecaseTestSuite) TestProcessPool() {
 		})
 	}
 }
-func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
-	getTickByIDFunc := func(effectiveTotalAmountSwapped string, unrealizedCancels int64, direction string) func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-		return func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-			tickValues := orderbookdomain.TickValues{
-				EffectiveTotalAmountSwapped: effectiveTotalAmountSwapped,
+
+func (s *OrderbookUsecaseTestSuite) TestGetActiveOrders() {
+	testCases := []struct {
+		name                 string
+		setupContext         func() context.Context
+		setupMocks           func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock)
+		address              string
+		expectedError        error
+		expectedOrders       []orderbookdomain.LimitOrder
+		expectedIsBestEffort bool
+	}{
+		{
+			name: "failed to get all canonical orderbook pool IDs",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock) {
+				poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = func() ([]domain.CanonicalOrderBooksResult, error) {
+					return nil, assert.AnError
+				}
+			},
+			address:       "osmo1npsku4qlqav6udkvgfk9eran4s4edzu69vzdm6",
+			expectedError: &types.FailedGetAllCanonicalOrderbookPoolIDsError{},
+		},
+		{
+			name: "context is done before processing all orderbooks",
+			setupContext: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock) {
+				poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = func() ([]domain.CanonicalOrderBooksResult, error) {
+					return []domain.CanonicalOrderBooksResult{
+						{PoolID: 1},
+					}, nil
+				}
+			},
+			address:       "osmo1glq2duq5f4x3m88fqwecfrfcuauy8343amy5fm",
+			expectedError: context.Canceled,
+		},
+		{
+			name: "isBestEffort set to true when one orderbook is processed with best effort",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock) {
+				poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = s.GetAllCanonicalOrderbookPoolIDsFunc(nil, s.NewCanonicalOrderBooksResult(1, "A"))
+
+				grpcclient.GetActiveOrdersCb = s.GetActiveOrdersFunc(orderbookdomain.Orders{s.NewOrder().Order}, 1, nil)
+
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFuncEmptyToken()
+
+				// Set is best effort to true
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(orderbookdomain.OrderbookTick{}, false)
+			},
+			address:              "osmo1777xu9gw22pham4yzssuywmxvel5wdyqkyacdw",
+			expectedError:        nil,
+			expectedOrders:       []orderbookdomain.LimitOrder{},
+			expectedIsBestEffort: true,
+		},
+		{
+			name: "successful retrieval of active orders",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock) {
+				poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = s.GetAllCanonicalOrderbookPoolIDsFunc(nil, s.NewCanonicalOrderBooksResult(1, "A"))
+
+				grpcclient.GetActiveOrdersCb = s.GetActiveOrdersFunc(orderbookdomain.Orders{s.NewOrder().Order}, 1, nil)
+
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFuncEmptyToken()
+
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(1, nil)
+
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
+			},
+			address:       "osmo1p2pq3dt5xkj39p0420p4mm9l45394xecr00299",
+			expectedError: nil,
+			expectedOrders: []orderbookdomain.LimitOrder{
+				s.NewLimitOrder().WithOrderbookAddress("A").LimitOrder,
+			},
+			expectedIsBestEffort: false,
+		},
+		{
+			name: "successful retrieval of active orders: 3 orders returned. 1 from orderbook A, 2 from orderbook B -> 3 orders are returned as intended",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock) {
+				poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = s.GetAllCanonicalOrderbookPoolIDsFunc(
+					nil,
+					s.NewCanonicalOrderBooksResult(1, "A"),
+					s.NewCanonicalOrderBooksResult(1, "B"),
+				)
+
+				grpcclient.GetActiveOrdersCb = func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error) {
+					if contractAddress == "A" {
+						return orderbookdomain.Orders{
+							s.NewOrder().WithOrderID(3).Order,
+						}, 1, nil
+					}
+					return orderbookdomain.Orders{
+						s.NewOrder().WithOrderID(1).Order,
+						s.NewOrder().WithOrderID(2).Order,
+					}, 2, nil
+				}
+
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFuncEmptyToken()
+
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
+					return osmomath.NewDec(1), nil
+				}
+
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
+			},
+			address:       "osmo1p2pq3dt5xkj39p0420p4mm9l45394xecr00299",
+			expectedError: nil,
+			expectedOrders: []orderbookdomain.LimitOrder{
+				s.NewLimitOrder().WithOrderID(1).WithOrderbookAddress("B").LimitOrder,
+				s.NewLimitOrder().WithOrderID(2).WithOrderbookAddress("B").LimitOrder,
+				s.NewLimitOrder().WithOrderID(3).WithOrderbookAddress("A").LimitOrder,
+			},
+			expectedIsBestEffort: false,
+		},
+		{
+			name: "successful retrieval of active orders: 2 orders returned. 1 from orderbook A, 1 from order book B. Orderbook B is not canonical -> only 1 order is returned",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock) {
+				poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = s.GetAllCanonicalOrderbookPoolIDsFunc(
+					nil,
+					s.NewCanonicalOrderBooksResult(1, "A"),
+					s.NewCanonicalOrderBooksResult(0, "B"), // Not canonical
+				)
+
+				grpcclient.GetActiveOrdersCb = func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error) {
+					if contractAddress == "B" {
+						return orderbookdomain.Orders{
+							s.NewOrder().WithOrderID(2).Order,
+						}, 1, nil
+					}
+					return orderbookdomain.Orders{
+						s.NewOrder().WithOrderID(1).Order,
+					}, 2, nil
+				}
+
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFuncEmptyToken()
+
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
+					return osmomath.NewDec(1), nil
+				}
+
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
+			},
+			address:       "osmo1p2pq3dt5xkj39p0420p4mm9l45394xecr00299",
+			expectedError: nil,
+			expectedOrders: []orderbookdomain.LimitOrder{
+				s.NewLimitOrder().WithOrderID(1).WithOrderbookAddress("A").LimitOrder,
+			},
+			expectedIsBestEffort: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create instances of the mocks
+			poolsUsecase := mocks.PoolsUsecaseMock{}
+			orderbookrepositorysitory := mocks.OrderbookRepositoryMock{}
+			client := mocks.OrderbookGRPCClientMock{}
+			tokensusecase := mocks.TokensUsecaseMock{}
+
+			// Setup the mocks according to the test case
+			usecase := orderbookusecase.New(&orderbookrepositorysitory, &client, &poolsUsecase, &tokensusecase, &log.NoOpLogger{})
+			if tc.setupMocks != nil {
+				tc.setupMocks(usecase, &orderbookrepositorysitory, &client, &poolsUsecase, &tokensusecase)
 			}
 
-			tick := orderbookdomain.OrderbookTick{
-				TickState:         orderbookdomain.TickState{},
-				UnrealizedCancels: orderbookdomain.UnrealizedCancels{},
+			ctx := tc.setupContext()
+
+			// Call the method under test
+			// We are not interested in the orders returned, it's tested
+			// in the TestCreateFormattedLimitOrder.
+			orders, isBestEffort, err := usecase.GetActiveOrders(ctx, tc.address)
+
+			// Sort the results by order ID to make the output more deterministic
+			sort.SliceStable(orders, func(i, j int) bool {
+				return orders[i].OrderId < orders[j].OrderId
+			})
+
+			// Assert the results
+			if tc.expectedError != nil {
+				s.Assert().Error(err)
+				s.ErrorIsAs(err, tc.expectedError)
+			} else {
+				s.Assert().NoError(err)
+				s.Assert().Equal(tc.expectedIsBestEffort, isBestEffort)
+				s.Assert().Equal(tc.expectedOrders, orders)
+			}
+		})
+	}
+}
+
+func (s *OrderbookUsecaseTestSuite) TestProcessOrderBookActiveOrders() {
+	newLimitOrder := func() orderbooktesting.LimitOrder {
+		order := s.NewLimitOrder()
+		order = order.WithQuoteAsset(orderbookdomain.Asset{Symbol: "ATOM", Decimals: 6})
+		order = order.WithBaseAsset(orderbookdomain.Asset{Symbol: "OSMO", Decimals: 6})
+		return order
+	}
+
+	testCases := []struct {
+		name                 string
+		setupMocks           func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, client *mocks.OrderbookGRPCClientMock, tokensusecase *mocks.TokensUsecaseMock)
+		poolID               uint64
+		order                orderbooktesting.LimitOrder
+		ownerAddress         string
+		expectedError        error
+		expectedOrders       []orderbookdomain.LimitOrder
+		expectedIsBestEffort bool
+	}{
+		{
+			name: "failed to get active orders",
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, client *mocks.OrderbookGRPCClientMock, tokensusecase *mocks.TokensUsecaseMock) {
+				client.GetActiveOrdersCb = s.GetActiveOrdersFunc(nil, 0, assert.AnError)
+			},
+			poolID:        1,
+			order:         newLimitOrder().WithOrderID(5),
+			ownerAddress:  "osmo1epp52vecttkkvs3s84c9m8s2v2jrf7gtm3jzhg",
+			expectedError: &types.FailedToGetActiveOrdersError{},
+		},
+		{
+			name: "no active orders to process",
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, client *mocks.OrderbookGRPCClientMock, tokensusecase *mocks.TokensUsecaseMock) {
+				client.GetActiveOrdersCb = s.GetActiveOrdersFunc(nil, 0, nil)
+			},
+			poolID:               83,
+			order:                newLimitOrder().WithOrderbookAddress("A"),
+			ownerAddress:         "osmo1h5la3t4y8cljl34lsqdszklvcn053u4ryz9qr78v64rsxezyxwlsdelsdr",
+			expectedError:        nil,
+			expectedOrders:       nil,
+			expectedIsBestEffort: false,
+		},
+		{
+			name: "failed to get quote token metadata",
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, client *mocks.OrderbookGRPCClientMock, tokensusecase *mocks.TokensUsecaseMock) {
+				client.GetActiveOrdersCb = s.GetActiveOrdersFunc(orderbookdomain.Orders{s.NewOrder().Order}, 1, nil)
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFunc(newLimitOrder(), "quoteToken")
+			},
+			poolID:        11,
+			order:         newLimitOrder().WithOrderID(1),
+			ownerAddress:  "osmo103l28g7r3q90d20vta2p2mz0x7qvdr3xgfwnas",
+			expectedError: &types.FailedToGetMetadataError{},
+		},
+		{
+			name: "failed to get base token metadata",
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, client *mocks.OrderbookGRPCClientMock, tokensusecase *mocks.TokensUsecaseMock) {
+				client.GetActiveOrdersCb = s.GetActiveOrdersFunc(orderbookdomain.Orders{s.NewOrder().Order}, 1, nil)
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFunc(newLimitOrder(), "quoteToken")
+			},
+			poolID:        35,
+			order:         newLimitOrder().WithOrderbookAddress("D"),
+			ownerAddress:  "osmo1rlj2g3etczywhawuk7zh3tv8sp9edavvntn7jr",
+			expectedError: &types.FailedToGetMetadataError{},
+		},
+		{
+			name: "error on creating formatted limit order ( no error - best effort )",
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, client *mocks.OrderbookGRPCClientMock, tokensusecase *mocks.TokensUsecaseMock) {
+				client.GetActiveOrdersCb = s.GetActiveOrdersFunc(orderbookdomain.Orders{
+					s.NewOrder().WithOrderID(1).WithTickID(1).Order,
+					s.NewOrder().WithOrderID(2).WithTickID(2).Order,
+				}, 1, nil)
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFunc(newLimitOrder(), "")
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(1, nil)
+				orderbookrepository.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+					tick := s.NewTick("500", 100, "bid")
+					if tickID == 1 {
+						return tick, true
+					}
+					return tick, false
+				}
+			},
+			poolID:        5,
+			order:         newLimitOrder().WithOrderID(2),
+			ownerAddress:  "osmo1c8udna9h9zsm44jav39g20dmtf7xjnrclpn5fw",
+			expectedError: nil,
+			expectedOrders: []orderbookdomain.LimitOrder{
+				newLimitOrder().WithOrderID(1).LimitOrder,
+			},
+			expectedIsBestEffort: true,
+		},
+		{
+			name: "successful processing of 1 active order",
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, client *mocks.OrderbookGRPCClientMock, tokensusecase *mocks.TokensUsecaseMock) {
+				client.GetActiveOrdersCb = s.GetActiveOrdersFunc(orderbookdomain.Orders{s.NewOrder().Order}, 1, nil)
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFunc(newLimitOrder(), "")
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(1, nil)
+			},
+
+			poolID:        39,
+			order:         newLimitOrder().WithOrderbookAddress("B"),
+			ownerAddress:  "osmo1xhkvmfyfll0303s7xm9hh8uzzwehd98tuyjpga",
+			expectedError: nil,
+			expectedOrders: []orderbookdomain.LimitOrder{
+				newLimitOrder().WithOrderbookAddress("B").LimitOrder,
+			},
+			expectedIsBestEffort: false,
+		},
+		{
+			name: "successful processing of 2 active orders",
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, client *mocks.OrderbookGRPCClientMock, tokensusecase *mocks.TokensUsecaseMock) {
+				client.GetActiveOrdersCb = s.GetActiveOrdersFunc(orderbookdomain.Orders{
+					s.NewOrder().WithOrderID(1).Order,
+					s.NewOrder().WithOrderID(2).Order,
+				}, 1, nil)
+				tokensusecase.GetMetadataByChainDenomFunc = s.GetMetadataByChainDenomFunc(newLimitOrder().WithBaseAsset(orderbookdomain.Asset{Symbol: "USDC", Decimals: 6}), "")
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(1, nil)
+			},
+			poolID:        93,
+			order:         newLimitOrder().WithBaseAsset(orderbookdomain.Asset{Symbol: "USDC", Decimals: 6}),
+			ownerAddress:  "osmo1xhkvmfyfll0303s7xm9hh8uzzwehd98tuyjpga",
+			expectedError: nil,
+			expectedOrders: []orderbookdomain.LimitOrder{
+				newLimitOrder().WithOrderID(1).WithBaseAsset(orderbookdomain.Asset{Symbol: "USDC", Decimals: 6}).LimitOrder,
+				newLimitOrder().WithOrderID(2).WithBaseAsset(orderbookdomain.Asset{Symbol: "USDC", Decimals: 6}).LimitOrder,
+			},
+			expectedIsBestEffort: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create instances of the mocks
+			client := mocks.OrderbookGRPCClientMock{}
+			tokensusecase := mocks.TokensUsecaseMock{}
+			orderbookrepository := mocks.OrderbookRepositoryMock{}
+
+			// Setup the mocks according to the test case
+			usecase := orderbookusecase.New(&orderbookrepository, &client, nil, &tokensusecase, &log.NoOpLogger{})
+			if tc.setupMocks != nil {
+				tc.setupMocks(usecase, &orderbookrepository, &client, &tokensusecase)
 			}
 
-			if direction == "bid" {
-				tick.TickState.BidValues = tickValues
-				if unrealizedCancels != 0 {
-					tick.UnrealizedCancels.BidUnrealizedCancels = osmomath.NewInt(unrealizedCancels)
+			// Call the method under test
+			orders, isBestEffort, err := usecase.ProcessOrderBookActiveOrders(context.Background(), domain.CanonicalOrderBooksResult{
+				ContractAddress: tc.order.OrderbookAddress,
+				PoolID:          tc.poolID,
+				Quote:           tc.order.QuoteAsset.Symbol,
+				Base:            tc.order.BaseAsset.Symbol,
+			}, tc.ownerAddress)
+
+			// Assert the results
+			if tc.expectedError != nil {
+				s.Assert().Error(err)
+				if errors.Is(err, tc.expectedError) {
+					s.Assert().ErrorIs(err, tc.expectedError)
+				} else {
+					s.Assert().ErrorAs(err, tc.expectedError)
 				}
 			} else {
-				tick.TickState.AskValues = tickValues
-				if unrealizedCancels != 0 {
-					tick.UnrealizedCancels.AskUnrealizedCancels = osmomath.NewInt(unrealizedCancels)
-				}
+				s.Assert().NoError(err)
+				s.Assert().Equal(tc.expectedOrders, orders)
+				s.Assert().Equal(tc.expectedIsBestEffort, isBestEffort)
 			}
-
-			return tick, true
-		}
+		})
 	}
+}
 
-	// Creates a new osmomath.Dec from a string
-	// Panics if the string is invalid
-	newDecFromStr := func(str string) osmomath.Dec {
-		dec, err := osmomath.NewDecFromStr(str)
-		s.Require().NoError(err)
-		return dec
-	}
-
+func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 	// Generates a string that overflows when converting to osmomath.Dec
 	overflowDecStr := func() string {
 		return "9223372036854775808" + strings.Repeat("0", 100000)
@@ -268,7 +621,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 		order         orderbookdomain.Order
 		quoteAsset    orderbookdomain.Asset
 		baseAsset     orderbookdomain.Asset
-		setupMocks    func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock)
+		setupMocks    func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock)
 		expectedError error
 		expectedOrder orderbookdomain.LimitOrder
 	}{
@@ -278,10 +631,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				TickId: 99, // Non-existent tick ID
 			},
 			expectedError: &types.TickForOrderbookNotFoundError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
-					return orderbookdomain.OrderbookTick{}, false
-				}
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(orderbookdomain.OrderbookTick{}, false)
 			},
 		},
 		{
@@ -290,8 +641,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Quantity: "invalid", // Invalid quantity
 			},
 			expectedError: &types.ParsingQuantityError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("6431", 935, "ask")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("6431", 935, "ask"), true)
 			},
 		},
 		{
@@ -303,8 +654,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				ClaimBounty:    "10",
 			},
 			expectedError: &types.ParsingQuantityError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
 			},
 		},
 		{
@@ -314,8 +665,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "invalid", // Invalid placed quantity
 			},
 			expectedError: &types.ParsingPlacedQuantityError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("813", 1331, "bid")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("813", 1331, "bid"), true)
 			},
 		},
 		{
@@ -327,8 +678,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				ClaimBounty:    "10",
 			},
 			expectedError: &types.ParsingPlacedQuantityError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
 			},
 		},
 		{
@@ -338,8 +689,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "0", // division by zero
 			},
 			expectedError: &types.InvalidPlacedQuantityError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("813", 1331, "bid")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("813", 1331, "bid"), true)
 			},
 		},
 		{
@@ -349,11 +700,9 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "183",
 			},
 			expectedError: &types.GettingSpotPriceScalingFactorError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("130", 13, "ask")
-				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
-					return osmomath.Dec{}, assert.AnError // Simulate an error
-				}
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("130", 13, "ask"), true)
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(1, assert.AnError)
 			},
 		},
 		{
@@ -364,8 +713,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderDirection: "bid",
 			},
 			expectedError: &types.ParsingTickValuesError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("invalid", 13, "bid")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("invalid", 13, "bid"), true)
 			},
 		},
 		{
@@ -376,8 +725,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderDirection: "ask",
 			},
 			expectedError: &types.ParsingTickValuesError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("invalid", 1, "ask")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("invalid", 1, "ask"), true)
 			},
 		},
 		{
@@ -388,8 +737,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderDirection: "bid",
 			},
 			expectedError: &types.ParsingUnrealizedCancelsError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("15", 0, "bid")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("15", 0, "bid"), true)
 			},
 		},
 		{
@@ -400,8 +749,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderDirection: "ask",
 			},
 			expectedError: &types.ParsingUnrealizedCancelsError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("13", 0, "ask")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("13", 0, "ask"), true)
 			},
 		},
 		{
@@ -413,8 +762,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "invalid", // Invalid ETAs
 			},
 			expectedError: &types.ParsingEtasError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("386", 830, "bid")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("386", 830, "bid"), true)
 			},
 		},
 		{
@@ -427,8 +776,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				ClaimBounty:    "10",
 			},
 			expectedError: &types.ParsingEtasError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
 			},
 		},
 		{
@@ -441,8 +790,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "100",
 			},
 			expectedError: &types.ConvertingTickToPriceError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("190", 150, "ask")
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("190", 150, "ask"), true)
 			},
 		},
 		{
@@ -456,73 +805,38 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedAt:       "invalid", // Invalid timestamp
 			},
 			expectedError: &types.ParsingPlacedAtError{},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("100", 100, "ask")
-				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
-					return osmomath.NewDec(10), nil
-				}
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("100", 100, "ask"), true)
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(10, nil)
 			},
 		},
 		{
-			name: "successful order processing",
-			order: orderbookdomain.Order{
-				TickId:         1,
-				OrderId:        1,
-				OrderDirection: "bid",
-				Owner:          "owner1",
-				Quantity:       "1000",
-				PlacedQuantity: "1500",
-				Etas:           "500",
-				ClaimBounty:    "10",
-				PlacedAt:       "1634764800000",
-			},
-			quoteAsset: orderbookdomain.Asset{Symbol: "ATOM", Decimals: 6},
-			baseAsset:  orderbookdomain.Asset{Symbol: "OSMO", Decimals: 6},
-			setupMocks: func(orderbookRepo *mocks.OrderbookRepositoryMock, tokensUsecase *mocks.TokensUsecaseMock) {
-				orderbookRepo.GetTickByIDFunc = getTickByIDFunc("500", 100, "bid")
-				tokensUsecase.GetSpotPriceScalingFactorByDenomFunc = func(baseDenom, quoteDenom string) (osmomath.Dec, error) {
-					return osmomath.NewDec(1), nil
-				}
+			name:  "successful order processing",
+			order: s.NewOrder().Order,
+			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
+				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
+				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(1, nil)
 			},
 			expectedError: nil,
-			expectedOrder: orderbookdomain.LimitOrder{
-				TickId:           1,
-				OrderId:          1,
-				OrderDirection:   "bid",
-				Owner:            "owner1",
-				Quantity:         osmomath.NewDec(1000),
-				Etas:             "500",
-				ClaimBounty:      "10",
-				PlacedQuantity:   osmomath.NewDec(1500),
-				PlacedAt:         1634,
-				Price:            newDecFromStr("1.000001000000000000"),
-				PercentClaimed:   newDecFromStr("0.333333333333333333"),
-				TotalFilled:      newDecFromStr("600"),
-				PercentFilled:    newDecFromStr("0.400000000000000000"),
-				OrderbookAddress: "someOrderbookAddress",
-				Status:           "partiallyFilled",
-				Output:           newDecFromStr("1499.998500001499998500"),
-				QuoteAsset:       orderbookdomain.Asset{Symbol: "ATOM", Decimals: 6},
-				BaseAsset:        orderbookdomain.Asset{Symbol: "OSMO", Decimals: 6},
-			},
+			expectedOrder: s.NewLimitOrder().LimitOrder,
 		},
 	}
 
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			// Create instances of the mocks
-			orderbookRepo := mocks.OrderbookRepositoryMock{}
-			tokensUsecase := mocks.TokensUsecaseMock{}
+			orderbookrepository := mocks.OrderbookRepositoryMock{}
+			tokensusecase := mocks.TokensUsecaseMock{}
 
 			// Setup the mocks according to the test case
-			tc.setupMocks(&orderbookRepo, &tokensUsecase)
+			tc.setupMocks(&orderbookrepository, &tokensusecase)
 
 			// Initialize the use case with the mocks
 			usecase := orderbookusecase.New(
-				&orderbookRepo,
+				&orderbookrepository,
 				nil,
 				nil,
-				&tokensUsecase,
+				&tokensusecase,
 				nil,
 			)
 

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -616,21 +616,23 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 	}
 
 	testCases := []struct {
-		name          string
-		poolID        uint64
-		order         orderbookdomain.Order
-		quoteAsset    orderbookdomain.Asset
-		baseAsset     orderbookdomain.Asset
-		setupMocks    func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock)
-		expectedError error
-		expectedOrder orderbookdomain.LimitOrder
+		name             string
+		poolID           uint64
+		order            orderbookdomain.Order
+		quoteAsset       orderbookdomain.Asset
+		baseAsset        orderbookdomain.Asset
+		orderbookAddress string
+		setupMocks       func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock)
+		expectedError    error
+		expectedOrder    orderbookdomain.LimitOrder
 	}{
 		{
 			name: "tick not found",
 			order: orderbookdomain.Order{
 				TickId: 99, // Non-existent tick ID
 			},
-			expectedError: &types.TickForOrderbookNotFoundError{},
+			orderbookAddress: "osmo10dl92ghwn3v44pd8w24c3htqn2mj29549zcsn06usr56ng9ppp0qe6wd0r",
+			expectedError:    &types.TickForOrderbookNotFoundError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(orderbookdomain.OrderbookTick{}, false)
 			},
@@ -640,7 +642,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			order: orderbookdomain.Order{
 				Quantity: "invalid", // Invalid quantity
 			},
-			expectedError: &types.ParsingQuantityError{},
+			orderbookAddress: "osmo1xvmtylht48gyvwe2s5rf3w6kn5g9rc4s0da0v0md82t9ldx447gsk07thg",
+			expectedError:    &types.ParsingQuantityError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("6431", 935, "ask"), true)
 			},
@@ -653,7 +656,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "500",
 				ClaimBounty:    "10",
 			},
-			expectedError: &types.ParsingQuantityError{},
+			orderbookAddress: "osmo1rummy6vy4pfm82ctzmz4rr6fxgk0y4jf8h5s7zsadr2znwtuvq7slvl7p4",
+			expectedError:    &types.ParsingQuantityError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
 			},
@@ -664,7 +668,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Quantity:       "1000",
 				PlacedQuantity: "invalid", // Invalid placed quantity
 			},
-			expectedError: &types.ParsingPlacedQuantityError{},
+			orderbookAddress: "osmo1pwnxmmynz4esx79qv60cshhxkuu0glmzltsaykhccnq7jmj7tvsqdumey8",
+			expectedError:    &types.ParsingPlacedQuantityError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("813", 1331, "bid"), true)
 			},
@@ -677,7 +682,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "500",
 				ClaimBounty:    "10",
 			},
-			expectedError: &types.ParsingPlacedQuantityError{},
+			orderbookAddress: "osmo1z6h6etav6mfljq66vej7eqwsu4kummg9dfkvs969syw09fm0592s3fwgcs",
+			expectedError:    &types.ParsingPlacedQuantityError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
 			},
@@ -688,7 +694,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Quantity:       "1000",
 				PlacedQuantity: "0", // division by zero
 			},
-			expectedError: &types.InvalidPlacedQuantityError{},
+			orderbookAddress: "osmo1w8jm03vws7h448yvh83utd8p43j02npydy2jll0r0k7f6w7hjspsvw2u42",
+			expectedError:    &types.InvalidPlacedQuantityError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("813", 1331, "bid"), true)
 			},
@@ -699,7 +706,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Quantity:       "931",
 				PlacedQuantity: "183",
 			},
-			expectedError: &types.GettingSpotPriceScalingFactorError{},
+			orderbookAddress: "osmo197hxw89l3gqn5ake3l5as0zh2ls6e52ata2sgq80lep0854dwe5sstljsp",
+			expectedError:    &types.GettingSpotPriceScalingFactorError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("130", 13, "ask"), true)
 				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(1, assert.AnError)
@@ -712,7 +720,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "131",
 				OrderDirection: "bid",
 			},
-			expectedError: &types.ParsingTickValuesError{},
+			orderbookAddress: "osmo1s552kx03vsr7ha5ck0k9tmg74gn4w72fmmjcqgr4ky3wf96wwpcqlg7vn9",
+			expectedError:    &types.ParsingTickValuesError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("invalid", 13, "bid"), true)
 			},
@@ -724,7 +733,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "131",
 				OrderDirection: "ask",
 			},
-			expectedError: &types.ParsingTickValuesError{},
+			orderbookAddress: "osmo1yuz6952hrcx0hadq4mgg6fq3t04d4kxhzwsfezlvvsvhq053qyys5udd8z",
+			expectedError:    &types.ParsingTickValuesError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("invalid", 1, "ask"), true)
 			},
@@ -736,7 +746,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "153",
 				OrderDirection: "bid",
 			},
-			expectedError: &types.ParsingUnrealizedCancelsError{},
+			orderbookAddress: "osmo1apmfjhycfh4cyvc7e6px4vtfwhnl5k4l0ssjq9el4rqx8kxzh2mq5gm3j9",
+			expectedError:    &types.ParsingUnrealizedCancelsError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("15", 0, "bid"), true)
 			},
@@ -748,7 +759,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				PlacedQuantity: "313",
 				OrderDirection: "ask",
 			},
-			expectedError: &types.ParsingUnrealizedCancelsError{},
+			orderbookAddress: "osmo17qvca7z822w5hy6jxzvaut46k44tlyk4fshx9aklkzq6prze4s9q73u4wz",
+			expectedError:    &types.ParsingUnrealizedCancelsError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("13", 0, "ask"), true)
 			},
@@ -761,7 +773,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderDirection: "bid",
 				Etas:           "invalid", // Invalid ETAs
 			},
-			expectedError: &types.ParsingEtasError{},
+			orderbookAddress: "osmo1dkqnzv7r5wgq08yaj7cxpqy766mwneec2z2agke2l59x7qxff5sqzd2y5l",
+			expectedError:    &types.ParsingEtasError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("386", 830, "bid"), true)
 			},
@@ -775,7 +788,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           overflowDecStr(), // overflow value for ETAs
 				ClaimBounty:    "10",
 			},
-			expectedError: &types.ParsingEtasError{},
+			orderbookAddress: "osmo1nkt9lwky3l3gnrdjw075u557fhzxn9ke085uxnxvtkpj6kz2asrqkd65ra",
+			expectedError:    &types.ParsingEtasError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
 			},
@@ -789,7 +803,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				OrderDirection: "ask",
 				Etas:           "100",
 			},
-			expectedError: &types.ConvertingTickToPriceError{},
+			orderbookAddress: "osmo1nzpy57uftd877avsgfqjnqtsg5jhnzt8uv8mmytnku7lt76qa4lqds80nn",
+			expectedError:    &types.ConvertingTickToPriceError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("190", 150, "ask"), true)
 			},
@@ -804,7 +819,8 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				Etas:           "100",
 				PlacedAt:       "invalid", // Invalid timestamp
 			},
-			expectedError: &types.ParsingPlacedAtError{},
+			orderbookAddress: "osmo1ewuvnvtvh5jrcve9v8txr9eqnnq9x9vq82ujct53yzt2jpc8usjsyx72sr",
+			expectedError:    &types.ParsingPlacedAtError{},
 			setupMocks: func(orderbookrepository *mocks.OrderbookRepositoryMock, tokensusecase *mocks.TokensUsecaseMock) {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("100", 100, "ask"), true)
 				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(10, nil)
@@ -817,8 +833,9 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 				orderbookrepository.GetTickByIDFunc = s.GetTickByIDFunc(s.NewTick("500", 100, "bid"), true)
 				tokensusecase.GetSpotPriceScalingFactorByDenomFunc = s.GetSpotPriceScalingFactorByDenomFunc(1, nil)
 			},
-			expectedError: nil,
-			expectedOrder: s.NewLimitOrder().LimitOrder,
+			orderbookAddress: "osmo1kfct7fcu3qqc9jlxeku873p7t5vucfzw5ujn0dh97hypg24t2w6qe9q5zs",
+			expectedError:    nil,
+			expectedOrder:    s.NewLimitOrder().WithOrderbookAddress("osmo1kfct7fcu3qqc9jlxeku873p7t5vucfzw5ujn0dh97hypg24t2w6qe9q5zs").LimitOrder,
 		},
 	}
 
@@ -841,7 +858,7 @@ func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 			)
 
 			// Call the method under test
-			result, err := usecase.CreateFormattedLimitOrder(tc.poolID, tc.order, tc.quoteAsset, tc.baseAsset, "someOrderbookAddress")
+			result, err := usecase.CreateFormattedLimitOrder(tc.poolID, tc.order, tc.quoteAsset, tc.baseAsset, tc.orderbookAddress)
 
 			// Assert the results
 			if tc.expectedError != nil {

--- a/orderbook/usecase/orderbooktesting/parsing/active_orders_response.json
+++ b/orderbook/usecase/orderbooktesting/parsing/active_orders_response.json
@@ -1,0 +1,53 @@
+{
+  "orders": [
+    {
+      "tick_id": 1,
+      "order_id": 1,
+      "order_direction": "bid",
+      "owner": "owner1",
+      "quantity": "1000.000000000000000000",
+      "etas": "500",
+      "claim_bounty": "10",
+      "placed_quantity": "1500.000000000000000000",
+      "placed_at": 1634,
+      "price": "1.000001000000000000",
+      "percentClaimed": "0.333333333333333333",
+      "totalFilled": "600.000000000000000000",
+      "percentFilled": "0.400000000000000000",
+      "orderbookAddress": "someOrderbookAddress",
+      "status": "partiallyFilled",
+      "output": "1499.998500001499998500",
+      "quote_asset": {
+        "symbol": ""
+      },
+      "base_asset": {
+        "symbol": ""
+      }
+    },
+    {
+      "tick_id": 1,
+      "order_id": 2,
+      "order_direction": "bid",
+      "owner": "owner1",
+      "quantity": "1000.000000000000000000",
+      "etas": "500",
+      "claim_bounty": "10",
+      "placed_quantity": "1500.000000000000000000",
+      "placed_at": 1634,
+      "price": "1.000001000000000000",
+      "percentClaimed": "0.333333333333333333",
+      "totalFilled": "600.000000000000000000",
+      "percentFilled": "0.400000000000000000",
+      "orderbookAddress": "someOrderbookAddress",
+      "status": "partiallyFilled",
+      "output": "1499.998500001499998500",
+      "quote_asset": {
+        "symbol": ""
+      },
+      "base_asset": {
+        "symbol": ""
+      }
+    }
+  ],
+  "is_best_effort": false
+}

--- a/orderbook/usecase/orderbooktesting/suite.go
+++ b/orderbook/usecase/orderbooktesting/suite.go
@@ -1,0 +1,208 @@
+package orderbooktesting
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osmosis-labs/sqs/domain"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+)
+
+// defaultOrder is a default order used for testing
+var defaultOrder = orderbookdomain.Order{
+	TickId:         1,
+	OrderId:        1,
+	OrderDirection: "bid",
+	Owner:          "owner1",
+	Quantity:       "1000",
+	PlacedQuantity: "1500",
+	Etas:           "500",
+	ClaimBounty:    "10",
+	PlacedAt:       "1634764800000",
+}
+
+// defaultLimitOrder is a default limit order used for testing
+var defaultLimitOrder = orderbookdomain.LimitOrder{
+	TickId:           1,
+	OrderId:          1,
+	OrderDirection:   "bid",
+	Owner:            "owner1",
+	Quantity:         osmomath.NewDec(1000),
+	Etas:             "500",
+	ClaimBounty:      "10",
+	PlacedQuantity:   osmomath.NewDec(1500),
+	PlacedAt:         1634,
+	Price:            osmomath.MustNewDecFromStr("1.000001000000000000"),
+	PercentClaimed:   osmomath.MustNewDecFromStr("0.333333333333333333"),
+	TotalFilled:      osmomath.MustNewDecFromStr("600"),
+	PercentFilled:    osmomath.MustNewDecFromStr("0.400000000000000000"),
+	OrderbookAddress: "someOrderbookAddress",
+	Status:           "partiallyFilled",
+	Output:           osmomath.MustNewDecFromStr("1499.998500001499998500"),
+}
+
+// Order is a wrapper around orderbookdomain.Order
+// it wraps additional helper methods for testing
+type Order struct {
+	orderbookdomain.Order
+}
+
+// WithOrderID sets the order ID for the order
+func (o Order) WithOrderID(id int64) Order {
+	o.OrderId = id
+	return o
+}
+
+// WithTickID sets the tick ID for the order
+func (o Order) WithTickID(id int64) Order {
+	o.TickId = id
+	return o
+}
+
+// LimitOrder wraps additional helper methods for testing
+type LimitOrder struct {
+	orderbookdomain.LimitOrder
+}
+
+// WithOrderID sets the order ID for the order
+func (o LimitOrder) WithOrderID(id int64) LimitOrder {
+	o.OrderId = id
+	return o
+}
+
+// WithOrderbookAddress sets the orderbook address for the order
+func (o LimitOrder) WithOrderbookAddress(address string) LimitOrder {
+	o.OrderbookAddress = address
+	return o
+}
+
+// WithQuoteAsset sets the quote asset for the order
+func (o LimitOrder) WithQuoteAsset(asset orderbookdomain.Asset) LimitOrder {
+	o.QuoteAsset = asset
+	return o
+}
+
+// WithBaseAsset sets the base asset for the order
+func (o LimitOrder) WithBaseAsset(asset orderbookdomain.Asset) LimitOrder {
+	o.BaseAsset = asset
+	return o
+}
+
+// OrderbookTestHelper is a helper struct for the orderbook usecase tests
+type OrderbookTestHelper struct {
+	routertesting.RouterTestHelper
+}
+
+// NewOrder creates a new order based on the defaultOrder.
+func (s *OrderbookTestHelper) NewOrder() Order {
+	return Order{defaultOrder}
+}
+
+// NewLimitOrder creates a new limit order based on the defaultLimitOrder.
+func (s *OrderbookTestHelper) NewLimitOrder() LimitOrder {
+	return LimitOrder{defaultLimitOrder}
+}
+
+// NewTick creates a new orderbook tick
+// direction can be either "bid" or "ask" and it determines the direction of the created tick.
+func (s *OrderbookTestHelper) NewTick(effectiveTotalAmountSwapped string, unrealizedCancels int64, direction string) orderbookdomain.OrderbookTick {
+	s.T().Helper()
+
+	tickValues := orderbookdomain.TickValues{
+		EffectiveTotalAmountSwapped: effectiveTotalAmountSwapped,
+	}
+
+	tick := orderbookdomain.OrderbookTick{
+		TickState:         orderbookdomain.TickState{},
+		UnrealizedCancels: orderbookdomain.UnrealizedCancels{},
+	}
+
+	if direction == "bid" {
+		tick.TickState.BidValues = tickValues
+		if unrealizedCancels != 0 {
+			tick.UnrealizedCancels.BidUnrealizedCancels = osmomath.NewInt(unrealizedCancels)
+		}
+	} else {
+		tick.TickState.AskValues = tickValues
+		if unrealizedCancels != 0 {
+			tick.UnrealizedCancels.AskUnrealizedCancels = osmomath.NewInt(unrealizedCancels)
+		}
+	}
+
+	return tick
+}
+
+// GetTickByIDFunc returns a function that returns a tick by ID
+// it is useful for mocking the repository.GetTickByIDFunc.
+func (s *OrderbookTestHelper) GetTickByIDFunc(tick orderbookdomain.OrderbookTick, ok bool) func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+	return func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+		return tick, ok
+	}
+}
+
+// NewCanonicalOrderBooksResult creates a new canonical orderbooks result
+func (s *OrderbookTestHelper) NewCanonicalOrderBooksResult(poolID uint64, contractAddress string) domain.CanonicalOrderBooksResult {
+	return domain.CanonicalOrderBooksResult{
+		Base:            "OSMO",
+		Quote:           "ATOM",
+		PoolID:          poolID,
+		ContractAddress: contractAddress,
+	}
+}
+
+// GetAllCanonicalOrderbookPoolIDsFunc returns a function that returns all canonical orderbook pool IDs
+// it is useful for mocking the poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc.
+func (s *OrderbookTestHelper) GetAllCanonicalOrderbookPoolIDsFunc(err error, orderbooks ...domain.CanonicalOrderBooksResult) func() ([]domain.CanonicalOrderBooksResult, error) {
+	return func() ([]domain.CanonicalOrderBooksResult, error) {
+		return orderbooks, err
+	}
+}
+
+// GetActiveOrdersFunc returns a function that returns active orders
+func (s *OrderbookTestHelper) GetActiveOrdersFunc(orders orderbookdomain.Orders, total uint64, err error) func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error) {
+	return func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error) {
+		return orders, total, err
+	}
+}
+
+// GetMetadataByChainDenomFuncEmptyToken returns a function that returns an empty token useful for mocking the tokensUsecase.GetMetadataByChainDenomFunc
+func (s *OrderbookTestHelper) GetMetadataByChainDenomFuncEmptyToken() func(denom string) (domain.Token, error) {
+	return func(denom string) (domain.Token, error) {
+		return domain.Token{}, nil
+	}
+}
+
+// GetMetadataByChainDenomFunc returns a function that returns a token by chain denom useful for mocking the tokensUsecase.GetMetadataByChainDenomFunc
+// If errIfNotDenom is not empty, it will return an error if the denom passed to GetMetadataByChainDenomFunc is not equal to errIfNotDenom.
+// If the denom passed to GetMetadataByChainDenomFunc is empty, it will return an empty token.
+// If the denom passed to GetMetadataByChainDenomFunc is equal to the quote/base asset symbol, it will return a token with the quote/base asset symbol and decimals.
+func (s *OrderbookTestHelper) GetMetadataByChainDenomFunc(order LimitOrder, errIfNotDenom string) func(denom string) (domain.Token, error) {
+	return func(denom string) (domain.Token, error) {
+		if errIfNotDenom != "" && errIfNotDenom != denom {
+			return domain.Token{}, assert.AnError
+		}
+		if denom == "" {
+			return domain.Token{}, nil
+		}
+
+		if denom == order.QuoteAsset.Symbol {
+			return domain.Token{
+				CoinMinimalDenom: order.QuoteAsset.Symbol,
+				Precision:        order.QuoteAsset.Decimals,
+			}, nil
+		}
+
+		if denom == order.BaseAsset.Symbol {
+			return domain.Token{
+				CoinMinimalDenom: order.BaseAsset.Symbol,
+				Precision:        order.BaseAsset.Decimals,
+			}, nil
+		}
+
+		return domain.Token{}, assert.AnError
+	}
+}

--- a/passthrough/delivery/http/passthrough_handler.go
+++ b/passthrough/delivery/http/passthrough_handler.go
@@ -6,16 +6,12 @@ import (
 	deliveryhttp "github.com/osmosis-labs/sqs/delivery/http"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
+	_ "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/orderbook/types"
 
 	"github.com/labstack/echo/v4"
 	"go.opentelemetry.io/otel/trace"
 )
-
-// ResponseError represent the response error struct
-type ResponseError struct {
-	Message string `json:"message"`
-}
 
 // PassthroughHandler is the http handler for passthrough use case
 type PassthroughHandler struct {
@@ -46,25 +42,36 @@ func NewPassthroughHandler(e *echo.Echo, ptu mvc.PassthroughUsecase, ou mvc.Orde
 // The user balances and total assets are brokend down by-coin with the capitalization of the entire account value.
 //
 // @Produce  json
-// @Success 200  struct  passthroughdomain.PortfolioAssetsResult  "Portfolio assets by-category and capitalization of the entire account value"
-// @Failure 500  struct  ResponseError  "Response error"
+// @Success 200  {object}  passthroughdomain.PortfolioAssetsResult  "Portfolio assets by-category and capitalization of the entire account value"
+// @Failure 500  {object}  domain.ResponseError  "Response error"
 // @Param address path string true "Wallet Address"
 // @Router /passthrough/portfolio-assets/{address} [get]
 func (a *PassthroughHandler) GetPortfolioAssetsByAddress(c echo.Context) error {
 	address := c.Param("address")
 
 	if address == "" {
-		return c.JSON(http.StatusInternalServerError, ResponseError{Message: "invalid address: cannot be empty"})
+		return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: "invalid address: cannot be empty"})
 	}
 
 	portfolioAssetsResult, err := a.PUsecase.GetPortfolioAssets(c.Request().Context(), address)
 	if err != nil {
-		return c.JSON(http.StatusPartialContent, ResponseError{Message: err.Error()})
+		return c.JSON(http.StatusPartialContent, domain.ResponseError{Message: err.Error()})
 	}
 
 	return c.JSON(http.StatusOK, portfolioAssetsResult)
 }
 
+// @Summary Returns all active orderbook orders associated with the given address.
+// @Description The returned data represents all active orders for all orderbooks available for the specified address.
+//
+// The is_best_effort flag indicates whether the error occurred while processing the orders due which not all orders were returned in the response.
+//
+// @Produce  json
+// @Success 200           {object}  types.GetActiveOrdersResponse  "List of active orders for all available orderboooks for the given address"
+// @Failure 400           {object}  domain.ResponseError                 "Response error"
+// @Failure 500           {object}  domain.ResponseError                 "Response error"
+// @Param  userOsmoAddress  query  string  true  "Osmo wallet address"
+// @Router /passthrough/active-orders [get]
 func (a *PassthroughHandler) GetActiveOrders(c echo.Context) (err error) {
 	ctx := c.Request().Context()
 
@@ -91,7 +98,7 @@ func (a *PassthroughHandler) GetActiveOrders(c echo.Context) (err error) {
 
 	orders, isBestEffort, err := a.OUsecase.GetActiveOrders(ctx, req.UserOsmoAddress)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: err.Error()})
+		return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: types.ErrInternalError.Error()})
 	}
 
 	resp := types.NewGetAllOrderResponse(orders, isBestEffort)

--- a/passthrough/delivery/http/passthrough_handler_test.go
+++ b/passthrough/delivery/http/passthrough_handler_test.go
@@ -1,0 +1,117 @@
+package http_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/osmosis-labs/sqs/domain/mocks"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/orderbook/types"
+	"github.com/osmosis-labs/sqs/orderbook/usecase/orderbooktesting"
+	passthroughdelivery "github.com/osmosis-labs/sqs/passthrough/delivery/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type PassthroughHandlerTestSuite struct {
+	orderbooktesting.OrderbookTestHelper
+}
+
+func TestPassthroughHandlerSuite(t *testing.T) {
+	suite.Run(t, new(PassthroughHandlerTestSuite))
+}
+
+func (s *PassthroughHandlerTestSuite) TestGetActiveOrders() {
+	testCases := []struct {
+		name               string
+		queryParams        map[string]string
+		setupMocks         func(usecase *mocks.OrderbookUsecaseMock)
+		expectedStatusCode int
+		expectedResponse   string
+		expectedError      bool
+	}{
+		{
+			name:               "validation error",
+			queryParams:        map[string]string{},
+			setupMocks:         func(usecase *mocks.OrderbookUsecaseMock) {},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   fmt.Sprintf(`{"message":"%s"}`, types.ErrUserOsmoAddressInvalid.Error()),
+			expectedError:      true,
+		},
+		{
+			name: "returns a few active orders",
+			queryParams: map[string]string{
+				"userOsmoAddress": "osmo1ugku28hwyexpljrrmtet05nd6kjlrvr9jz6z00",
+			},
+			setupMocks: func(usecase *mocks.OrderbookUsecaseMock) {
+				usecase.GetActiveOrdersFunc = func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+					return []orderbookdomain.LimitOrder{
+						s.NewLimitOrder().WithOrderID(1).LimitOrder,
+						s.NewLimitOrder().WithOrderID(2).LimitOrder,
+					}, false, nil
+				}
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   s.MustReadFile("../../../orderbook/usecase/orderbooktesting/parsing/active_orders_response.json"),
+			expectedError:      false,
+		},
+		{
+			name: "internal server error from usecase",
+			queryParams: map[string]string{
+				"userOsmoAddress": "osmo1ev0vtddkl7jlwfawlk06yzncapw2x9quva4wzw",
+			},
+			setupMocks: func(usecase *mocks.OrderbookUsecaseMock) {
+				usecase.GetActiveOrdersFunc = func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+					return nil, false, assert.AnError
+				}
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedResponse:   fmt.Sprintf(`{"message":"%s"}`, types.ErrInternalError.Error()),
+			expectedError:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			e := echo.New()
+			req := httptest.NewRequest(echo.GET, "/", nil)
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			q := req.URL.Query()
+			for k, v := range tc.queryParams {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			// Set up the mocks
+			usecase := mocks.OrderbookUsecaseMock{}
+			if tc.setupMocks != nil {
+				tc.setupMocks(&usecase)
+			}
+
+			// Initialize the handler with mocked usecase
+			handler := passthroughdelivery.PassthroughHandler{OUsecase: &usecase}
+
+			// Call the method under test
+			err := handler.GetActiveOrders(c)
+
+			// Check the error condition
+			if tc.expectedError {
+				s.Assert().Nil(err)
+			} else {
+				s.Assert().NoError(err)
+			}
+
+			// Check the response
+			s.Assert().Equal(tc.expectedStatusCode, rec.Code)
+			s.Assert().JSONEq(tc.expectedResponse, strings.TrimSpace(rec.Body.String()))
+		})
+	}
+}

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -168,7 +168,7 @@ func getStatusCode(err error) int {
 // @Produce  json
 // @Param  base  query  string  true  "Base denom"
 // @Param  quote  query  string  true  "Quote denom"
-// @Success 200  struct domain.CanonicalOrderBooksResult  "Canonical Orderbook Pool ID for the given base and quote"
+// @Success 200  {object} domain.CanonicalOrderBooksResult  "Canonical Orderbook Pool ID for the given base and quote"
 // @Router /pools/canonical-orderbook [get]
 func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 	base := c.QueryParam("base")

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -1,6 +1,7 @@
 package routertesting
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -456,4 +457,14 @@ func PrepareValidSortedRouterPools(pools []sqsdomain.PoolI, minPoolLiquidityCap 
 	poolsAboveMinLiquidity := routerusecase.FilterPoolsByMinLiquidity(sortedPools, minPoolLiquidityCap)
 
 	return poolsAboveMinLiquidity
+}
+
+// ErrorIsAs first checks whether target error is equal to expectedError, if not, it checks whether
+// at least one of the errors in target's chain matches expectedError.
+func (s *RouterTestHelper) ErrorIsAs(target error, expectedError error) {
+	if errors.Is(target, expectedError) {
+		s.Assert().ErrorIs(target, expectedError)
+	} else {
+		s.Assert().ErrorAs(target, expectedError)
+	}
 }


### PR DESCRIPTION
This PR introduces unit tests for Orderbook usecase `createFormattedLimitOrder` method. The aim of the tests are to cover edge cases as well as successful scenario. As a side effect pull request introduces `OrderbookRepositoryMock`.

```
❯ go test ./orderbook/usecase -run "TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder" -v
=== RUN   TestOrderbookUsecaseTestSuite
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/tick_not_found
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_quantity
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_placed_quantity
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_getting_spot_price_scaling_factor
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_bid_effective_total_amount_swapped
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_bid_unrealized_cancels
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_etas
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_converting_tick_to_price
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_placed_at
=== RUN   TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/successful_order_processing
--- PASS: TestOrderbookUsecaseTestSuite (0.03s)
    --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder (0.03s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/tick_not_found (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_quantity (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_placed_quantity (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_getting_spot_price_scaling_factor (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_bid_effective_total_amount_swapped (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_bid_unrealized_cancels (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_etas (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_converting_tick_to_price (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/error_parsing_placed_at (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestCreateFormattedLimitOrder/successful_order_processing (0.00s)
PASS
ok      github.com/osmosis-labs/sqs/orderbook/usecase   0.090s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a mock implementation for the OrderBookRepository to enhance testing capabilities.
	- Added a public interface for creating formatted limit orders in the order book domain.
	- Implemented a comprehensive test suite for the OrderbookUsecase functionality, covering various scenarios for order creation.
	- Defined custom error types for improved error handling and reporting within the order book system.
	- Enhanced the OrderBookClient interface with new methods for fetching unrealized cancels and ticks in chunks.
	- Updated the LimitOrder struct to use higher precision decimal types for key fields.
	- Added a new endpoint to retrieve active orders associated with a specified Osmo wallet address.

- **Bug Fixes**
	- Added validation for `placedQuantity` in order creation to prevent invalid orders.
	- Adjusted return types for better performance and type handling in order book use case functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->