### PR TITLE
Fix sqsdomain package version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/osmosis-labs/osmosis/osmomath v0.0.13
 	github.com/osmosis-labs/osmosis/osmoutils v0.0.13
 	github.com/osmosis-labs/osmosis/v25 v25.0.2-0.20240524131320-44f70454a543
-	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810225250-04d58c7c19a0
+	github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240823173943-3e62a5a6700c
 	github.com/prometheus/client_golang v1.19.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.18.2
@@ -58,7 +58,7 @@ require (
 	cosmossdk.io/api v0.3.1
 	cosmossdk.io/core v0.5.1 // indirect
 	cosmossdk.io/depinject v1.0.0-alpha.4 // indirect
-	cosmossdk.io/errors v1.0.1 // indirect
+	cosmossdk.io/errors v1.0.1
 	cosmossdk.io/log v1.3.0 // indirect
 	cosmossdk.io/tools/rosetta v0.2.1 // indirect
 	filippo.io/edwards25519 v1.0.0 // indirect
@@ -90,7 +90,7 @@ require (
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
-	github.com/cosmos/gogoproto v1.4.11 // indirect
+	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/iavl v1.1.2-0.20240405173644-e52f7630d3b7 // indirect
 	github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7 v7.1.3 // indirect
 	github.com/cosmos/ibc-apps/modules/async-icq/v7 v7.1.1 // indirect
@@ -218,7 +218,7 @@ require (
 	go.etcd.io/bbolt v1.3.8 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0
-	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -905,8 +905,10 @@ github.com/osmosis-labs/osmosis/x/epochs v0.0.9 h1:KKNMuoGlGv3yxmh+hF5yIqjYbxjXW
 github.com/osmosis-labs/osmosis/x/epochs v0.0.9/go.mod h1:jROhCibKGjWW1IyPaCFUIEJ9P25S0VawgIpWRxcqYqQ=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.15 h1:bUBZwiMibgQWQQSqyMPqj0p54hpsDwbkCpNROWdWYJk=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.15/go.mod h1:c72yyA6FvQNgOm/NxQuDXQfRpYy2JCJpf1o+G4kFuyM=
-github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810225250-04d58c7c19a0 h1:tKCEThvtPd6N8+6Kkbk4m91MIgDkRrv4i4PtXBaUXeM=
-github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240810225250-04d58c7c19a0/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240823173943-3e62a5a6700c h1:e3HT5VKyiQDuOQDjgxzg/h0icH8rbjlyTM4hmLXxfo4=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.4-0.20240823173943-3e62a5a6700c/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.5 h1:xigpJMR7Jlf8ZgPdJ3JlSVPQ88lRWw198bt809I8lZs=
+github.com/osmosis-labs/sqs/sqsdomain v0.18.5/go.mod h1:PInk1hZ2DQ0Kd9tHSafPgXdavdyXQyNysVF4FNzo1eU=
 github.com/osmosis-labs/wasmd v0.45.0-osmo h1:NIp7pvJV5HuBN1HwPgEmXKQM2TjVIVdJErIHnB9IMO8=
 github.com/osmosis-labs/wasmd v0.45.0-osmo/go.mod h1:J6eRvwii5T1WxhetZkBg1kOJS3GTn1Bw2OLyZBb8EVU=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=


### PR DESCRIPTION
Old version of `v0.18.4-0.20240810225250-04d58c7c19a0` does not longer works and causes build errors, orginally noticed [here](https://github.com/osmosis-labs/sqs/actions/runs/10789483056/job/29928134749). This PR fixes/bumps `sqsdomain` package version to fix an error.

```
#16 1.835 (22/22) Installing linux-headers (6.6-r0)
#16 1.953 Executing busybox-1.36.1-r29.trigger
#16 1.960 OK: 233 MiB in 37 packages
#16 2.025 + go mod download
#16 59.91 go: github.com/osmosis-labs/sqs/sqsdomain@v0.18.4-0.20240810225250-04d58c7c19a0: git init --bare in /go/pkg/mod/cache/vcs/9836731457b120de50ddba96f7ca828cbaa328ebb43584908b8a45a9a1a1a74e: exec: "git": executable file not found in $PATH
#16 ERROR: process "/bin/sh -c set -eux; apk add --no-cache ca-certificates build-base linux-headers &&     go mod download" did not complete successfully: exit code: 1
------
 > [builder 5/7] RUN set -eux; apk add --no-cache ca-certificates build-base linux-headers &&     go mod download:
1.590 (17/22) Installing g++ (13.2.1_git20240309-r0)
1.796 (18/22) Installing make (4.4.1-r2)
1.807 (19/22) Installing fortify-headers (1.1-r3)
1.817 (20/22) Installing patch (2.7.6-r10)
1.827 (21/22) Installing build-base (0.5-r3)
1.835 (22/22) Installing linux-headers (6.6-r0)
1.953 Executing busybox-1.36.1-r29.trigger
1.960 OK: 233 MiB in 37 packages
2.025 + go mod download
59.91 go: github.com/osmosis-labs/sqs/sqsdomain@v0.18.4-0.20240810225250-04d58c7c19a0: git init --bare in /go/pkg/mod/cache/vcs/9836731457b120de50ddba96f7ca828cbaa328ebb43584908b8a45a9a1a1a74e: exec: "git": executable file not found in $PATH
------

 2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 42)
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 10)
Dockerfile:20
--------------------
  19 |     
  20 | >>> RUN set -eux; apk add --no-cache ca-certificates build-base linux-headers && \
  21 | >>>     go mod download
  22 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c set -eux; apk add --no-cache ca-certificates build-base linux-headers &&     go mod download" did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c set -eux; apk add --no-cache ca-certificates build-base linux-headers &&     go mod download" did not complete successfully: exit code: 1`
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Chores**
	- Updated dependencies to ensure compatibility and incorporate potential improvements and bug fixes.
	- Minor formatting adjustments made to the dependency declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->