### PR TITLE
SQS-378 | GetActiveOrders

### DIFF
--- a/.swaggo
+++ b/.swaggo
@@ -1,0 +1,5 @@
+// Swagger overrides file
+// @link https://github.com/swaggo/swag?tab=readme-ov-file#use-global-overrides-to-support-a-custom-type
+
+// Replace all Dec with string 
+replace osmomath.Dec string

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ generate-mocks: mockery
 	bin/mockery --config mockery.yaml
 
 swagger-gen:
-	$(HOME)/go/bin/swag init -g app/main.go
+	$(HOME)/go/bin/swag init -g app/main.go --pd --overridesFile ./.swaggo
 
 run:
 	go run -ldflags="-X github.com/osmosis-labs/sqs/version=${VERSION}" app/*.go  --config config.json

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,44 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/passthrough/active-orders": {
+            "get": {
+                "description": "The returned data represents all active orders for all orderbooks available for the specified address.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Returns all active orderbook orders associated with the given address.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Osmo wallet address",
+                        "name": "userOsmoAddress",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of active orders for all available orderboooks for the given address",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Response error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Response error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ResponseError"
+                        }
+                    }
+                }
+            }
+        },
         "/passthrough/portfolio-assets/{address}": {
             "get": {
                 "description": "The returned data represents the potfolio asset breakdown by category for the specified address.",
@@ -35,13 +73,13 @@ const docTemplate = `{
                     "200": {
                         "description": "Portfolio assets by-category and capitalization of the entire account value",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult"
                         }
                     },
                     "500": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     }
                 }
@@ -113,7 +151,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Canonical Orderbook Pool ID for the given base and quote",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.CanonicalOrderBooksResult"
                         }
                     }
                 }
@@ -436,6 +474,14 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.ResponseError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Token": {
             "type": "object",
             "properties": {
@@ -461,6 +507,159 @@ const docTemplate = `{
                 "symbol": {
                     "description": "HumanDenom is the human readable denom, e.g. atom",
                     "type": "string"
+                }
+            }
+        },
+        "github_com_cosmos_cosmos-sdk_types.Coin": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "$ref": "#/definitions/types.Int"
+                },
+                "denom": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.Asset": {
+            "type": "object",
+            "properties": {
+                "symbol": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder": {
+            "type": "object",
+            "properties": {
+                "base_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "claim_bounty": {
+                    "type": "string"
+                },
+                "etas": {
+                    "type": "string"
+                },
+                "order_direction": {
+                    "type": "string"
+                },
+                "order_id": {
+                    "type": "integer"
+                },
+                "orderbookAddress": {
+                    "type": "string"
+                },
+                "output": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "percentClaimed": {
+                    "type": "string"
+                },
+                "percentFilled": {
+                    "type": "string"
+                },
+                "placed_at": {
+                    "type": "integer"
+                },
+                "placed_quantity": {
+                    "type": "string"
+                },
+                "placed_tx": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "quote_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus"
+                },
+                "tick_id": {
+                    "type": "integer"
+                },
+                "totalFilled": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus": {
+            "type": "string",
+            "enum": [
+                "open",
+                "partiallyFilled",
+                "filled",
+                "fullyClaimed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "StatusOpen",
+                "StatusPartiallyFilled",
+                "StatusFilled",
+                "StatusFullyClaimed",
+                "StatusCancelled"
+            ]
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult": {
+            "type": "object",
+            "properties": {
+                "cap_value": {
+                    "type": "string"
+                },
+                "coin": {
+                    "$ref": "#/definitions/github_com_cosmos_cosmos-sdk_types.Coin"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult": {
+            "type": "object",
+            "properties": {
+                "account_coins_result": {
+                    "description": "AccountCoinsResult represents coins only from user balances (contrary to TotalValueCap).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult"
+                    }
+                },
+                "capitalization": {
+                    "description": "Capitalization represents the total value of the assets in the portfolio.\nincludes capitalization of user balances, value in locks, bonding or unbonding\nas well as the concentrated positions.",
+                    "type": "string"
+                },
+                "is_best_effort": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult": {
+            "type": "object",
+            "properties": {
+                "categories": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult"
+                    }
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse": {
+            "type": "object",
+            "properties": {
+                "is_best_effort": {
+                    "type": "boolean"
+                },
+                "orders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder"
+                    }
                 }
             }
         },
@@ -508,6 +707,9 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "types.Int": {
+            "type": "object"
         }
     }
 }`

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6,6 +6,44 @@
         "version": "1.0"
     },
     "paths": {
+        "/passthrough/active-orders": {
+            "get": {
+                "description": "The returned data represents all active orders for all orderbooks available for the specified address.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Returns all active orderbook orders associated with the given address.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Osmo wallet address",
+                        "name": "userOsmoAddress",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of active orders for all available orderboooks for the given address",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Response error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ResponseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Response error",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ResponseError"
+                        }
+                    }
+                }
+            }
+        },
         "/passthrough/portfolio-assets/{address}": {
             "get": {
                 "description": "The returned data represents the potfolio asset breakdown by category for the specified address.",
@@ -26,13 +64,13 @@
                     "200": {
                         "description": "Portfolio assets by-category and capitalization of the entire account value",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult"
                         }
                     },
                     "500": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     }
                 }
@@ -104,7 +142,7 @@
                     "200": {
                         "description": "Canonical Orderbook Pool ID for the given base and quote",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.CanonicalOrderBooksResult"
                         }
                     }
                 }
@@ -427,6 +465,14 @@
                 }
             }
         },
+        "domain.ResponseError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Token": {
             "type": "object",
             "properties": {
@@ -452,6 +498,159 @@
                 "symbol": {
                     "description": "HumanDenom is the human readable denom, e.g. atom",
                     "type": "string"
+                }
+            }
+        },
+        "github_com_cosmos_cosmos-sdk_types.Coin": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "$ref": "#/definitions/types.Int"
+                },
+                "denom": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.Asset": {
+            "type": "object",
+            "properties": {
+                "symbol": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder": {
+            "type": "object",
+            "properties": {
+                "base_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "claim_bounty": {
+                    "type": "string"
+                },
+                "etas": {
+                    "type": "string"
+                },
+                "order_direction": {
+                    "type": "string"
+                },
+                "order_id": {
+                    "type": "integer"
+                },
+                "orderbookAddress": {
+                    "type": "string"
+                },
+                "output": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "percentClaimed": {
+                    "type": "string"
+                },
+                "percentFilled": {
+                    "type": "string"
+                },
+                "placed_at": {
+                    "type": "integer"
+                },
+                "placed_quantity": {
+                    "type": "string"
+                },
+                "placed_tx": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "quote_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus"
+                },
+                "tick_id": {
+                    "type": "integer"
+                },
+                "totalFilled": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus": {
+            "type": "string",
+            "enum": [
+                "open",
+                "partiallyFilled",
+                "filled",
+                "fullyClaimed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "StatusOpen",
+                "StatusPartiallyFilled",
+                "StatusFilled",
+                "StatusFullyClaimed",
+                "StatusCancelled"
+            ]
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult": {
+            "type": "object",
+            "properties": {
+                "cap_value": {
+                    "type": "string"
+                },
+                "coin": {
+                    "$ref": "#/definitions/github_com_cosmos_cosmos-sdk_types.Coin"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult": {
+            "type": "object",
+            "properties": {
+                "account_coins_result": {
+                    "description": "AccountCoinsResult represents coins only from user balances (contrary to TotalValueCap).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult"
+                    }
+                },
+                "capitalization": {
+                    "description": "Capitalization represents the total value of the assets in the portfolio.\nincludes capitalization of user balances, value in locks, bonding or unbonding\nas well as the concentrated positions.",
+                    "type": "string"
+                },
+                "is_best_effort": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult": {
+            "type": "object",
+            "properties": {
+                "categories": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult"
+                    }
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse": {
+            "type": "object",
+            "properties": {
+                "is_best_effort": {
+                    "type": "boolean"
+                },
+                "orders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder"
+                    }
                 }
             }
         },
@@ -499,6 +698,9 @@
                     }
                 }
             }
+        },
+        "types.Int": {
+            "type": "object"
         }
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -10,6 +10,11 @@ definitions:
       quote:
         type: string
     type: object
+  domain.ResponseError:
+    properties:
+      message:
+        type: string
+    type: object
   domain.Token:
     properties:
       coinMinimalDenom:
@@ -29,6 +34,113 @@ definitions:
       symbol:
         description: HumanDenom is the human readable denom, e.g. atom
         type: string
+    type: object
+  github_com_cosmos_cosmos-sdk_types.Coin:
+    properties:
+      amount:
+        $ref: '#/definitions/types.Int'
+      denom:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.Asset:
+    properties:
+      symbol:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder:
+    properties:
+      base_asset:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset'
+      claim_bounty:
+        type: string
+      etas:
+        type: string
+      order_direction:
+        type: string
+      order_id:
+        type: integer
+      orderbookAddress:
+        type: string
+      output:
+        type: string
+      owner:
+        type: string
+      percentClaimed:
+        type: string
+      percentFilled:
+        type: string
+      placed_at:
+        type: integer
+      placed_quantity:
+        type: string
+      placed_tx:
+        type: string
+      price:
+        type: string
+      quantity:
+        type: string
+      quote_asset:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset'
+      status:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus'
+      tick_id:
+        type: integer
+      totalFilled:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus:
+    enum:
+    - open
+    - partiallyFilled
+    - filled
+    - fullyClaimed
+    - cancelled
+    type: string
+    x-enum-varnames:
+    - StatusOpen
+    - StatusPartiallyFilled
+    - StatusFilled
+    - StatusFullyClaimed
+    - StatusCancelled
+  github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult:
+    properties:
+      cap_value:
+        type: string
+      coin:
+        $ref: '#/definitions/github_com_cosmos_cosmos-sdk_types.Coin'
+    type: object
+  github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult:
+    properties:
+      account_coins_result:
+        description: AccountCoinsResult represents coins only from user balances (contrary
+          to TotalValueCap).
+        items:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult'
+        type: array
+      capitalization:
+        description: |-
+          Capitalization represents the total value of the assets in the portfolio.
+          includes capitalization of user balances, value in locks, bonding or unbonding
+          as well as the concentrated positions.
+        type: string
+      is_best_effort:
+        type: boolean
+    type: object
+  github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult:
+    properties:
+      categories:
+        additionalProperties:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult'
+        type: object
+    type: object
+  github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse:
+    properties:
+      is_best_effort:
+        type: boolean
+      orders:
+        items:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder'
+        type: array
     type: object
   sqsdomain.CandidatePool:
     properties:
@@ -59,11 +171,40 @@ definitions:
           type: object
         type: object
     type: object
+  types.Int:
+    type: object
 info:
   contact: {}
   title: Osmosis Sidecar Query Server Example API
   version: "1.0"
 paths:
+  /passthrough/active-orders:
+    get:
+      description: The returned data represents all active orders for all orderbooks
+        available for the specified address.
+      parameters:
+      - description: Osmo wallet address
+        in: query
+        name: userOsmoAddress
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of active orders for all available orderboooks for the
+            given address
+          schema:
+            $ref: '#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse'
+        "400":
+          description: Response error
+          schema:
+            $ref: '#/definitions/domain.ResponseError'
+        "500":
+          description: Response error
+          schema:
+            $ref: '#/definitions/domain.ResponseError'
+      summary: Returns all active orderbook orders associated with the given address.
   /passthrough/portfolio-assets/{address}:
     get:
       description: The returned data represents the potfolio asset breakdown by category
@@ -81,11 +222,11 @@ paths:
           description: Portfolio assets by-category and capitalization of the entire
             account value
           schema:
-            type: struct
+            $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult'
         "500":
           description: Response error
           schema:
-            type: struct
+            $ref: '#/definitions/domain.ResponseError'
       summary: Returns portfolio assets associated with the given address by category.
   /pools:
     get:
@@ -138,7 +279,7 @@ paths:
         "200":
           description: Canonical Orderbook Pool ID for the given base and quote
           schema:
-            type: struct
+            $ref: '#/definitions/domain.CanonicalOrderBooksResult'
       summary: Get canonical orderbook pool ID for the given base and quote.
   /pools/canonical-orderbooks:
     get:

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -17,6 +17,13 @@ var (
 	ErrBadParamInput = errors.New("given Param is not valid")
 )
 
+var (
+	ErrBaseDenomNotValid       = errors.New("base denom is empty")
+	ErrQuoteDenomNotValid      = errors.New("quote denom is empty")
+	ErrPoolIDNotValid          = errors.New("pool ID is zero")
+	ErrContractAddressNotValid = errors.New("contract address is empty")
+)
+
 // GetStatusCode returbs status code given error
 func GetStatusCode(err error) int {
 	if err == nil {

--- a/domain/mocks/orderbook_grpc_client_mock.go
+++ b/domain/mocks/orderbook_grpc_client_mock.go
@@ -12,33 +12,33 @@ var _ orderbookgrpcclientdomain.OrderBookClient = (*OrderbookGRPCClientMock)(nil
 
 // OrderbookGRPCClientMock is a mock struct that implements orderbookplugindomain.OrderbookGRPCClient.
 type OrderbookGRPCClientMock struct {
-	MockGetOrdersByTickCb          func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
-	MockGetActiveOrdersCb          func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error)
-	MockGetTickUnrealizedCancelsCb func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
-	FetchTickUnrealizedCancelsCb   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
-	MockQueryTicksCb               func(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error)
-	FetchTicksCb                   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error)
+	GetOrdersByTickCb            func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
+	GetActiveOrdersCb            func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error)
+	GetTickUnrealizedCancelsCb   func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
+	FetchTickUnrealizedCancelsCb func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
+	MockQueryTicksCb             func(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error)
+	FetchTicksCb                 func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error)
 }
 
 func (o *OrderbookGRPCClientMock) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
-	if o.MockGetOrdersByTickCb != nil {
-		return o.MockGetOrdersByTickCb(ctx, contractAddress, tick)
+	if o.GetOrdersByTickCb != nil {
+		return o.GetOrdersByTickCb(ctx, contractAddress, tick)
 	}
 
 	return nil, nil
 }
 
 func (o *OrderbookGRPCClientMock) GetActiveOrders(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error) {
-	if o.MockGetActiveOrdersCb != nil {
-		return o.MockGetActiveOrdersCb(ctx, contractAddress, ownerAddress)
+	if o.GetActiveOrdersCb != nil {
+		return o.GetActiveOrdersCb(ctx, contractAddress, ownerAddress)
 	}
 
 	return nil, 0, nil
 }
 
 func (o *OrderbookGRPCClientMock) GetTickUnrealizedCancels(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
-	if o.MockGetTickUnrealizedCancelsCb != nil {
-		return o.MockGetTickUnrealizedCancelsCb(ctx, contractAddress, tickIDs)
+	if o.GetTickUnrealizedCancelsCb != nil {
+		return o.GetTickUnrealizedCancelsCb(ctx, contractAddress, tickIDs)
 	}
 
 	return nil, nil

--- a/domain/mocks/orderbook_grpc_client_mock.go
+++ b/domain/mocks/orderbook_grpc_client_mock.go
@@ -15,7 +15,9 @@ type OrderbookGRPCClientMock struct {
 	MockGetOrdersByTickCb          func(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
 	MockGetActiveOrdersCb          func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error)
 	MockGetTickUnrealizedCancelsCb func(ctx context.Context, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
+	FetchTickUnrealizedCancelsCb   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error)
 	MockQueryTicksCb               func(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error)
+	FetchTicksCb                   func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error)
 }
 
 func (o *OrderbookGRPCClientMock) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
@@ -42,9 +44,25 @@ func (o *OrderbookGRPCClientMock) GetTickUnrealizedCancels(ctx context.Context, 
 	return nil, nil
 }
 
+func (o *OrderbookGRPCClientMock) FetchTickUnrealizedCancels(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+	if o.FetchTickUnrealizedCancelsCb != nil {
+		return o.FetchTickUnrealizedCancelsCb(ctx, chunkSize, contractAddress, tickIDs)
+	}
+
+	return nil, nil
+}
+
 func (o *OrderbookGRPCClientMock) QueryTicks(ctx context.Context, contractAddress string, ticks []int64) ([]orderbookdomain.Tick, error) {
 	if o.MockQueryTicksCb != nil {
 		return o.MockQueryTicksCb(ctx, contractAddress, ticks)
+	}
+
+	return nil, nil
+}
+
+func (o *OrderbookGRPCClientMock) FetchTicks(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+	if o.FetchTicksCb != nil {
+		return o.FetchTicksCb(ctx, chunkSize, contractAddress, tickIDs)
 	}
 
 	return nil, nil

--- a/domain/mocks/orderbook_usecase_mock.go
+++ b/domain/mocks/orderbook_usecase_mock.go
@@ -1,0 +1,39 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/osmosis-labs/sqs/domain/mvc"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/sqsdomain"
+)
+
+var _ mvc.OrderBookUsecase = &OrderbookUsecaseMock{}
+
+// OrderbookUsecaseMock is a mock implementation of the RouterUsecase interface
+type OrderbookUsecaseMock struct {
+	ProcessPoolFunc     func(ctx context.Context, pool sqsdomain.PoolI) error
+	GetAllTicksFunc     func(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool)
+	GetActiveOrdersFunc func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
+}
+
+func (m *OrderbookUsecaseMock) ProcessPool(ctx context.Context, pool sqsdomain.PoolI) error {
+	if m.ProcessPoolFunc != nil {
+		return m.ProcessPoolFunc(ctx, pool)
+	}
+	panic("unimplemented")
+}
+
+func (m *OrderbookUsecaseMock) GetAllTicks(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool) {
+	if m.GetAllTicksFunc != nil {
+		return m.GetAllTicksFunc(poolID)
+	}
+	panic("unimplemented")
+}
+
+func (m *OrderbookUsecaseMock) GetActiveOrders(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+	if m.GetActiveOrdersFunc != nil {
+		return m.GetActiveOrdersFunc(ctx, address)
+	}
+	panic("unimplemented")
+}

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -28,6 +28,8 @@ type PoolsUsecaseMock struct {
 	GetPoolSpotPriceFunc        func(ctx context.Context, poolID uint64, takerFee osmomath.Dec, quoteAsset, baseAsset string) (osmomath.BigDec, error)
 	GetCosmWasmPoolConfigFunc   func() domain.CosmWasmPoolRouterConfig
 	CalcExitCFMMPoolFunc        func(poolID uint64, exitingShares osmomath.Int) (sdk.Coins, error)
+	GetAllCanonicalOrderbookPoolIDsFunc func() ([]domain.CanonicalOrderBooksResult, error)
+
 
 	Pools        []sqsdomain.PoolI
 	TickModelMap map[uint64]*sqsdomain.TickModel
@@ -40,6 +42,9 @@ func (pm *PoolsUsecaseMock) IsCanonicalOrderbookPool(poolID uint64) bool {
 
 // GetAllCanonicalOrderbookPoolIDs implements mvc.PoolsUsecase.
 func (pm *PoolsUsecaseMock) GetAllCanonicalOrderbookPoolIDs() ([]domain.CanonicalOrderBooksResult, error) {
+	if pm.GetAllCanonicalOrderbookPoolIDsFunc != nil {
+		return pm.GetAllCanonicalOrderbookPoolIDsFunc()
+	}
 	panic("unimplemented")
 }
 

--- a/domain/mocks/pools_usecase_mock.go
+++ b/domain/mocks/pools_usecase_mock.go
@@ -19,17 +19,16 @@ import (
 var _ mvc.PoolsUsecase = &PoolsUsecaseMock{}
 
 type PoolsUsecaseMock struct {
-	GetAllPoolsFunc             func() ([]sqsdomain.PoolI, error)
-	GetPoolsFunc                func(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, error)
-	StorePoolsFunc              func(pools []sqsdomain.PoolI) error
-	GetRoutesFromCandidatesFunc func(candidateRoutes sqsdomain.CandidateRoutes, tokenInDenom, tokenOutDenom string) ([]route.RouteImpl, error)
-	GetTickModelMapFunc         func(poolIDs []uint64) (map[uint64]*sqsdomain.TickModel, error)
-	GetPoolFunc                 func(poolID uint64) (sqsdomain.PoolI, error)
-	GetPoolSpotPriceFunc        func(ctx context.Context, poolID uint64, takerFee osmomath.Dec, quoteAsset, baseAsset string) (osmomath.BigDec, error)
-	GetCosmWasmPoolConfigFunc   func() domain.CosmWasmPoolRouterConfig
-	CalcExitCFMMPoolFunc        func(poolID uint64, exitingShares osmomath.Int) (sdk.Coins, error)
+	GetAllPoolsFunc                     func() ([]sqsdomain.PoolI, error)
+	GetPoolsFunc                        func(opts ...domain.PoolsOption) ([]sqsdomain.PoolI, error)
+	StorePoolsFunc                      func(pools []sqsdomain.PoolI) error
+	GetRoutesFromCandidatesFunc         func(candidateRoutes sqsdomain.CandidateRoutes, tokenInDenom, tokenOutDenom string) ([]route.RouteImpl, error)
+	GetTickModelMapFunc                 func(poolIDs []uint64) (map[uint64]*sqsdomain.TickModel, error)
+	GetPoolFunc                         func(poolID uint64) (sqsdomain.PoolI, error)
+	GetPoolSpotPriceFunc                func(ctx context.Context, poolID uint64, takerFee osmomath.Dec, quoteAsset, baseAsset string) (osmomath.BigDec, error)
+	GetCosmWasmPoolConfigFunc           func() domain.CosmWasmPoolRouterConfig
+	CalcExitCFMMPoolFunc                func(poolID uint64, exitingShares osmomath.Int) (sdk.Coins, error)
 	GetAllCanonicalOrderbookPoolIDsFunc func() ([]domain.CanonicalOrderBooksResult, error)
-
 
 	Pools        []sqsdomain.PoolI
 	TickModelMap map[uint64]*sqsdomain.TickModel

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -67,6 +67,23 @@ type CanonicalOrderBooksResult struct {
 	ContractAddress string `json:"contract_address"`
 }
 
+// Validate validates the canonical orderbook result.
+func (c CanonicalOrderBooksResult) Validate() error {
+	if c.Base == "" {
+		return ErrBaseDenomNotValid
+	}
+	if c.Quote == "" {
+		return ErrQuoteDenomNotValid
+	}
+	if c.PoolID == 0 {
+		return ErrPoolIDNotValid
+	}
+	if c.ContractAddress == "" {
+		return ErrContractAddressNotValid
+	}
+	return nil
+}
+
 type PoolsOptions struct {
 	MinPoolLiquidityCap  uint64
 	PoolIDFilter         []uint64

--- a/orderbook/types/errors.go
+++ b/orderbook/types/errors.go
@@ -191,3 +191,23 @@ type TickIDMismatchError struct {
 func (e TickIDMismatchError) Error() string {
 	return fmt.Sprintf("tick id mismatch when fetching tick states %d %d", e.ExpectedID, e.ActualID)
 }
+
+// FailedGetAllCanonicalOrderbookPoolIDsError represents an error when failing to get all canonical orderbook pool IDs.
+type FailedGetAllCanonicalOrderbookPoolIDsError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e FailedGetAllCanonicalOrderbookPoolIDsError) Error() string {
+	return fmt.Sprintf("failed to get all canonical orderbook pool IDs: %v", e.Err)
+}
+
+// FailedProcessingOrderbookActiveOrdersError represents an error when failing to process orderbook active orders.
+type FailedProcessingOrderbookActiveOrdersError struct {
+	Err error
+}
+
+// Error implements the error interface.
+func (e FailedProcessingOrderbookActiveOrdersError) Error() string {
+	return fmt.Sprintf("failed to process orderbook active orders: %v", e.Err)
+}

--- a/orderbook/types/errors.go
+++ b/orderbook/types/errors.go
@@ -195,13 +195,3 @@ type FailedGetAllCanonicalOrderbookPoolIDsError struct {
 func (e FailedGetAllCanonicalOrderbookPoolIDsError) Error() string {
 	return fmt.Sprintf("failed to get all canonical orderbook pool IDs: %v", e.Err)
 }
-
-// FailedProcessingOrderbookActiveOrdersError represents an error when failing to process orderbook active orders.
-type FailedProcessingOrderbookActiveOrdersError struct {
-	Err error
-}
-
-// Error implements the error interface.
-func (e FailedProcessingOrderbookActiveOrdersError) Error() string {
-	return fmt.Sprintf("failed to process orderbook active orders: %v", e.Err)
-}

--- a/orderbook/types/errors.go
+++ b/orderbook/types/errors.go
@@ -195,3 +195,26 @@ type FailedGetAllCanonicalOrderbookPoolIDsError struct {
 func (e FailedGetAllCanonicalOrderbookPoolIDsError) Error() string {
 	return fmt.Sprintf("failed to get all canonical orderbook pool IDs: %v", e.Err)
 }
+
+// FailedToGetActiveOrdersError is returned when the retrieval of active orders fails.
+type FailedToGetActiveOrdersError struct {
+	ContractAddress string
+	OwnerAddress    string
+	Err             error
+}
+
+// Error implements the error interface.
+func (e FailedToGetActiveOrdersError) Error() string {
+	return fmt.Sprintf("failed to get active orders for contract: %s and owner: %s: %v", e.ContractAddress, e.OwnerAddress, e.Err)
+}
+
+// FailedToGetMetadataError is returned when getting token metadata fails.
+type FailedToGetMetadataError struct {
+	TokenDenom string
+	Err        error
+}
+
+// Error implements the error interface.
+func (e FailedToGetMetadataError) Error() string {
+	return fmt.Sprintf("failed to get metadata for token denom: %s: %v", e.TokenDenom, e.Err)
+}

--- a/orderbook/types/get_orders_request.go
+++ b/orderbook/types/get_orders_request.go
@@ -1,47 +1,40 @@
 package types
 
 import (
+	"fmt"
 	"sort"
-	"strconv"
 
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/labstack/echo/v4"
+)
+
+var (
+	// ErrUserOsmoAddressInvalid is generic error returned when the user address is invalid.
+	ErrUserOsmoAddressInvalid = fmt.Errorf("userOsmoAddress is not valid osmo address")
+
+	ErrInternalError = fmt.Errorf("internal error")
 )
 
 // GetActiveOrdersRequest represents get orders request for the /pools/all-orders endpoint.
 type GetActiveOrdersRequest struct {
 	UserOsmoAddress string
-	Limit           int
-	Cursor          int
 }
 
 // UnmarshalHTTPRequest unmarshals the HTTP request to GetActiveOrdersRequest.
 func (r *GetActiveOrdersRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	r.UserOsmoAddress = c.QueryParam("userOsmoAddress")
-
-	if limit := c.QueryParam("limit"); limit != "" {
-		i, err := strconv.Atoi(limit)
-		if err != nil {
-			return err
-		}
-		r.Limit = i
-	}
-
-	if cursor := c.QueryParam("cursor"); cursor != "" {
-		i, err := strconv.Atoi(cursor)
-		if err != nil {
-			return err
-		}
-		r.Cursor = i
-	}
-
 	return nil
 }
 
 // Validate validates the GetActiveOrdersRequest.
-// TODO: implement validation rules
 func (r *GetActiveOrdersRequest) Validate() error {
+	_, err := sdk.AccAddressFromBech32(r.UserOsmoAddress)
+	if err != nil {
+		return ErrUserOsmoAddressInvalid
+	}
 	return nil
 }
 

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -1,8 +1,6 @@
 package orderbookusecase
 
 import (
-	"context"
-	"github.com/osmosis-labs/sqs/domain"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 )
 
@@ -15,9 +13,4 @@ func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	orderbookAddress string,
 ) (orderbookdomain.LimitOrder, error) {
 	return o.createFormattedLimitOrder(poolID, order, quoteAsset, baseAsset, orderbookAddress)
-}
-
-// SetProcessOrderBookActiveOrdersFunc is a setter for processOrderBookActiveOrdersFunc
-func (o *OrderbookUseCaseImpl) SetProcessOrderBookActiveOrdersFunc(fn func(ctx context.Context, orderbook domain.CanonicalOrderBooksResult, address string) ([]orderbookdomain.LimitOrder, bool, error)) {
-	o.processOrderBookActiveOrdersFunc = fn
 }

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 // OrderBookEntry is an alias of orderBookEntry for testing purposes
-func (o *orderbookUseCaseImpl) CreateFormattedLimitOrder(
+func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	poolID uint64,
 	order orderbookdomain.Order,
 	quoteAsset orderbookdomain.Asset,

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -1,10 +1,12 @@
 package orderbookusecase
 
 import (
+	"context"
+	"github.com/osmosis-labs/sqs/domain"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 )
 
-// OrderBookEntry is an alias of orderBookEntry for testing purposes
+// CreateFormattedLimitOrder is an alias of createFormattedLimitOrder for testing purposes
 func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	poolID uint64,
 	order orderbookdomain.Order,
@@ -13,4 +15,9 @@ func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	orderbookAddress string,
 ) (orderbookdomain.LimitOrder, error) {
 	return o.createFormattedLimitOrder(poolID, order, quoteAsset, baseAsset, orderbookAddress)
+}
+
+// ProcessOrderBookActiveOrders is an alias of processOrderBookActiveOrders for testing purposes
+func (o *OrderbookUseCaseImpl) ProcessOrderBookActiveOrders(ctx context.Context, orderBook domain.CanonicalOrderBooksResult, ownerAddress string) ([]orderbookdomain.LimitOrder, bool, error) {
+	return o.processOrderBookActiveOrders(ctx, orderBook, ownerAddress)
 }

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -1,6 +1,8 @@
 package orderbookusecase
 
 import (
+	"context"
+	"github.com/osmosis-labs/sqs/domain"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 )
 
@@ -13,4 +15,9 @@ func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
 	orderbookAddress string,
 ) (orderbookdomain.LimitOrder, error) {
 	return o.createFormattedLimitOrder(poolID, order, quoteAsset, baseAsset, orderbookAddress)
+}
+
+// SetProcessOrderBookActiveOrdersFunc is a setter for processOrderBookActiveOrdersFunc
+func (o *OrderbookUseCaseImpl) SetProcessOrderBookActiveOrdersFunc(fn func(ctx context.Context, orderbook domain.CanonicalOrderBooksResult, address string) ([]orderbookdomain.LimitOrder, bool, error)) {
+	o.processOrderBookActiveOrdersFunc = fn
 }

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -179,7 +179,7 @@ func (o *OrderbookUseCaseImpl) GetActiveOrders(ctx context.Context, address stri
 			if result.err != nil {
 				telemetry.ProcessingOrderbookActiveOrdersErrorCounter.Inc()
 				o.logger.Error(telemetry.ProcessingOrderbookActiveOrdersErrorMetricName, zap.Any("orderbook_id", result.orderbookID), zap.Any("err", result.err))
-				return nil, false, result.err
+				return nil, false, fmt.Errorf("failed to process orderbook active orders: %w", result.err)
 			}
 
 			isBestEffort = isBestEffort || result.isBestEffort

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -202,7 +202,11 @@ func (o *OrderbookUseCaseImpl) processOrderBookActiveOrders(ctx context.Context,
 
 	orders, count, err := o.orderBookClient.GetActiveOrders(ctx, orderBook.ContractAddress, ownerAddress)
 	if err != nil {
-		return nil, false, err
+		return nil, false, types.FailedToGetActiveOrdersError{
+			ContractAddress: orderBook.ContractAddress,
+			OwnerAddress:    ownerAddress,
+			Err:             err,
+		}
 	}
 
 	// There are orders to process for given orderbook
@@ -212,12 +216,18 @@ func (o *OrderbookUseCaseImpl) processOrderBookActiveOrders(ctx context.Context,
 
 	quoteToken, err := o.tokensUsecease.GetMetadataByChainDenom(orderBook.Quote)
 	if err != nil {
-		return nil, false, err
+		return nil, false, types.FailedToGetMetadataError{
+			TokenDenom: orderBook.Quote,
+			Err:        err,
+		}
 	}
 
 	baseToken, err := o.tokensUsecease.GetMetadataByChainDenom(orderBook.Base)
 	if err != nil {
-		return nil, false, err
+		return nil, false, types.FailedToGetMetadataError{
+			TokenDenom: orderBook.Base,
+			Err:        err,
+		}
 	}
 
 	// Create a slice to store the results

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -17,6 +17,7 @@ import (
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	orderbookgrpcclientdomain "github.com/osmosis-labs/sqs/domain/orderbook/grpcclient"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
+	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v25/app/apptesting"

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -1,14 +1,21 @@
 package orderbookusecase_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/osmosis-labs/sqs/sqsdomain"
+
+	cwpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
+	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
+
 	cltypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	orderbookgrpcclientdomain "github.com/osmosis-labs/sqs/domain/orderbook/grpcclient"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 
@@ -24,6 +31,260 @@ func TestOrderbookUsecaseTestSuite(t *testing.T) {
 	suite.Run(t, new(OrderbookUsecaseTestSuite))
 }
 
+func (s *OrderbookUsecaseTestSuite) TestProcessPool() {
+	testCases := []struct {
+		name          string
+		pool          sqsdomain.PoolI
+		setupMocks    func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock)
+		expectedError string
+	}{
+		{
+			name:          "pool is nil",
+			pool:          nil,
+			expectedError: "pool is nil when processing order book",
+		},
+		{
+			name: "cosmWasmPoolModel is nil",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: nil,
+			},
+			expectedError: "cw pool model is nil when processing order book",
+		},
+		{
+			name: "pool is not an orderbook pool",
+			pool: &mocks.MockRoutablePool{
+				ID:                1,
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{},
+			},
+			expectedError: "pool is not an orderbook pool 1",
+		},
+		{
+			name: "orderbook pool has no ticks, nothing to process",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{},
+						},
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name: "failed to cast pool model to CosmWasmPool",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &mocks.ChainPoolMock{
+					ID:   1,
+					Type: poolmanagertypes.Balancer,
+				},
+			},
+			expectedError: "failed to cast pool model to CosmWasmPool",
+		},
+		{
+			name: "failed to fetch ticks for pool",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return nil, assert.AnError
+				}
+			},
+			expectedError: "failed to fetch ticks for pool",
+		},
+		{
+			name: "failed to fetch unrealized cancels for pool",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return nil, assert.AnError
+				}
+			},
+			expectedError: "failed to fetch unrealized cancels for pool",
+		},
+		{
+			name: "tick ID mismatch when fetching unrealized ticks",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 1},
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{TickID: 2}, // Mismatch
+					}, nil
+				}
+			},
+			expectedError: "tick id mismatch when fetching unrealized ticks 2 1",
+		},
+		{
+			name: "tick ID mismatch when fetching tick states",
+			pool: &mocks.MockRoutablePool{
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 2}, // Mismatched TickID
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{TickID: 1},
+					}, nil
+				}
+			},
+			expectedError: "tick id mismatch when fetching tick states 2 1",
+		},
+		{
+			name: "successful pool processing",
+			pool: &mocks.MockRoutablePool{
+				ID: 1,
+				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
+					ContractInfo: cosmwasmpool.ContractInfo{
+						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
+						Version:  cosmwasmpool.ORDERBOOK_MIN_CONTRACT_VERSION,
+					},
+					Data: cosmwasmpool.CosmWasmPoolData{
+						Orderbook: &cosmwasmpool.OrderbookData{
+							Ticks: []cosmwasmpool.OrderbookTick{
+								{TickId: 1},
+							},
+						},
+					},
+				},
+				ChainPoolModel: &cwpoolmodel.CosmWasmPool{},
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, client *mocks.OrderbookGRPCClientMock, repository *mocks.OrderbookRepositoryMock) {
+				client.FetchTicksCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookdomain.Tick, error) {
+					return []orderbookdomain.Tick{
+						{TickID: 1, TickState: orderbookdomain.TickState{
+							BidValues: orderbookdomain.TickValues{
+								EffectiveTotalAmountSwapped: "100",
+							},
+						}},
+					}, nil
+				}
+				client.FetchTickUnrealizedCancelsCb = func(ctx context.Context, chunkSize int, contractAddress string, tickIDs []int64) ([]orderbookgrpcclientdomain.UnrealizedTickCancels, error) {
+					return []orderbookgrpcclientdomain.UnrealizedTickCancels{
+						{
+							TickID: 1,
+							UnrealizedCancelsState: orderbookdomain.UnrealizedCancels{
+								BidUnrealizedCancels: osmomath.NewInt(100),
+							},
+						},
+					}, nil
+				}
+				repository.StoreTicksFunc = func(poolID uint64, ticksMap map[int64]orderbookdomain.OrderbookTick) {
+					// Assume ticks are correctly stored, no need for implementation here
+				}
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			// Create instances of the mocks
+			repository := mocks.OrderbookRepositoryMock{}
+			tokensUsecase := mocks.TokensUsecaseMock{}
+			client := mocks.OrderbookGRPCClientMock{}
+
+			// Setup the mocks according to the test case
+			usecase := orderbookusecase.New(&repository, &client, nil, &tokensUsecase, nil)
+			if tc.setupMocks != nil {
+				tc.setupMocks(usecase, &client, &repository)
+			}
+
+			// Call the method under test
+			err := usecase.ProcessPool(context.Background(), tc.pool)
+
+			// Assert the results
+			if tc.expectedError != "" {
+				s.Assert().Error(err)
+				s.Assert().Contains(err.Error(), tc.expectedError)
+			} else {
+				s.Assert().NoError(err)
+			}
+		})
+	}
+}
 func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 	testCases := []struct {
 		name          string

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -262,12 +262,12 @@ func (s *OrderbookUsecaseTestSuite) TestGetActiveOrders() {
 			expectedError: &types.FailedGetAllCanonicalOrderbookPoolIDsError{},
 		},
 		{
+			name: "context is done before processing all orderbooks",
 			setupContext: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 				return ctx
 			},
-			name: "context is done before processing all orderbooks",
 			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock) {
 				withGetAllCanonicalOrderbookPoolIDs(poolsUsecase)
 			},

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
+// defaultOrder is a default order used for testing
 var defaultOrder = orderbookdomain.Order{
 	TickId:         1,
 	OrderId:        1,
@@ -39,6 +40,8 @@ var defaultOrder = orderbookdomain.Order{
 	PlacedAt:       "1634764800000",
 }
 
+
+// defaultLimitOrder is a default limit order used for testing
 var defaultLimitOrder = orderbookdomain.LimitOrder{
 	TickId:           1,
 	OrderId:          1,
@@ -56,45 +59,54 @@ var defaultLimitOrder = orderbookdomain.LimitOrder{
 	OrderbookAddress: "someOrderbookAddress",
 	Status:           "partiallyFilled",
 	Output:           osmomath.MustNewDecFromStr("1499.998500001499998500"),
-	// QuoteAsset:       orderbookdomain.Asset{Symbol: "ATOM", Decimals: 6},
-	// BaseAsset:        orderbookdomain.Asset{Symbol: "OSMO", Decimals: 6},
 }
 
-type OrderbookTestHelper struct {
-	routertesting.RouterTestHelper
-}
-
+// Order is a wrapper around orderbookdomain.Order
+// it wraps additional helper methods for testing
 type Order struct {
 	orderbookdomain.Order
 }
 
+// withOrderID sets the order ID for the order
 func (o Order) withOrderID(id int64) Order {
 	o.OrderId = id
 	return o
 }
 
+// withOrderbookAddress sets the orderbook address for the order
+// it wraps additional helper methods for testing
 type LimitOrder struct {
 	orderbookdomain.LimitOrder
 }
 
+// withOrderID sets the order ID for the order
 func (o LimitOrder) withOrderID(id int64) LimitOrder {
 	o.OrderId = id
 	return o
 }
 
+// withOrderbookAddress sets the orderbook address for the order
 func (o LimitOrder) withOrderbookAddress(address string) LimitOrder {
 	o.OrderbookAddress = address
 	return o
 }
 
+// OrderbookTestHelper is a helper struct for the orderbook usecase tests
+type OrderbookTestHelper struct {
+	routertesting.RouterTestHelper
+}
+
+// newOrder creates a new order
 func (s *OrderbookTestHelper) newOrder() Order {
 	return Order{defaultOrder}
 }
 
+// newLimitOrder creates a new limit order
 func (s *OrderbookTestHelper) newLimitOrder() LimitOrder {
 	return LimitOrder{defaultLimitOrder}
 }
 
+// newTick creates a new orderbook tick
 func (s *OrderbookTestHelper) newTick(effectiveTotalAmountSwapped string, unrealizedCancels int64, direction string) orderbookdomain.OrderbookTick {
 	s.T().Helper()
 
@@ -122,12 +134,15 @@ func (s *OrderbookTestHelper) newTick(effectiveTotalAmountSwapped string, unreal
 	return tick
 }
 
+// getTickByIDFunc returns a function that returns a tick by ID
+// it is useful for mocking the repository.GetTickByIDFunc.
 func (s *OrderbookTestHelper) getTickByIDFunc(tick orderbookdomain.OrderbookTick, ok bool) func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
 	return func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
 		return tick, ok
 	}
 }
 
+// newCanonicalOrderBooksResult creates a new canonical orderbooks result
 func (s *OrderbookTestHelper) newCanonicalOrderBooksResult(poolID uint64, contractAddress string) domain.CanonicalOrderBooksResult {
 	return domain.CanonicalOrderBooksResult{
 		Base:            "OSMO",
@@ -138,16 +153,20 @@ func (s *OrderbookTestHelper) newCanonicalOrderBooksResult(poolID uint64, contra
 
 }
 
+// getAllCanonicalOrderbookPoolIDsFunc returns a function that returns all canonical orderbook pool IDs
+// it is useful for mocking the poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc.
 func (s *OrderbookTestHelper) getAllCanonicalOrderbookPoolIDsFunc(err error, orderbooks ...domain.CanonicalOrderBooksResult) func() ([]domain.CanonicalOrderBooksResult, error) {
 	return func() ([]domain.CanonicalOrderBooksResult, error) {
 		return orderbooks, err
 	}
 }
 
+// OrderbookUsecaseTestSuite is a test suite for the orderbook usecase
 type OrderbookUsecaseTestSuite struct {
 	OrderbookTestHelper
 }
 
+// SetupTest sets up the test suite
 func TestOrderbookUsecaseTestSuite(t *testing.T) {
 	suite.Run(t, new(OrderbookUsecaseTestSuite))
 }

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -12,6 +12,7 @@ import (
 	cwpoolmodel "github.com/osmosis-labs/osmosis/v25/x/cosmwasmpool/model"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v25/x/poolmanager/types"
 
+	"github.com/osmosis-labs/sqs/domain"
 	cltypes "github.com/osmosis-labs/osmosis/v25/x/concentrated-liquidity/types"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
@@ -284,6 +285,76 @@ func (s *OrderbookUsecaseTestSuite) TestProcessPool() {
 			}
 		})
 	}
+}
+
+func (s *OrderbookUsecaseTestSuite) TestGetActiveOrders() {
+    testCases := []struct {
+        name          string
+		setupContext  func() context.Context
+        setupMocks    func(usecase *orderbookusecase.OrderbookUseCaseImpl, poolsUsecase *mocks.PoolsUsecaseMock)
+        expectedError string
+        expectedOrders []orderbookdomain.LimitOrder
+        expectedIsBestEffort bool
+    }{
+        {
+            name: "failed to get all canonical orderbook pool IDs",
+			setupContext:  func() context.Context {
+				return context.Background()
+			},
+            setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, poolsUsecase *mocks.PoolsUsecaseMock) {
+                poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = func() ([]domain.CanonicalOrderBooksResult, error) {
+                    return nil, assert.AnError
+                }
+            },
+            expectedError: "failed to get all canonical orderbook pool IDs",
+        },
+        {
+			setupContext:  func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+            name: "context is done before processing all orderbooks",
+            setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, poolsUsecase *mocks.PoolsUsecaseMock) {
+                poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = func() ([]domain.CanonicalOrderBooksResult, error) {
+                    return []domain.CanonicalOrderBooksResult{
+                        {PoolID: 1},
+                    }, nil
+                }
+            },
+            expectedError: context.Canceled.Error(),
+        },
+    }
+
+    for _, tc := range testCases {
+        s.Run(tc.name, func() {
+            // Create instances of the mocks
+            poolsUsecase := mocks.PoolsUsecaseMock{}
+            orderbookRepo := mocks.OrderbookRepositoryMock{}
+            client := mocks.OrderbookGRPCClientMock{}
+
+            // Setup the mocks according to the test case
+            usecase := orderbookusecase.New(&orderbookRepo, &client, &poolsUsecase, nil, nil)
+            if tc.setupMocks != nil {
+                tc.setupMocks(usecase, &poolsUsecase)
+            }
+
+			ctx := tc.setupContext()
+
+            // Call the method under test
+            orders, isBestEffort, err := usecase.GetActiveOrders(ctx, "address")
+
+            // Assert the results
+            if tc.expectedError != "" {
+                s.Assert().Error(err)
+                s.Assert().Contains(err.Error(), tc.expectedError)
+            } else {
+                s.Assert().NoError(err)
+                s.Assert().Equal(tc.expectedOrders, orders)
+                s.Assert().Equal(tc.expectedIsBestEffort, isBestEffort)
+            }
+        })
+    }
 }
 func (s *OrderbookUsecaseTestSuite) TestCreateFormattedLimitOrder() {
 	testCases := []struct {

--- a/orderbook/usecase/orderbooktesting/parsing/active_orders_response.json
+++ b/orderbook/usecase/orderbooktesting/parsing/active_orders_response.json
@@ -1,0 +1,53 @@
+{
+  "orders": [
+    {
+      "tick_id": 1,
+      "order_id": 1,
+      "order_direction": "bid",
+      "owner": "owner1",
+      "quantity": "1000.000000000000000000",
+      "etas": "500",
+      "claim_bounty": "10",
+      "placed_quantity": "1500.000000000000000000",
+      "placed_at": 1634,
+      "price": "1.000001000000000000",
+      "percentClaimed": "0.333333333333333333",
+      "totalFilled": "600.000000000000000000",
+      "percentFilled": "0.400000000000000000",
+      "orderbookAddress": "someOrderbookAddress",
+      "status": "partiallyFilled",
+      "output": "1499.998500001499998500",
+      "quote_asset": {
+        "symbol": ""
+      },
+      "base_asset": {
+        "symbol": ""
+      }
+    },
+    {
+      "tick_id": 1,
+      "order_id": 2,
+      "order_direction": "bid",
+      "owner": "owner1",
+      "quantity": "1000.000000000000000000",
+      "etas": "500",
+      "claim_bounty": "10",
+      "placed_quantity": "1500.000000000000000000",
+      "placed_at": 1634,
+      "price": "1.000001000000000000",
+      "percentClaimed": "0.333333333333333333",
+      "totalFilled": "600.000000000000000000",
+      "percentFilled": "0.400000000000000000",
+      "orderbookAddress": "someOrderbookAddress",
+      "status": "partiallyFilled",
+      "output": "1499.998500001499998500",
+      "quote_asset": {
+        "symbol": ""
+      },
+      "base_asset": {
+        "symbol": ""
+      }
+    }
+  ],
+  "is_best_effort": false
+}

--- a/orderbook/usecase/orderbooktesting/suite.go
+++ b/orderbook/usecase/orderbooktesting/suite.go
@@ -1,0 +1,208 @@
+package orderbooktesting
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/osmosis-labs/sqs/domain"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/router/usecase/routertesting"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+)
+
+// defaultOrder is a default order used for testing
+var defaultOrder = orderbookdomain.Order{
+	TickId:         1,
+	OrderId:        1,
+	OrderDirection: "bid",
+	Owner:          "owner1",
+	Quantity:       "1000",
+	PlacedQuantity: "1500",
+	Etas:           "500",
+	ClaimBounty:    "10",
+	PlacedAt:       "1634764800000",
+}
+
+// defaultLimitOrder is a default limit order used for testing
+var defaultLimitOrder = orderbookdomain.LimitOrder{
+	TickId:           1,
+	OrderId:          1,
+	OrderDirection:   "bid",
+	Owner:            "owner1",
+	Quantity:         osmomath.NewDec(1000),
+	Etas:             "500",
+	ClaimBounty:      "10",
+	PlacedQuantity:   osmomath.NewDec(1500),
+	PlacedAt:         1634,
+	Price:            osmomath.MustNewDecFromStr("1.000001000000000000"),
+	PercentClaimed:   osmomath.MustNewDecFromStr("0.333333333333333333"),
+	TotalFilled:      osmomath.MustNewDecFromStr("600"),
+	PercentFilled:    osmomath.MustNewDecFromStr("0.400000000000000000"),
+	OrderbookAddress: "someOrderbookAddress",
+	Status:           "partiallyFilled",
+	Output:           osmomath.MustNewDecFromStr("1499.998500001499998500"),
+}
+
+// Order is a wrapper around orderbookdomain.Order
+// it wraps additional helper methods for testing
+type Order struct {
+	orderbookdomain.Order
+}
+
+// WithOrderID sets the order ID for the order
+func (o Order) WithOrderID(id int64) Order {
+	o.OrderId = id
+	return o
+}
+
+// WithTickID sets the tick ID for the order
+func (o Order) WithTickID(id int64) Order {
+	o.TickId = id
+	return o
+}
+
+// LimitOrder wraps additional helper methods for testing
+type LimitOrder struct {
+	orderbookdomain.LimitOrder
+}
+
+// WithOrderID sets the order ID for the order
+func (o LimitOrder) WithOrderID(id int64) LimitOrder {
+	o.OrderId = id
+	return o
+}
+
+// WithOrderbookAddress sets the orderbook address for the order
+func (o LimitOrder) WithOrderbookAddress(address string) LimitOrder {
+	o.OrderbookAddress = address
+	return o
+}
+
+// WithQuoteAsset sets the quote asset for the order
+func (o LimitOrder) WithQuoteAsset(asset orderbookdomain.Asset) LimitOrder {
+	o.QuoteAsset = asset
+	return o
+}
+
+// WithBaseAsset sets the base asset for the order
+func (o LimitOrder) WithBaseAsset(asset orderbookdomain.Asset) LimitOrder {
+	o.BaseAsset = asset
+	return o
+}
+
+// OrderbookTestHelper is a helper struct for the orderbook usecase tests
+type OrderbookTestHelper struct {
+	routertesting.RouterTestHelper
+}
+
+// NewOrder creates a new order based on the defaultOrder.
+func (s *OrderbookTestHelper) NewOrder() Order {
+	return Order{defaultOrder}
+}
+
+// NewLimitOrder creates a new limit order based on the defaultLimitOrder.
+func (s *OrderbookTestHelper) NewLimitOrder() LimitOrder {
+	return LimitOrder{defaultLimitOrder}
+}
+
+// NewTick creates a new orderbook tick
+// direction can be either "bid" or "ask" and it determines the direction of the created tick.
+func (s *OrderbookTestHelper) NewTick(effectiveTotalAmountSwapped string, unrealizedCancels int64, direction string) orderbookdomain.OrderbookTick {
+	s.T().Helper()
+
+	tickValues := orderbookdomain.TickValues{
+		EffectiveTotalAmountSwapped: effectiveTotalAmountSwapped,
+	}
+
+	tick := orderbookdomain.OrderbookTick{
+		TickState:         orderbookdomain.TickState{},
+		UnrealizedCancels: orderbookdomain.UnrealizedCancels{},
+	}
+
+	if direction == "bid" {
+		tick.TickState.BidValues = tickValues
+		if unrealizedCancels != 0 {
+			tick.UnrealizedCancels.BidUnrealizedCancels = osmomath.NewInt(unrealizedCancels)
+		}
+	} else {
+		tick.TickState.AskValues = tickValues
+		if unrealizedCancels != 0 {
+			tick.UnrealizedCancels.AskUnrealizedCancels = osmomath.NewInt(unrealizedCancels)
+		}
+	}
+
+	return tick
+}
+
+// GetTickByIDFunc returns a function that returns a tick by ID
+// it is useful for mocking the repository.GetTickByIDFunc.
+func (s *OrderbookTestHelper) GetTickByIDFunc(tick orderbookdomain.OrderbookTick, ok bool) func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+	return func(poolID uint64, tickID int64) (orderbookdomain.OrderbookTick, bool) {
+		return tick, ok
+	}
+}
+
+// NewCanonicalOrderBooksResult creates a new canonical orderbooks result
+func (s *OrderbookTestHelper) NewCanonicalOrderBooksResult(poolID uint64, contractAddress string) domain.CanonicalOrderBooksResult {
+	return domain.CanonicalOrderBooksResult{
+		Base:            "OSMO",
+		Quote:           "ATOM",
+		PoolID:          poolID,
+		ContractAddress: contractAddress,
+	}
+}
+
+// GetAllCanonicalOrderbookPoolIDsFunc returns a function that returns all canonical orderbook pool IDs
+// it is useful for mocking the poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc.
+func (s *OrderbookTestHelper) GetAllCanonicalOrderbookPoolIDsFunc(err error, orderbooks ...domain.CanonicalOrderBooksResult) func() ([]domain.CanonicalOrderBooksResult, error) {
+	return func() ([]domain.CanonicalOrderBooksResult, error) {
+		return orderbooks, err
+	}
+}
+
+// GetActiveOrdersFunc returns a function that returns active orders
+func (s *OrderbookTestHelper) GetActiveOrdersFunc(orders orderbookdomain.Orders, total uint64, err error) func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error) {
+	return func(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error) {
+		return orders, total, err
+	}
+}
+
+// GetMetadataByChainDenomFuncEmptyToken returns a function that returns an empty token useful for mocking the tokensUsecase.GetMetadataByChainDenomFunc
+func (s *OrderbookTestHelper) GetMetadataByChainDenomFuncEmptyToken() func(denom string) (domain.Token, error) {
+	return func(denom string) (domain.Token, error) {
+		return domain.Token{}, nil
+	}
+}
+
+// GetMetadataByChainDenomFunc returns a function that returns a token by chain denom useful for mocking the tokensUsecase.GetMetadataByChainDenomFunc
+// If errIfNotDenom is not empty, it will return an error if the denom passed to GetMetadataByChainDenomFunc is not equal to errIfNotDenom.
+// If the denom passed to GetMetadataByChainDenomFunc is empty, it will return an empty token.
+// If the denom passed to GetMetadataByChainDenomFunc is equal to the quote/base asset symbol, it will return a token with the quote/base asset symbol and decimals.
+func (s *OrderbookTestHelper) GetMetadataByChainDenomFunc(order LimitOrder, errIfNotDenom string) func(denom string) (domain.Token, error) {
+	return func(denom string) (domain.Token, error) {
+		if errIfNotDenom != "" && errIfNotDenom != denom {
+			return domain.Token{}, assert.AnError
+		}
+		if denom == "" {
+			return domain.Token{}, nil
+		}
+
+		if denom == order.QuoteAsset.Symbol {
+			return domain.Token{
+				CoinMinimalDenom: order.QuoteAsset.Symbol,
+				Precision:        order.QuoteAsset.Decimals,
+			}, nil
+		}
+
+		if denom == order.BaseAsset.Symbol {
+			return domain.Token{
+				CoinMinimalDenom: order.BaseAsset.Symbol,
+				Precision:        order.BaseAsset.Decimals,
+			}, nil
+		}
+
+		return domain.Token{}, assert.AnError
+	}
+}

--- a/passthrough/delivery/http/passthrough_handler.go
+++ b/passthrough/delivery/http/passthrough_handler.go
@@ -6,16 +6,12 @@ import (
 	deliveryhttp "github.com/osmosis-labs/sqs/delivery/http"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
+	_ "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/orderbook/types"
 
 	"github.com/labstack/echo/v4"
 	"go.opentelemetry.io/otel/trace"
 )
-
-// ResponseError represent the response error struct
-type ResponseError struct {
-	Message string `json:"message"`
-}
 
 // PassthroughHandler is the http handler for passthrough use case
 type PassthroughHandler struct {
@@ -46,25 +42,36 @@ func NewPassthroughHandler(e *echo.Echo, ptu mvc.PassthroughUsecase, ou mvc.Orde
 // The user balances and total assets are brokend down by-coin with the capitalization of the entire account value.
 //
 // @Produce  json
-// @Success 200  struct  passthroughdomain.PortfolioAssetsResult  "Portfolio assets by-category and capitalization of the entire account value"
-// @Failure 500  struct  ResponseError  "Response error"
+// @Success 200  {object}  passthroughdomain.PortfolioAssetsResult  "Portfolio assets by-category and capitalization of the entire account value"
+// @Failure 500  {object}  domain.ResponseError  "Response error"
 // @Param address path string true "Wallet Address"
 // @Router /passthrough/portfolio-assets/{address} [get]
 func (a *PassthroughHandler) GetPortfolioAssetsByAddress(c echo.Context) error {
 	address := c.Param("address")
 
 	if address == "" {
-		return c.JSON(http.StatusInternalServerError, ResponseError{Message: "invalid address: cannot be empty"})
+		return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: "invalid address: cannot be empty"})
 	}
 
 	portfolioAssetsResult, err := a.PUsecase.GetPortfolioAssets(c.Request().Context(), address)
 	if err != nil {
-		return c.JSON(http.StatusPartialContent, ResponseError{Message: err.Error()})
+		return c.JSON(http.StatusPartialContent, domain.ResponseError{Message: err.Error()})
 	}
 
 	return c.JSON(http.StatusOK, portfolioAssetsResult)
 }
 
+// @Summary Returns all active orderbook orders associated with the given address.
+// @Description The returned data represents all active orders for all orderbooks available for the specified address.
+//
+// The is_best_effort flag indicates whether the error occurred while processing the orders due which not all orders were returned in the response.
+//
+// @Produce  json
+// @Success 200           {object}  types.GetActiveOrdersResponse  "List of active orders for all available orderboooks for the given address"
+// @Failure 400           {object}  domain.ResponseError                 "Response error"
+// @Failure 500           {object}  domain.ResponseError                 "Response error"
+// @Param  userOsmoAddress  query  string  true  "Osmo wallet address"
+// @Router /passthrough/active-orders [get]
 func (a *PassthroughHandler) GetActiveOrders(c echo.Context) (err error) {
 	ctx := c.Request().Context()
 
@@ -91,7 +98,7 @@ func (a *PassthroughHandler) GetActiveOrders(c echo.Context) (err error) {
 
 	orders, isBestEffort, err := a.OUsecase.GetActiveOrders(ctx, req.UserOsmoAddress)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: err.Error()})
+		return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: types.ErrInternalError.Error()})
 	}
 
 	resp := types.NewGetAllOrderResponse(orders, isBestEffort)

--- a/passthrough/delivery/http/passthrough_handler_test.go
+++ b/passthrough/delivery/http/passthrough_handler_test.go
@@ -1,0 +1,117 @@
+package http_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/osmosis-labs/sqs/domain/mocks"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/orderbook/types"
+	"github.com/osmosis-labs/sqs/orderbook/usecase/orderbooktesting"
+	passthroughdelivery "github.com/osmosis-labs/sqs/passthrough/delivery/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type PassthroughHandlerTestSuite struct {
+	orderbooktesting.OrderbookTestHelper
+}
+
+func TestPassthroughHandlerSuite(t *testing.T) {
+	suite.Run(t, new(PassthroughHandlerTestSuite))
+}
+
+func (s *PassthroughHandlerTestSuite) TestGetActiveOrders() {
+	testCases := []struct {
+		name               string
+		queryParams        map[string]string
+		setupMocks         func(usecase *mocks.OrderbookUsecaseMock)
+		expectedStatusCode int
+		expectedResponse   string
+		expectedError      bool
+	}{
+		{
+			name:               "validation error",
+			queryParams:        map[string]string{},
+			setupMocks:         func(usecase *mocks.OrderbookUsecaseMock) {},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   fmt.Sprintf(`{"message":"%s"}`, types.ErrUserOsmoAddressInvalid.Error()),
+			expectedError:      true,
+		},
+		{
+			name: "returns a few active orders",
+			queryParams: map[string]string{
+				"userOsmoAddress": "osmo1ugku28hwyexpljrrmtet05nd6kjlrvr9jz6z00",
+			},
+			setupMocks: func(usecase *mocks.OrderbookUsecaseMock) {
+				usecase.GetActiveOrdersFunc = func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+					return []orderbookdomain.LimitOrder{
+						s.NewLimitOrder().WithOrderID(1).LimitOrder,
+						s.NewLimitOrder().WithOrderID(2).LimitOrder,
+					}, false, nil
+				}
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   s.MustReadFile("../../../orderbook/usecase/orderbooktesting/parsing/active_orders_response.json"),
+			expectedError:      false,
+		},
+		{
+			name: "internal server error from usecase",
+			queryParams: map[string]string{
+				"userOsmoAddress": "osmo1ev0vtddkl7jlwfawlk06yzncapw2x9quva4wzw",
+			},
+			setupMocks: func(usecase *mocks.OrderbookUsecaseMock) {
+				usecase.GetActiveOrdersFunc = func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+					return nil, false, assert.AnError
+				}
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedResponse:   fmt.Sprintf(`{"message":"%s"}`, types.ErrInternalError.Error()),
+			expectedError:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			e := echo.New()
+			req := httptest.NewRequest(echo.GET, "/", nil)
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			q := req.URL.Query()
+			for k, v := range tc.queryParams {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			// Set up the mocks
+			usecase := mocks.OrderbookUsecaseMock{}
+			if tc.setupMocks != nil {
+				tc.setupMocks(&usecase)
+			}
+
+			// Initialize the handler with mocked usecase
+			handler := passthroughdelivery.PassthroughHandler{OUsecase: &usecase}
+
+			// Call the method under test
+			err := handler.GetActiveOrders(c)
+
+			// Check the error condition
+			if tc.expectedError {
+				s.Assert().Nil(err)
+			} else {
+				s.Assert().NoError(err)
+			}
+
+			// Check the response
+			s.Assert().Equal(tc.expectedStatusCode, rec.Code)
+			s.Assert().JSONEq(tc.expectedResponse, strings.TrimSpace(rec.Body.String()))
+		})
+	}
+}

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -168,7 +168,7 @@ func getStatusCode(err error) int {
 // @Produce  json
 // @Param  base  query  string  true  "Base denom"
 // @Param  quote  query  string  true  "Quote denom"
-// @Success 200  struct domain.CanonicalOrderBooksResult  "Canonical Orderbook Pool ID for the given base and quote"
+// @Success 200  {object} domain.CanonicalOrderBooksResult  "Canonical Orderbook Pool ID for the given base and quote"
 // @Router /pools/canonical-orderbook [get]
 func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 	base := c.QueryParam("base")

--- a/router/usecase/routertesting/suite.go
+++ b/router/usecase/routertesting/suite.go
@@ -1,6 +1,7 @@
 package routertesting
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -456,4 +457,14 @@ func PrepareValidSortedRouterPools(pools []sqsdomain.PoolI, minPoolLiquidityCap 
 	poolsAboveMinLiquidity := routerusecase.FilterPoolsByMinLiquidity(sortedPools, minPoolLiquidityCap)
 
 	return poolsAboveMinLiquidity
+}
+
+// ErrorIsAs first checks whether target error is equal to expectedError, if not, it checks whether
+// at least one of the errors in target's chain matches expectedError.
+func (s *RouterTestHelper) ErrorIsAs(target error, expectedError error) {
+	if errors.Is(target, expectedError) {
+		s.Assert().ErrorIs(target, expectedError)
+	} else {
+		s.Assert().ErrorAs(target, expectedError)
+	}
 }


### PR DESCRIPTION
This PR introduces unit tests for Orderbook usecase `GetActiveOrders` method. The aim of the tests are to cover edge cases as well as successful scenario.

```
❯ go test ./orderbook/usecase -run "TestOrderbookUsecaseTestSuite/TestGetActiveOrders" -v
=== RUN   TestOrderbookUsecaseTestSuite
=== RUN   TestOrderbookUsecaseTestSuite/TestGetActiveOrders
=== RUN   TestOrderbookUsecaseTestSuite/TestGetActiveOrders/failed_to_get_all_canonical_orderbook_pool_IDs
=== RUN   TestOrderbookUsecaseTestSuite/TestGetActiveOrders/context_is_done_before_processing_all_orderbooks
=== RUN   TestOrderbookUsecaseTestSuite/TestGetActiveOrders/processOrderBookActiveOrders_returns_an_error
=== RUN   TestOrderbookUsecaseTestSuite/TestGetActiveOrders/isBestEffort_set_to_true_when_one_orderbook_is_processed_with_best_effort
=== RUN   TestOrderbookUsecaseTestSuite/TestGetActiveOrders/successful_retrieval_of_active_orders
--- PASS: TestOrderbookUsecaseTestSuite (0.03s)
    --- PASS: TestOrderbookUsecaseTestSuite/TestGetActiveOrders (0.03s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestGetActiveOrders/failed_to_get_all_canonical_orderbook_pool_IDs (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestGetActiveOrders/context_is_done_before_processing_all_orderbooks (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestGetActiveOrders/processOrderBookActiveOrders_returns_an_error (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestGetActiveOrders/isBestEffort_set_to_true_when_one_orderbook_is_processed_with_best_effort (0.00s)
        --- PASS: TestOrderbookUsecaseTestSuite/TestGetActiveOrders/successful_retrieval_of_active_orders (0.00s)
PASS
ok      github.com/osmosis-labs/sqs/orderbook/usecase   (cached)

```