### PR TITLE
chore: update sqsdomain to tagged v26 osmosis node

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,8 @@ require (
 	github.com/labstack/echo/v4 v4.12.0
 	github.com/osmosis-labs/osmosis/osmomath v0.0.13
 	github.com/osmosis-labs/osmosis/osmoutils v0.0.13
-	github.com/osmosis-labs/osmosis/v26 v26.0.0-20240827120025-dd5be6c09d02
-	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240827051322-39476f7c3dd9
+	github.com/osmosis-labs/osmosis/v26 v26.0.0-rc1
+	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240829164133-a141f0387bc1
 	github.com/prometheus/client_golang v1.20.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.19.0
@@ -280,8 +280,6 @@ replace (
 	github.com/osmosis-labs/osmosis/v26 => github.com/osmosis-labs/osmosis/v26 v26.0.0-20240827120025-dd5be6c09d02
 	github.com/osmosis-labs/osmosis/x/epochs => github.com/osmosis-labs/osmosis/x/epochs v0.0.5-0.20240825083448-87db4447a1ff
 	github.com/osmosis-labs/osmosis/x/ibc-hooks => github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20240825083448-87db4447a1ff
-
-	github.com/osmosis-labs/sqs/sqsdomain => ./sqsdomain
 
 	// replace as directed by sdk upgrading.md https://github.com/cosmos/cosmos-sdk/blob/393de266c8675dc16cc037c1a15011b1e990975f/UPGRADING.md?plain=1#L713
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/go.sum
+++ b/go.sum
@@ -894,6 +894,8 @@ github.com/osmosis-labs/osmosis/x/epochs v0.0.5-0.20240825083448-87db4447a1ff h1
 github.com/osmosis-labs/osmosis/x/epochs v0.0.5-0.20240825083448-87db4447a1ff/go.mod h1:7ylCTvH4gEtZ5E8paiwSjmOzOKOOls8Br45W9uwWnP0=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20240825083448-87db4447a1ff h1:OZGMwv/Km6xnIB16d4zghFf0x7K9JlWqRaxgOVBIv7Y=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20240825083448-87db4447a1ff/go.mod h1:AXHoG4L1AMDCMEGeSdzcy7ik2mBt5fTyzEAWlGt+aSc=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240829164133-a141f0387bc1 h1:Gzj7QJMvObV9MO+G4x8LaDldch4wNuXV5V4VId4DRsY=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240829164133-a141f0387bc1/go.mod h1:VeL3pCCrxfzKyxI4JStbKR9hvC6g5yLrBNxXzFYeiqs=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=

--- a/sqsdomain/go.mod
+++ b/sqsdomain/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.50.9
 	github.com/json-iterator/go v1.1.12
 	github.com/osmosis-labs/osmosis/osmomath v0.0.13
-	github.com/osmosis-labs/osmosis/v26 v26.0.0-20240825083448-87db4447a1ff
+	github.com/osmosis-labs/osmosis/v26 v26.0.0-rc1
 	github.com/osmosis-labs/sqs v0.19.2-rc2.0.20240826173240-e5733bb3700d
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.65.0


### PR DESCRIPTION
### Description

update sqs domain to tagged v26