### PR TITLE
SQS-406 | E2E Tests: Increase expected latency upper bound for /passthrough/active-orders enpoint

### DIFF
--- a/tests/test_passthrough.py
+++ b/tests/test_passthrough.py
@@ -9,7 +9,7 @@ from e2e_math import *
 from decimal import *
 
 # Arbitrary choice based on performance at the time of test writing
-EXPECTED_LATENCY_UPPER_BOUND_MS = 150
+EXPECTED_LATENCY_UPPER_BOUND_MS = 450
 
 user_balances_assets_category_name = "user-balances"
 unstaking_assets_category_name = "unstaking"


### PR DESCRIPTION
This PR Increases latency upper bound from 150ms to 450ms based on our current observations via monitoring tools to make tests less noisy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the expected latency threshold to accommodate higher latency values, which may improve test reliability under varying performance conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->