### PR TITLE
SQS-377 | Unit test ProcessPool

### DIFF
--- a/domain/mocks/orderbook_grpc_client_mock.go
+++ b/domain/mocks/orderbook_grpc_client_mock.go
@@ -15,7 +15,9 @@ type OrderbookGRPCClientMock struct {
 	MockGetOrdersByTickCb          func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
 	MockGetActiveOrdersCb          func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error)
 	MockGetTickUnrealizedCancelsCb func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
+	FetchTickUnrealizedCancelsCb   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
 	MockQueryTicksCb               func(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error)
+	FetchTicksCb                   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error)
 }
 
 func (o *OrderbookGRPCClientMock) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
@@ -42,9 +44,25 @@ func (o *OrderbookGRPCClientMock) GetTickUnrealizedCancels(ctx context.Context, 
 	return nil, nil
 }
 
+func (o *OrderbookGRPCClientMock) FetchTickUnrealizedCancels(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+	if o.FetchTickUnrealizedCancelsCb != nil {
+		return o.FetchTickUnrealizedCancelsCb(ctx, chunkSize, contractAddress, tickIDs)
+	}
+
+	return nil, nil
+}
+
 func (o *OrderbookGRPCClientMock) QueryTicks(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error) {
 	if o.MockQueryTicksCb != nil {
 		return o.MockQueryTicksCb(ctx, contractAddress, ticks)
+	}
+
+	return nil, nil
+}
+
+func (o *OrderbookGRPCClientMock) FetchTicks(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+	if o.FetchTicksCb != nil {
+		return o.FetchTicksCb(ctx, chunkSize, contractAddress, tickIDs)
 	}
 
 	return nil, nil

--- a/orderbook/types/errors.go
+++ b/orderbook/types/errors.go
@@ -131,3 +131,63 @@ type ParsingPlacedAtError struct {
 func (e ParsingPlacedAtError) Error() string {
 	return fmt.Sprintf("error parsing placed_at %s: %v", e.PlacedAt, e.Err)
 }
+
+// PoolNilError represents an error when the pool is nil.
+type PoolNilError struct{}
+
+func (e PoolNilError) Error() string {
+	return "pool is nil when processing order book"
+}
+
+// CosmWasmPoolModelNilError represents an error when the CosmWasmPoolModel is nil.
+type CosmWasmPoolModelNilError struct{}
+
+func (e CosmWasmPoolModelNilError) Error() string {
+	return "cw pool model is nil when processing order book"
+}
+
+// NotAnOrderbookPoolError represents an error when the pool is not an orderbook pool.
+type NotAnOrderbookPoolError struct {
+	PoolID uint64
+}
+
+func (e NotAnOrderbookPoolError) Error() string {
+	return fmt.Sprintf("pool is not an orderbook pool %d", e.PoolID)
+}
+
+// FailedToCastPoolModelError represents an error when the pool model cannot be cast to a CosmWasmPool.
+type FailedToCastPoolModelError struct{}
+
+func (e FailedToCastPoolModelError) Error() string {
+	return "failed to cast pool model to CosmWasmPool"
+}
+
+// FetchTicksError represents an error when fetching ticks fails.
+type FetchTicksError struct {
+	ContractAddress string
+	Err             error
+}
+
+func (e FetchTicksError) Error() string {
+	return fmt.Sprintf("failed to fetch ticks for pool %s: %v", e.ContractAddress, e.Err)
+}
+
+// FetchUnrealizedCancelsError represents an error when fetching unrealized cancels fails.
+type FetchUnrealizedCancelsError struct {
+	ContractAddress string
+	Err             error
+}
+
+func (e FetchUnrealizedCancelsError) Error() string {
+	return fmt.Sprintf("failed to fetch unrealized cancels for pool %s: %v", e.ContractAddress, e.Err)
+}
+
+// TickIDMismatchError represents an error when there is a mismatch between tick IDs.
+type TickIDMismatchError struct {
+	ExpectedID int64
+	ActualID   int64
+}
+
+func (e TickIDMismatchError) Error() string {
+	return fmt.Sprintf("tick id mismatch when fetching tick states %d %d", e.ExpectedID, e.ActualID)
+}

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 // OrderBookEntry is an alias of orderBookEntry for testing purposes
-func (o *orderbookUseCaseImpl) CreateFormattedLimitOrder(
+func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	poolID uint64,
 	order orderbookdomain.Order,
 	quoteAsset orderbookdomain.Asset,

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -17,6 +17,7 @@ import (
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	orderbookgrpcclientdomain "github.com/osmosis-labs/sqs/domain/orderbook/grpcclient"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app/apptesting"

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -1,14 +1,21 @@
 package orderbookusecase_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/osmosis-labs/sqs/sqsdomain"
+
+	cwpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
+
 	cltypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	orderbookgrpcclientdomain "github.com/osmosis-labs/sqs/domain/orderbook/grpcclient"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 
@@ -24,6 +31,260 @@ func TestOrderbookUsecaseTestSuite(t *testing.T) {
 	suite.Run(t, new(OrderbookUsecaseTestSuite))
 }
 
+func (s *OrderbookUsecaseTestSuite) TestProcessPool() {
+	testCases := []struct {
+		name          string
+		pool          sqsdomain.PoolI
+		setupMocks    func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock)
+		expectedError string
+	}{
+		{
+			name:          "pool is nil",
+			pool:          nil,
+			expectedError: "pool is nil when processing order book",
+		},
+		{
+			name: "cosmWasmPoolModel is nil",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: nil,
+			},
+			expectedError: "cw pool model is nil when processing order book",
+		},
+		{
+			name: "pool is not an orderbook pool",
+			pool: &mocks.MockRoutablePool{
+				ID:                1,
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{},
+			},
+			expectedError: "pool is not an orderbook pool 1",
+		},
+		{
+			name: "orderbook pool has no ticks, nothing to process",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{},
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "failed to cast pool model to CosmWasmPool",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &mocks.ChainPoolMock{
+					ID:   1,
+					Type: poolmanagertypes.Balancer,
+				},
+			},
+			expectedError: "failed to cast pool model to CosmWasmPool",
+		},
+		{
+			name: "failed to fetch ticks for pool",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return nil, assert.AnError
+				}
+			},
+			expectedError: "failed to fetch ticks for pool",
+		},
+		{
+			name: "failed to fetch unrealized cancels for pool",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return nil, assert.AnError
+				}
+			},
+			expectedError: "failed to fetch unrealized cancels for pool",
+		},
+		{
+			name: "tick ID mismatch when fetching unrealized ticks",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 1},
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{TickID: 2}, // Mismatch
+					}, nil
+				}
+			},
+			expectedError: "tick id mismatch when fetching unrealized ticks 2 1",
+		},
+		{
+			name: "tick ID mismatch when fetching tick states",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 2}, // Mismatched TickID
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{TickID: 1},
+					}, nil
+				}
+			},
+			expectedError: "tick id mismatch when fetching tick states 2 1",
+		},
+		{
+			name: "successful pool processing",
+			pool: &mocks.MockRoutablePool{
+				ID: 1,
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 1, TickState: orderbookdomain.TickState{
+							BidValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "100",
+							},
+						}},
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{
+							TickID: 1,
+							UnrealizedCancelsState: orderbookdomain.UnrealizedCancels{
+								BidUnrealizedCancels: osmomath.NewInt(100),
+							},
+						},
+					}, nil
+				}
+				repository.StoreTicksFunc = func(poolID uint64, ticksMap map[int64]orderbookdomain.OrderbookTick) {
+					// Assume ticks are correctly stored, no need for implementation here
+				}
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create instances of the mocks
+			repository := mocks.OrderbookRepositoryMock{}
+			tokensUsecase := mocks.TokensUsecaseMock{}
+			client := mocks.OrderbookGRPCClientMock{}
+
+			// Setup the mocks according to the test case
+			usecase := orderbookusecase.New(&repository, &client, nil, &tokensUsecase, nil)
+			if tc.setupMocks != nil {
+				tc.setupMocks(usecase, &client, &repository)
+			}
+
+			// Call the method under test
+			err := usecase.ProcessPool(context.Background(), tc.pool)
+
+			// Assert the results
+			if tc.expectedError != "" {
+				s.Assert().Error(err)
+				s.Assert().Contains(err.Error(), tc.expectedError)
+			} else {
+				s.Assert().NoError(err)
+			}
+		})
+	}
+}
 func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 	testCases := []struct {
 		name          string


### PR DESCRIPTION
This pull request introduces unit tests for Orderbook usecase `ProcessPool` method. As a side effect for more efficient testing  it refactors several program parts, for example `FetchTickUnrealizedCancels` and `FetchTicks` are moved to the `client` side instead of keeping in `orberbook` usecase.

Tests aims to cover errors and one one successful case:

```
❯ go test ./orderbook/usecase -run "TestOrderbookUsecaseTestSuite/TestProcessPool" -v
=== RUN   TestOrderbookUsecaseTestSuite
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/pool_is_nil
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/cosmWasmPoolModel_is_nil
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/pool_is_not_an_orderbook_pool
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/orderbook_pool_has_no_ticks,_nothing_to_process
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/failed_to_cast_pool_model_to_CosmWasmPool
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/failed_to_fetch_ticks_for_pool
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/failed_to_fetch_unrealized_cancels_for_pool
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/tick_ID_mismatch_when_fetching_unrealized_ticks
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/tick_ID_mismatch_when_fetching_tick_states
=== RUN   TestOrderbookUsecaseTestSuite/TestProcessPool/successful_pool_processing
--- PASS: TestOrderbookUsecaseTestSuite (0.03s)
    --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool (0.03s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/pool_is_nil (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/cosmWasmPoolModel_is_nil (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/pool_is_not_an_orderbook_pool (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/orderbook_pool_has_no_ticks,_nothing_to_process (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/failed_to_cast_pool_model_to_CosmWasmPool (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/failed_to_fetch_ticks_for_pool (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/failed_to_fetch_unrealized_cancels_for_pool (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/tick_ID_mismatch_when_fetching_unrealized_ticks (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/tick_ID_mismatch_when_fetching_tick_states (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestProcessPool/successful_pool_processing (0.00s)
PASS
ok      github.com/osmosis-labs/sqs/orderbook/usecase   (cached)
```