### PR TITLE
SQS-346 | handler tests, swagger API

### DIFF
--- a/.swaggo
+++ b/.swaggo
@@ -1,0 +1,5 @@
+// Swagger overrides file
+// @link https://github.com/swaggo/swag?tab=readme-ov-file#use-global-overrides-to-support-a-custom-type
+
+// Replace all Dec with string 
+replace osmomath.Dec string

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ generate-mocks: mockery
 	bin/mockery --config mockery.yaml
 
 swagger-gen:
-	$(HOME)/go/bin/swag init -g app/main.go
+	$(HOME)/go/bin/swag init -g app/main.go --pd --overridesFile ./.swaggo
 
 run:
 	go run -ldflags="-X github.com/osmosis-labs/sqs/version=${VERSION}" app/*.go  --config config.json

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -15,6 +15,44 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/passthrough/active-orders": {
+            "get": {
+                "description": "The returned data represents all active orders for all orderbooks available for the specified address.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Returns all active orderbook orders associated with the given address.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Osmo wallet address",
+                        "name": "userOsmoAddress",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of active orders for all available orderboooks for the given address",
+                        "schema": {
+                            "type": "struct"
+                        }
+                    },
+                    "400": {
+                        "description": "Response error",
+                        "schema": {
+                            "type": "struct"
+                        }
+                    },
+                    "500": {
+                        "description": "Response error",
+                        "schema": {
+                            "type": "struct"
+                        }
+                    }
+                }
+            }
+        },
         "/passthrough/portfolio-assets/{address}": {
             "get": {
                 "description": "The returned data represents the potfolio asset breakdown by category for the specified address.",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -35,19 +35,19 @@ const docTemplate = `{
                     "200": {
                         "description": "List of active orders for all available orderboooks for the given address",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse"
                         }
                     },
                     "400": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     },
                     "500": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     }
                 }
@@ -73,13 +73,13 @@ const docTemplate = `{
                     "200": {
                         "description": "Portfolio assets by-category and capitalization of the entire account value",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult"
                         }
                     },
                     "500": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     }
                 }
@@ -151,7 +151,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Canonical Orderbook Pool ID for the given base and quote",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.CanonicalOrderBooksResult"
                         }
                     }
                 }
@@ -474,6 +474,14 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.ResponseError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Token": {
             "type": "object",
             "properties": {
@@ -499,6 +507,159 @@ const docTemplate = `{
                 "symbol": {
                     "description": "HumanDenom is the human readable denom, e.g. atom",
                     "type": "string"
+                }
+            }
+        },
+        "github_com_cosmos_cosmos-sdk_types.Coin": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "$ref": "#/definitions/types.Int"
+                },
+                "denom": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.Asset": {
+            "type": "object",
+            "properties": {
+                "symbol": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder": {
+            "type": "object",
+            "properties": {
+                "base_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "claim_bounty": {
+                    "type": "string"
+                },
+                "etas": {
+                    "type": "string"
+                },
+                "order_direction": {
+                    "type": "string"
+                },
+                "order_id": {
+                    "type": "integer"
+                },
+                "orderbookAddress": {
+                    "type": "string"
+                },
+                "output": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "percentClaimed": {
+                    "type": "string"
+                },
+                "percentFilled": {
+                    "type": "string"
+                },
+                "placed_at": {
+                    "type": "integer"
+                },
+                "placed_quantity": {
+                    "type": "string"
+                },
+                "placed_tx": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "quote_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus"
+                },
+                "tick_id": {
+                    "type": "integer"
+                },
+                "totalFilled": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus": {
+            "type": "string",
+            "enum": [
+                "open",
+                "partiallyFilled",
+                "filled",
+                "fullyClaimed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "StatusOpen",
+                "StatusPartiallyFilled",
+                "StatusFilled",
+                "StatusFullyClaimed",
+                "StatusCancelled"
+            ]
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult": {
+            "type": "object",
+            "properties": {
+                "cap_value": {
+                    "type": "string"
+                },
+                "coin": {
+                    "$ref": "#/definitions/github_com_cosmos_cosmos-sdk_types.Coin"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult": {
+            "type": "object",
+            "properties": {
+                "account_coins_result": {
+                    "description": "AccountCoinsResult represents coins only from user balances (contrary to TotalValueCap).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult"
+                    }
+                },
+                "capitalization": {
+                    "description": "Capitalization represents the total value of the assets in the portfolio.\nincludes capitalization of user balances, value in locks, bonding or unbonding\nas well as the concentrated positions.",
+                    "type": "string"
+                },
+                "is_best_effort": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult": {
+            "type": "object",
+            "properties": {
+                "categories": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult"
+                    }
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse": {
+            "type": "object",
+            "properties": {
+                "is_best_effort": {
+                    "type": "boolean"
+                },
+                "orders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder"
+                    }
                 }
             }
         },
@@ -546,6 +707,9 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "types.Int": {
+            "type": "object"
         }
     }
 }`

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6,6 +6,44 @@
         "version": "1.0"
     },
     "paths": {
+        "/passthrough/active-orders": {
+            "get": {
+                "description": "The returned data represents all active orders for all orderbooks available for the specified address.",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Returns all active orderbook orders associated with the given address.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Osmo wallet address",
+                        "name": "userOsmoAddress",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of active orders for all available orderboooks for the given address",
+                        "schema": {
+                            "type": "struct"
+                        }
+                    },
+                    "400": {
+                        "description": "Response error",
+                        "schema": {
+                            "type": "struct"
+                        }
+                    },
+                    "500": {
+                        "description": "Response error",
+                        "schema": {
+                            "type": "struct"
+                        }
+                    }
+                }
+            }
+        },
         "/passthrough/portfolio-assets/{address}": {
             "get": {
                 "description": "The returned data represents the potfolio asset breakdown by category for the specified address.",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -26,19 +26,19 @@
                     "200": {
                         "description": "List of active orders for all available orderboooks for the given address",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse"
                         }
                     },
                     "400": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     },
                     "500": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     }
                 }
@@ -64,13 +64,13 @@
                     "200": {
                         "description": "Portfolio assets by-category and capitalization of the entire account value",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult"
                         }
                     },
                     "500": {
                         "description": "Response error",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.ResponseError"
                         }
                     }
                 }
@@ -142,7 +142,7 @@
                     "200": {
                         "description": "Canonical Orderbook Pool ID for the given base and quote",
                         "schema": {
-                            "type": "struct"
+                            "$ref": "#/definitions/domain.CanonicalOrderBooksResult"
                         }
                     }
                 }
@@ -465,6 +465,14 @@
                 }
             }
         },
+        "domain.ResponseError": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Token": {
             "type": "object",
             "properties": {
@@ -490,6 +498,159 @@
                 "symbol": {
                     "description": "HumanDenom is the human readable denom, e.g. atom",
                     "type": "string"
+                }
+            }
+        },
+        "github_com_cosmos_cosmos-sdk_types.Coin": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "$ref": "#/definitions/types.Int"
+                },
+                "denom": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.Asset": {
+            "type": "object",
+            "properties": {
+                "symbol": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder": {
+            "type": "object",
+            "properties": {
+                "base_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "claim_bounty": {
+                    "type": "string"
+                },
+                "etas": {
+                    "type": "string"
+                },
+                "order_direction": {
+                    "type": "string"
+                },
+                "order_id": {
+                    "type": "integer"
+                },
+                "orderbookAddress": {
+                    "type": "string"
+                },
+                "output": {
+                    "type": "string"
+                },
+                "owner": {
+                    "type": "string"
+                },
+                "percentClaimed": {
+                    "type": "string"
+                },
+                "percentFilled": {
+                    "type": "string"
+                },
+                "placed_at": {
+                    "type": "integer"
+                },
+                "placed_quantity": {
+                    "type": "string"
+                },
+                "placed_tx": {
+                    "type": "string"
+                },
+                "price": {
+                    "type": "string"
+                },
+                "quantity": {
+                    "type": "string"
+                },
+                "quote_asset": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset"
+                },
+                "status": {
+                    "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus"
+                },
+                "tick_id": {
+                    "type": "integer"
+                },
+                "totalFilled": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus": {
+            "type": "string",
+            "enum": [
+                "open",
+                "partiallyFilled",
+                "filled",
+                "fullyClaimed",
+                "cancelled"
+            ],
+            "x-enum-varnames": [
+                "StatusOpen",
+                "StatusPartiallyFilled",
+                "StatusFilled",
+                "StatusFullyClaimed",
+                "StatusCancelled"
+            ]
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult": {
+            "type": "object",
+            "properties": {
+                "cap_value": {
+                    "type": "string"
+                },
+                "coin": {
+                    "$ref": "#/definitions/github_com_cosmos_cosmos-sdk_types.Coin"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult": {
+            "type": "object",
+            "properties": {
+                "account_coins_result": {
+                    "description": "AccountCoinsResult represents coins only from user balances (contrary to TotalValueCap).",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult"
+                    }
+                },
+                "capitalization": {
+                    "description": "Capitalization represents the total value of the assets in the portfolio.\nincludes capitalization of user balances, value in locks, bonding or unbonding\nas well as the concentrated positions.",
+                    "type": "string"
+                },
+                "is_best_effort": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult": {
+            "type": "object",
+            "properties": {
+                "categories": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult"
+                    }
+                }
+            }
+        },
+        "github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse": {
+            "type": "object",
+            "properties": {
+                "is_best_effort": {
+                    "type": "boolean"
+                },
+                "orders": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder"
+                    }
                 }
             }
         },
@@ -537,6 +698,9 @@
                     }
                 }
             }
+        },
+        "types.Int": {
+            "type": "object"
         }
     }
 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -64,6 +64,33 @@ info:
   title: Osmosis Sidecar Query Server Example API
   version: "1.0"
 paths:
+  /passthrough/active-orders:
+    get:
+      description: The returned data represents all active orders for all orderbooks
+        available for the specified address.
+      parameters:
+      - description: Osmo wallet address
+        in: query
+        name: userOsmoAddress
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: List of active orders for all available orderboooks for the
+            given address
+          schema:
+            type: struct
+        "400":
+          description: Response error
+          schema:
+            type: struct
+        "500":
+          description: Response error
+          schema:
+            type: struct
+      summary: Returns all active orderbook orders associated with the given address.
   /passthrough/portfolio-assets/{address}:
     get:
       description: The returned data represents the potfolio asset breakdown by category

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -10,6 +10,11 @@ definitions:
       quote:
         type: string
     type: object
+  domain.ResponseError:
+    properties:
+      message:
+        type: string
+    type: object
   domain.Token:
     properties:
       coinMinimalDenom:
@@ -29,6 +34,113 @@ definitions:
       symbol:
         description: HumanDenom is the human readable denom, e.g. atom
         type: string
+    type: object
+  github_com_cosmos_cosmos-sdk_types.Coin:
+    properties:
+      amount:
+        $ref: '#/definitions/types.Int'
+      denom:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.Asset:
+    properties:
+      symbol:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder:
+    properties:
+      base_asset:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset'
+      claim_bounty:
+        type: string
+      etas:
+        type: string
+      order_direction:
+        type: string
+      order_id:
+        type: integer
+      orderbookAddress:
+        type: string
+      output:
+        type: string
+      owner:
+        type: string
+      percentClaimed:
+        type: string
+      percentFilled:
+        type: string
+      placed_at:
+        type: integer
+      placed_quantity:
+        type: string
+      placed_tx:
+        type: string
+      price:
+        type: string
+      quantity:
+        type: string
+      quote_asset:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.Asset'
+      status:
+        $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus'
+      tick_id:
+        type: integer
+      totalFilled:
+        type: string
+    type: object
+  github_com_osmosis-labs_sqs_domain_orderbook.OrderStatus:
+    enum:
+    - open
+    - partiallyFilled
+    - filled
+    - fullyClaimed
+    - cancelled
+    type: string
+    x-enum-varnames:
+    - StatusOpen
+    - StatusPartiallyFilled
+    - StatusFilled
+    - StatusFullyClaimed
+    - StatusCancelled
+  github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult:
+    properties:
+      cap_value:
+        type: string
+      coin:
+        $ref: '#/definitions/github_com_cosmos_cosmos-sdk_types.Coin'
+    type: object
+  github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult:
+    properties:
+      account_coins_result:
+        description: AccountCoinsResult represents coins only from user balances (contrary
+          to TotalValueCap).
+        items:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.AccountCoinsResult'
+        type: array
+      capitalization:
+        description: |-
+          Capitalization represents the total value of the assets in the portfolio.
+          includes capitalization of user balances, value in locks, bonding or unbonding
+          as well as the concentrated positions.
+        type: string
+      is_best_effort:
+        type: boolean
+    type: object
+  github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult:
+    properties:
+      categories:
+        additionalProperties:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsCategoryResult'
+        type: object
+    type: object
+  github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse:
+    properties:
+      is_best_effort:
+        type: boolean
+      orders:
+        items:
+          $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_orderbook.LimitOrder'
+        type: array
     type: object
   sqsdomain.CandidatePool:
     properties:
@@ -59,6 +171,8 @@ definitions:
           type: object
         type: object
     type: object
+  types.Int:
+    type: object
 info:
   contact: {}
   title: Osmosis Sidecar Query Server Example API
@@ -81,15 +195,15 @@ paths:
           description: List of active orders for all available orderboooks for the
             given address
           schema:
-            type: struct
+            $ref: '#/definitions/github_com_osmosis-labs_sqs_orderbook_types.GetActiveOrdersResponse'
         "400":
           description: Response error
           schema:
-            type: struct
+            $ref: '#/definitions/domain.ResponseError'
         "500":
           description: Response error
           schema:
-            type: struct
+            $ref: '#/definitions/domain.ResponseError'
       summary: Returns all active orderbook orders associated with the given address.
   /passthrough/portfolio-assets/{address}:
     get:
@@ -108,11 +222,11 @@ paths:
           description: Portfolio assets by-category and capitalization of the entire
             account value
           schema:
-            type: struct
+            $ref: '#/definitions/github_com_osmosis-labs_sqs_domain_passthrough.PortfolioAssetsResult'
         "500":
           description: Response error
           schema:
-            type: struct
+            $ref: '#/definitions/domain.ResponseError'
       summary: Returns portfolio assets associated with the given address by category.
   /pools:
     get:
@@ -165,7 +279,7 @@ paths:
         "200":
           description: Canonical Orderbook Pool ID for the given base and quote
           schema:
-            type: struct
+            $ref: '#/definitions/domain.CanonicalOrderBooksResult'
       summary: Get canonical orderbook pool ID for the given base and quote.
   /pools/canonical-orderbooks:
     get:

--- a/domain/mocks/orderbook_usecase_mock.go
+++ b/domain/mocks/orderbook_usecase_mock.go
@@ -1,0 +1,39 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/osmosis-labs/sqs/domain/mvc"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/sqsdomain"
+)
+
+var _ mvc.OrderBookUsecase = &OrderbookUsecaseMock{}
+
+// OrderbookUsecaseMock is a mock implementation of the RouterUsecase interface
+type OrderbookUsecaseMock struct {
+	ProcessPoolFunc     func(ctx context.Context, pool sqsdomain.PoolI) error
+	GetAllTicksFunc     func(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool)
+	GetActiveOrdersFunc func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
+}
+
+func (m *OrderbookUsecaseMock) ProcessPool(ctx context.Context, pool sqsdomain.PoolI) error {
+	if m.ProcessPoolFunc != nil {
+		return m.ProcessPoolFunc(ctx, pool)
+	}
+	panic("unimplemented")
+}
+
+func (m *OrderbookUsecaseMock) GetAllTicks(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool) {
+	if m.GetAllTicksFunc != nil {
+		return m.GetAllTicksFunc(poolID)
+	}
+	panic("unimplemented")
+}
+
+func (m *OrderbookUsecaseMock) GetActiveOrders(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+	if m.GetActiveOrdersFunc != nil {
+		return m.GetActiveOrdersFunc(ctx, address)
+	}
+	panic("unimplemented")
+}

--- a/orderbook/types/get_orders_request.go
+++ b/orderbook/types/get_orders_request.go
@@ -1,47 +1,40 @@
 package types
 
 import (
+	"fmt"
 	"sort"
-	"strconv"
 
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	"github.com/labstack/echo/v4"
+)
+
+var (
+	// ErrUserOsmoAddressInvalid is generic error returned when the user address is invalid.
+	ErrUserOsmoAddressInvalid = fmt.Errorf("userOsmoAddress is not valid osmo address")
+
+	ErrInternalError = fmt.Errorf("internal error")
 )
 
 // GetActiveOrdersRequest represents get orders request for the /pools/all-orders endpoint.
 type GetActiveOrdersRequest struct {
 	UserOsmoAddress string
-	Limit           int
-	Cursor          int
 }
 
 // UnmarshalHTTPRequest unmarshals the HTTP request to GetActiveOrdersRequest.
 func (r *GetActiveOrdersRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	r.UserOsmoAddress = c.QueryParam("userOsmoAddress")
-
-	if limit := c.QueryParam("limit"); limit != "" {
-		i, err := strconv.Atoi(limit)
-		if err != nil {
-			return err
-		}
-		r.Limit = i
-	}
-
-	if cursor := c.QueryParam("cursor"); cursor != "" {
-		i, err := strconv.Atoi(cursor)
-		if err != nil {
-			return err
-		}
-		r.Cursor = i
-	}
-
 	return nil
 }
 
 // Validate validates the GetActiveOrdersRequest.
-// TODO: implement validation rules
 func (r *GetActiveOrdersRequest) Validate() error {
+	_, err := sdk.AccAddressFromBech32(r.UserOsmoAddress)
+	if err != nil {
+		return ErrUserOsmoAddressInvalid
+	}
 	return nil
 }
 

--- a/orderbook/usecase/orderbooktesting/parsing/active_orders_response.json
+++ b/orderbook/usecase/orderbooktesting/parsing/active_orders_response.json
@@ -1,0 +1,53 @@
+{
+  "orders": [
+    {
+      "tick_id": 1,
+      "order_id": 1,
+      "order_direction": "bid",
+      "owner": "owner1",
+      "quantity": "1000.000000000000000000",
+      "etas": "500",
+      "claim_bounty": "10",
+      "placed_quantity": "1500.000000000000000000",
+      "placed_at": 1634,
+      "price": "1.000001000000000000",
+      "percentClaimed": "0.333333333333333333",
+      "totalFilled": "600.000000000000000000",
+      "percentFilled": "0.400000000000000000",
+      "orderbookAddress": "someOrderbookAddress",
+      "status": "partiallyFilled",
+      "output": "1499.998500001499998500",
+      "quote_asset": {
+        "symbol": ""
+      },
+      "base_asset": {
+        "symbol": ""
+      }
+    },
+    {
+      "tick_id": 1,
+      "order_id": 2,
+      "order_direction": "bid",
+      "owner": "owner1",
+      "quantity": "1000.000000000000000000",
+      "etas": "500",
+      "claim_bounty": "10",
+      "placed_quantity": "1500.000000000000000000",
+      "placed_at": 1634,
+      "price": "1.000001000000000000",
+      "percentClaimed": "0.333333333333333333",
+      "totalFilled": "600.000000000000000000",
+      "percentFilled": "0.400000000000000000",
+      "orderbookAddress": "someOrderbookAddress",
+      "status": "partiallyFilled",
+      "output": "1499.998500001499998500",
+      "quote_asset": {
+        "symbol": ""
+      },
+      "base_asset": {
+        "symbol": ""
+      }
+    }
+  ],
+  "is_best_effort": false
+}

--- a/passthrough/delivery/http/passthrough_handler.go
+++ b/passthrough/delivery/http/passthrough_handler.go
@@ -65,6 +65,17 @@ func (a *PassthroughHandler) GetPortfolioAssetsByAddress(c echo.Context) error {
 	return c.JSON(http.StatusOK, portfolioAssetsResult)
 }
 
+// @Summary Returns all active orderbook orders associated with the given address.
+// @Description The returned data represents all active orders for all orderbooks available for the specified address.
+//
+// The is_best_effort flag indicates whether the error occurred while processing the orders due which not all orders were returned in the response.
+//
+// @Produce  json
+// @Success 200           struct  []orderbookdomain.LimitOrder  "List of active orders for all available orderboooks for the given address"
+// @Failure 400           struct  ResponseError                 "Response error"
+// @Failure 500           struct  ResponseError                 "Response error"
+// @Param  userOsmoAddress  query  string  true  "Osmo wallet address"
+// @Router /passthrough/active-orders [get]
 func (a *PassthroughHandler) GetActiveOrders(c echo.Context) (err error) {
 	ctx := c.Request().Context()
 
@@ -91,7 +102,7 @@ func (a *PassthroughHandler) GetActiveOrders(c echo.Context) (err error) {
 
 	orders, isBestEffort, err := a.OUsecase.GetActiveOrders(ctx, req.UserOsmoAddress)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: err.Error()})
+		return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: types.ErrInternalError.Error()})
 	}
 
 	resp := types.NewGetAllOrderResponse(orders, isBestEffort)

--- a/passthrough/delivery/http/passthrough_handler_test.go
+++ b/passthrough/delivery/http/passthrough_handler_test.go
@@ -1,0 +1,117 @@
+package http_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/osmosis-labs/sqs/domain/mocks"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/orderbook/types"
+	"github.com/osmosis-labs/sqs/orderbook/usecase/orderbooktesting"
+	passthroughdelivery "github.com/osmosis-labs/sqs/passthrough/delivery/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type PassthroughHandlerTestSuite struct {
+	orderbooktesting.OrderbookTestHelper
+}
+
+func TestPassthroughHandlerSuite(t *testing.T) {
+	suite.Run(t, new(PassthroughHandlerTestSuite))
+}
+
+func (s *PassthroughHandlerTestSuite) TestGetActiveOrders() {
+	testCases := []struct {
+		name               string
+		queryParams        map[string]string
+		setupMocks         func(usecase *mocks.OrderbookUsecaseMock)
+		expectedStatusCode int
+		expectedResponse   string
+		expectedError      bool
+	}{
+		{
+			name:               "validation error",
+			queryParams:        map[string]string{},
+			setupMocks:         func(usecase *mocks.OrderbookUsecaseMock) {},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   fmt.Sprintf(`{"message":"%s"}`, types.ErrUserOsmoAddressInvalid.Error()),
+			expectedError:      true,
+		},
+		{
+			name: "returns a few active orders",
+			queryParams: map[string]string{
+				"userOsmoAddress": "osmo1ugku28hwyexpljrrmtet05nd6kjlrvr9jz6z00",
+			},
+			setupMocks: func(usecase *mocks.OrderbookUsecaseMock) {
+				usecase.GetActiveOrdersFunc = func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+					return []orderbookdomain.LimitOrder{
+						s.NewLimitOrder().WithOrderID(1).LimitOrder,
+						s.NewLimitOrder().WithOrderID(2).LimitOrder,
+					}, false, nil
+				}
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   s.MustReadFile("../../../orderbook/usecase/orderbooktesting/parsing/active_orders_response.json"),
+			expectedError:      false,
+		},
+		{
+			name: "internal server error from usecase",
+			queryParams: map[string]string{
+				"userOsmoAddress": "osmo1ev0vtddkl7jlwfawlk06yzncapw2x9quva4wzw",
+			},
+			setupMocks: func(usecase *mocks.OrderbookUsecaseMock) {
+				usecase.GetActiveOrdersFunc = func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
+					return nil, false, assert.AnError
+				}
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedResponse:   fmt.Sprintf(`{"message":"%s"}`, types.ErrInternalError.Error()),
+			expectedError:      true,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			e := echo.New()
+			req := httptest.NewRequest(echo.GET, "/", nil)
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			q := req.URL.Query()
+			for k, v := range tc.queryParams {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			// Set up the mocks
+			usecase := mocks.OrderbookUsecaseMock{}
+			if tc.setupMocks != nil {
+				tc.setupMocks(&usecase)
+			}
+
+			// Initialize the handler with mocked usecase
+			handler := passthroughdelivery.PassthroughHandler{OUsecase: &usecase}
+
+			// Call the method under test
+			err := handler.GetActiveOrders(c)
+
+			// Check the error condition
+			if tc.expectedError {
+				s.Assert().Nil(err)
+			} else {
+				s.Assert().NoError(err)
+			}
+
+			// Check the response
+			s.Assert().Equal(tc.expectedStatusCode, rec.Code)
+			s.Assert().JSONEq(tc.expectedResponse, strings.TrimSpace(rec.Body.String()))
+		})
+	}
+}

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -168,7 +168,7 @@ func getStatusCode(err error) int {
 // @Produce  json
 // @Param  base  query  string  true  "Base denom"
 // @Param  quote  query  string  true  "Quote denom"
-// @Success 200  struct domain.CanonicalOrderBooksResult  "Canonical Orderbook Pool ID for the given base and quote"
+// @Success 200  {object} domain.CanonicalOrderBooksResult  "Canonical Orderbook Pool ID for the given base and quote"
 // @Router /pools/canonical-orderbook [get]
 func (a *PoolsHandler) GetCanonicalOrderbook(c echo.Context) error {
 	base := c.QueryParam("base")


### PR DESCRIPTION
Implements unit tests for the orderbook active orders handler and adds swagger API for the endpoint.

```
❯ go test ./passthrough/delivery/http -run "TestPassthroughHandlerSuite" -v
=== RUN   TestPassthroughHandlerSuite
=== RUN   TestPassthroughHandlerSuite/TestGetActiveOrders
=== RUN   TestPassthroughHandlerSuite/TestGetActiveOrders/validation_error
=== RUN   TestPassthroughHandlerSuite/TestGetActiveOrders/returns_a_few_active_orders
=== RUN   TestPassthroughHandlerSuite/TestGetActiveOrders/internal_server_error_from_usecase
--- PASS: TestPassthroughHandlerSuite (0.03s)
    --- PASS: TestPassthroughHandlerSuite/TestGetActiveOrders (0.03s)
        --- PASS: TestPassthroughHandlerSuite/TestGetActiveOrders/validation_error (0.00s)
        --- PASS: TestPassthroughHandlerSuite/TestGetActiveOrders/returns_a_few_active_orders (0.00s)
        --- PASS: TestPassthroughHandlerSuite/TestGetActiveOrders/internal_server_error_from_usecase (0.00s)
PASS
ok      github.com/osmosis-labs/sqs/passthrough/delivery/http   0.093s
```

Swagger API:

![image](https://github.com/user-attachments/assets/2ded983e-220b-44c0-8f23-e5c666e9b1d4)

---

Additionally this PR fixes parsing response objects for a several other endpoints for a Swagger API.
