### PR TITLE
SQS-412 | Active Orders Query: SSE

### DIFF
--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -203,7 +203,7 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 
 	// HTTP handlers
 	poolsHttpDelivery.NewPoolsHandler(e, poolsUseCase)
-	passthroughHttpDelivery.NewPassthroughHandler(e, passthroughUseCase, orderBookUseCase)
+	passthroughHttpDelivery.NewPassthroughHandler(e, passthroughUseCase, orderBookUseCase, logger)
 	systemhttpdelivery.NewSystemHandler(e, config, logger, chainInfoUseCase)
 	if err := tokenshttpdelivery.NewTokensHandler(e, *config.Pricing, tokensUseCase, pricingSimpleRouterUsecase, logger); err != nil {
 		return nil, err

--- a/delivery/http/event.go
+++ b/delivery/http/event.go
@@ -1,0 +1,98 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/labstack/echo/v4"
+)
+
+// Event represents Server-Sent Event.
+// SSE explanation: https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format
+type Event struct {
+	// ID is used to set the EventSource object's last event ID value.
+	ID []byte
+	// Data field is for the message. When the EventSource receives multiple consecutive lines
+	// that begin with data:, it concatenates them, inserting a newline character between each one.
+	// Trailing newlines are removed.
+	Data []byte
+	// Event is a string identifying the type of event described. If this is specified, an event
+	// will be dispatched on the browser to the listener for the specified event name; the website
+	// source code should use addEventListener() to listen for named events. The onmessage handler
+	// is called if no event name is specified for a message.
+	Event []byte
+	// Retry is the reconnection time. If the connection to the server is lost, the browser will
+	// wait for the specified time before attempting to reconnect. This must be an integer, specifying
+	// the reconnection time in milliseconds. If a non-integer value is specified, the field is ignored.
+	Retry []byte
+	// Comment line can be used to prevent connections from timing out; a server can send a comment
+	// periodically to keep the connection alive.
+	Comment []byte
+}
+
+// MarshalTo marshals Event to given Writer
+func (ev *Event) MarshalTo(w io.Writer) error {
+	// Marshalling part is taken from: https://github.com/r3labs/sse/blob/c6d5381ee3ca63828b321c16baa008fd6c0b4564/http.go#L16
+	if len(ev.Data) == 0 && len(ev.Comment) == 0 {
+		return nil
+	}
+
+	if len(ev.Data) > 0 {
+		if _, err := fmt.Fprintf(w, "id: %s\n", ev.ID); err != nil {
+			return err
+		}
+
+		sd := bytes.Split(ev.Data, []byte("\n"))
+		for i := range sd {
+			if _, err := fmt.Fprintf(w, "data: %s\n", sd[i]); err != nil {
+				return err
+			}
+		}
+
+		if len(ev.Event) > 0 {
+			if _, err := fmt.Fprintf(w, "event: %s\n", ev.Event); err != nil {
+				return err
+			}
+		}
+
+		if len(ev.Retry) > 0 {
+			if _, err := fmt.Fprintf(w, "retry: %s\n", ev.Retry); err != nil {
+				return err
+			}
+		}
+	}
+
+	if len(ev.Comment) > 0 {
+		if _, err := fmt.Fprintf(w, ": %s\n", ev.Comment); err != nil {
+			return err
+		}
+	}
+
+	if _, err := fmt.Fprint(w, "\n"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// WriteEvent writes the given data to the given ResponseWriter as an Event.
+func WriteEvent(w *echo.Response, data any) error {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	event := Event{
+		Data: b,
+	}
+
+	if err := event.MarshalTo(w); err != nil {
+		return err
+	}
+
+	w.Flush()
+
+	return nil
+}

--- a/delivery/http/http.go
+++ b/delivery/http/http.go
@@ -2,6 +2,7 @@ package http
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/osmosis-labs/sqs/validator"
 )
 
 // RequestUnmarshaler is any type capable to unmarshal data from HTTP request to itself.
@@ -12,4 +13,18 @@ type RequestUnmarshaler interface {
 // UnmarshalRequest unmarshals HTTP request into m.
 func UnmarshalRequest(c echo.Context, m RequestUnmarshaler) error {
 	return m.UnmarshalHTTPRequest(c)
+}
+
+// ParseRequest encapsulates the request unmarshalling and validation logic.
+// It unmarshals the request and validates it if the request implements the Validator interface.
+func ParseRequest(c echo.Context, req RequestUnmarshaler) error {
+	if err := UnmarshalRequest(c, req); err != nil {
+		return err
+	}
+
+	v, ok := req.(validator.Validator)
+	if !ok {
+		return nil
+	}
+	return validator.Validate(v)
 }

--- a/delivery/http/trace.go
+++ b/delivery/http/trace.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"context"
+
+	"github.com/labstack/echo/v4"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Span returns the current span from the context.
+func Span(c echo.Context) (context.Context, trace.Span) {
+	ctx := c.Request().Context()
+	span := trace.SpanFromContext(ctx)
+	return ctx, span
+}
+
+// RecordSpanError records an error ( if any ) for the span.
+func RecordSpanError(ctx context.Context, span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+	}
+	// Note: we do not end the span here as it is ended in the middleware.
+}

--- a/domain/mocks/orderbook_usecase_mock.go
+++ b/domain/mocks/orderbook_usecase_mock.go
@@ -12,9 +12,10 @@ var _ mvc.OrderBookUsecase = &OrderbookUsecaseMock{}
 
 // OrderbookUsecaseMock is a mock implementation of the RouterUsecase interface
 type OrderbookUsecaseMock struct {
-	ProcessPoolFunc     func(ctx context.Context, pool sqsdomain.PoolI) error
-	GetAllTicksFunc     func(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool)
-	GetActiveOrdersFunc func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
+	ProcessPoolFunc           func(ctx context.Context, pool sqsdomain.PoolI) error
+	GetAllTicksFunc           func(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool)
+	GetActiveOrdersFunc       func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
+	GetActiveOrdersStreamFunc func(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult
 }
 
 func (m *OrderbookUsecaseMock) ProcessPool(ctx context.Context, pool sqsdomain.PoolI) error {
@@ -34,6 +35,13 @@ func (m *OrderbookUsecaseMock) GetAllTicks(poolID uint64) (map[int64]orderbookdo
 func (m *OrderbookUsecaseMock) GetActiveOrders(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
 	if m.GetActiveOrdersFunc != nil {
 		return m.GetActiveOrdersFunc(ctx, address)
+	}
+	panic("unimplemented")
+}
+
+func (m *OrderbookUsecaseMock) GetActiveOrdersStream(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult {
+	if m.GetActiveOrdersStreamFunc != nil {
+		return m.GetActiveOrdersStreamFunc(ctx, address)
 	}
 	panic("unimplemented")
 }

--- a/domain/mvc/orderbook.go
+++ b/domain/mvc/orderbook.go
@@ -18,7 +18,7 @@ type OrderBookUsecase interface {
 	GetActiveOrders(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
 
 	// GetActiveOrdersStream returns a channel for streaming limit orderbook orders for a given address.
-	// The caller should range over the channel, but note that channel is never closed since there may by multiple
+	// The caller should range over the channel, but note that channel is never closed since there may be multiple
 	// sender goroutines.
 	GetActiveOrdersStream(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult
 }

--- a/domain/mvc/orderbook.go
+++ b/domain/mvc/orderbook.go
@@ -16,4 +16,9 @@ type OrderBookUsecase interface {
 
 	// GetOrder returns all active orderbook orders for a given address.
 	GetActiveOrders(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
+
+	// GetActiveOrdersStream returns a channel for streaming limit orderbook orders for a given address.
+	// The caller should range over the channel, but note that channel is never closed since there may by multiple
+	// sender goroutines.
+	GetActiveOrdersStream(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult
 }

--- a/domain/orderbook/order.go
+++ b/domain/orderbook/order.go
@@ -72,6 +72,7 @@ type Asset struct {
 	Decimals int    `json:"-"`
 }
 
+// LimitOrder represents a limit order in the orderbook.
 type LimitOrder struct {
 	TickId           int64        `json:"tick_id"`
 	OrderId          int64        `json:"order_id"`
@@ -92,4 +93,12 @@ type LimitOrder struct {
 	QuoteAsset       Asset        `json:"quote_asset"`
 	BaseAsset        Asset        `json:"base_asset"`
 	PlacedTx         *string      `json:"placed_tx,omitempty"`
+}
+
+// OrderbookResult represents orderbook orders result.
+type OrderbookResult struct {
+	LimitOrders  []LimitOrder // The channel on which the orders are delivered.
+	PoolID       uint64       // The PoolID ID.
+	IsBestEffort bool
+	Error        error
 }

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -2,9 +2,16 @@ package orderbookusecase
 
 import (
 	"context"
+	"time"
+
 	"github.com/osmosis-labs/sqs/domain"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 )
+
+// SetFetchActiveOrdersEveryDuration overrides the fetchActiveOrdersDuration for testing purposes
+func (o *OrderbookUseCaseImpl) SetFetchActiveOrdersEveryDuration(duration time.Duration) {
+	fetchActiveOrdersDuration = duration
+}
 
 // CreateFormattedLimitOrder is an alias of createFormattedLimitOrder for testing purposes
 func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -140,7 +140,7 @@ func (o *OrderbookUseCaseImpl) ProcessPool(ctx context.Context, pool sqsdomain.P
 var (
 	// fetchActiveOrdersEvery is a duration in which orders are pushed to the client periodically
 	// This is an arbitrary number selected to avoid spamming the client
-	fetchActiveOrdersDuration = 5 * time.Second
+	fetchActiveOrdersDuration = 10 * time.Second
 
 	// getActiveOrdersStreamChanLen is the length of the channel for active orders stream
 	// length is arbitrary number selected to avoid blocking

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -137,6 +137,77 @@ func (o *OrderbookUseCaseImpl) ProcessPool(ctx context.Context, pool sqsdomain.P
 	return nil
 }
 
+var (
+	// fetchActiveOrdersEvery is a duration in which orders are pushed to the client periodically
+	// This is an arbitrary number selected to avoid spamming the client
+	fetchActiveOrdersDuration = 5 * time.Second
+
+	// getActiveOrdersStreamChanLen is the length of the channel for active orders stream
+	// length is arbitrary number selected to avoid blocking
+	getActiveOrdersStreamChanLen = 50
+)
+
+// GetActiveOrdersStream implements mvc.OrderBookUsecase.
+func (o *OrderbookUseCaseImpl) GetActiveOrdersStream(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult {
+	// Result channel
+	c := make(chan orderbookdomain.OrderbookResult, getActiveOrdersStreamChanLen)
+
+	// Function to fetch orders
+	fetchOrders := func(ctx context.Context) {
+		orderbooks, err := o.poolsUsecease.GetAllCanonicalOrderbookPoolIDs()
+		if err != nil {
+			c <- orderbookdomain.OrderbookResult{
+				Error: types.FailedGetAllCanonicalOrderbookPoolIDsError{Err: err},
+			}
+			return
+		}
+
+		for _, orderbook := range orderbooks {
+			go func(orderbook domain.CanonicalOrderBooksResult) {
+				limitOrders, isBestEffort, err := o.processOrderBookActiveOrders(ctx, orderbook, address)
+				if len(limitOrders) == 0 && err == nil {
+					return // skip empty orders
+				}
+
+				if err != nil {
+					telemetry.ProcessingOrderbookActiveOrdersErrorCounter.Inc()
+					o.logger.Error(telemetry.ProcessingOrderbookActiveOrdersErrorMetricName, zap.Any("pool_id", orderbook.PoolID), zap.Any("err", err))
+				}
+
+				select {
+				case c <- orderbookdomain.OrderbookResult{
+					PoolID:       orderbook.PoolID,
+					IsBestEffort: isBestEffort,
+					LimitOrders:  limitOrders,
+					Error:        err,
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}(orderbook)
+		}
+	}
+
+	// Fetch orders immediately on start
+	go fetchOrders(ctx)
+
+	// Pull orders periodically based on duration
+	go func() {
+		ticker := time.NewTicker(fetchActiveOrdersDuration)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				fetchOrders(ctx)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return c
+}
+
 // GetActiveOrders implements mvc.OrderBookUsecase.
 func (o *OrderbookUseCaseImpl) GetActiveOrders(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error) {
 	orderbooks, err := o.poolsUsecease.GetAllCanonicalOrderbookPoolIDs()
@@ -144,25 +215,17 @@ func (o *OrderbookUseCaseImpl) GetActiveOrders(ctx context.Context, address stri
 		return nil, false, types.FailedGetAllCanonicalOrderbookPoolIDsError{Err: err}
 	}
 
-	type orderbookResult struct {
-		isBestEffort bool
-		orderbookID  uint64
-		limitOrders  []orderbookdomain.LimitOrder
-		err          error
-	}
-
-	results := make(chan orderbookResult, len(orderbooks))
+	results := make(chan orderbookdomain.OrderbookResult, len(orderbooks))
 
 	// Process orderbooks concurrently
 	for _, orderbook := range orderbooks {
 		go func(orderbook domain.CanonicalOrderBooksResult) {
 			limitOrders, isBestEffort, err := o.processOrderBookActiveOrders(ctx, orderbook, address)
-
-			results <- orderbookResult{
-				isBestEffort: isBestEffort,
-				orderbookID:  orderbook.PoolID,
-				limitOrders:  limitOrders,
-				err:          err,
+			results <- orderbookdomain.OrderbookResult{
+				IsBestEffort: isBestEffort,
+				PoolID:       orderbook.PoolID,
+				LimitOrders:  limitOrders,
+				Error:        err,
 			}
 		}(orderbook)
 	}
@@ -174,14 +237,14 @@ func (o *OrderbookUseCaseImpl) GetActiveOrders(ctx context.Context, address stri
 	for i := 0; i < len(orderbooks); i++ {
 		select {
 		case result := <-results:
-			if result.err != nil {
+			if result.Error != nil {
 				telemetry.ProcessingOrderbookActiveOrdersErrorCounter.Inc()
-				o.logger.Error(telemetry.ProcessingOrderbookActiveOrdersErrorMetricName, zap.Any("orderbook_id", result.orderbookID), zap.Any("err", result.err))
+				o.logger.Error(telemetry.ProcessingOrderbookActiveOrdersErrorMetricName, zap.Any("pool_id", result.PoolID), zap.Any("err", result.Error))
 			}
 
-			isBestEffort = isBestEffort || result.isBestEffort
+			isBestEffort = isBestEffort || result.IsBestEffort
 
-			finalResults = append(finalResults, result.limitOrders...)
+			finalResults = append(finalResults, result.LimitOrders...)
 		case <-ctx.Done():
 			return nil, false, ctx.Err()
 		}

--- a/passthrough/delivery/http/passthrough_handler.go
+++ b/passthrough/delivery/http/passthrough_handler.go
@@ -7,16 +7,20 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	_ "github.com/osmosis-labs/sqs/domain/passthrough"
+	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/orderbook/types"
 
 	"github.com/labstack/echo/v4"
 	"go.opentelemetry.io/otel/trace"
+
+	"go.uber.org/zap"
 )
 
 // PassthroughHandler is the http handler for passthrough use case
 type PassthroughHandler struct {
 	PUsecase mvc.PassthroughUsecase
 	OUsecase mvc.OrderBookUsecase
+	Logger   log.Logger
 }
 
 const resourcePrefix = "/passthrough"
@@ -26,14 +30,21 @@ func formatPassthroughResource(resource string) string {
 }
 
 // NewPassthroughHandler will initialize the pools/ resources endpoint
-func NewPassthroughHandler(e *echo.Echo, ptu mvc.PassthroughUsecase, ou mvc.OrderBookUsecase) {
+func NewPassthroughHandler(e *echo.Echo, ptu mvc.PassthroughUsecase, ou mvc.OrderBookUsecase, logger log.Logger) {
 	handler := &PassthroughHandler{
 		PUsecase: ptu,
 		OUsecase: ou,
+		Logger:   logger,
 	}
 
 	e.GET(formatPassthroughResource("/portfolio-assets/:address"), handler.GetPortfolioAssetsByAddress)
 	e.GET(formatPassthroughResource("/active-orders"), handler.GetActiveOrders)
+	e.GET(formatPassthroughResource("/active-orders"), func(c echo.Context) error {
+		if c.QueryParam("sse") != "" {
+			return handler.GetActiveOrdersStream(c) // Server-Sent Events (SSE)
+		}
+		return handler.GetActiveOrders(c)
+	})
 }
 
 // @Summary Returns portfolio assets associated with the given address by category.
@@ -61,6 +72,73 @@ func (a *PassthroughHandler) GetPortfolioAssetsByAddress(c echo.Context) error {
 	return c.JSON(http.StatusOK, portfolioAssetsResult)
 }
 
+// parseAndValidateGetActiveOrdersRequest encapsulates the request unmarshalling and validation logic
+// for the GetActiveOrders request.
+func (a *PassthroughHandler) parseAndValidateGetActiveOrdersRequest(c echo.Context) (types.GetActiveOrdersRequest, error) {
+	var req types.GetActiveOrdersRequest
+	if err := deliveryhttp.UnmarshalRequest(c, &req); err != nil {
+		return req, err
+	}
+
+	// Validate the request
+	if err := req.Validate(); err != nil {
+		return req, err
+	}
+
+	return req, nil
+}
+
+func (a *PassthroughHandler) GetActiveOrdersStream(c echo.Context) (err error) {
+	ctx := c.Request().Context()
+
+	span := trace.SpanFromContext(ctx)
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			// nolint:errcheck // ignore error
+			c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
+		}
+
+		// Note: we do not end the span here as it is ended in the middleware.
+	}()
+
+	req, err := a.parseAndValidateGetActiveOrdersRequest(c)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
+	}
+
+	w := c.Response()
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	ch := a.OUsecase.GetActiveOrdersStream(ctx, req.UserOsmoAddress)
+
+	for {
+		select {
+		case <-c.Request().Context().Done():
+			return c.NoContent(http.StatusOK)
+		case orders, ok := <-ch:
+			if !ok {
+				return c.NoContent(http.StatusOK)
+			}
+
+			if orders.Error != nil {
+				a.Logger.Error("GET "+c.Request().URL.String(), zap.Error(orders.Error))
+			}
+
+			err := deliveryhttp.WriteEvent(
+				w,
+				types.NewGetAllOrderResponse(orders.LimitOrders, orders.IsBestEffort),
+			)
+
+			if err != nil {
+				a.Logger.Error("GET "+c.Request().URL.String(), zap.Error(err))
+			}
+		}
+	}
+}
+
 // @Summary Returns all active orderbook orders associated with the given address.
 // @Description The returned data represents all active orders for all orderbooks available for the specified address.
 //
@@ -86,13 +164,8 @@ func (a *PassthroughHandler) GetActiveOrders(c echo.Context) (err error) {
 		// Note: we do not end the span here as it is ended in the middleware.
 	}()
 
-	var req types.GetActiveOrdersRequest
-	if err := deliveryhttp.UnmarshalRequest(c, &req); err != nil {
-		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
-	}
-
-	// Validate the request
-	if err := req.Validate(); err != nil {
+	req, err := a.parseAndValidateGetActiveOrdersRequest(c)
+	if err != nil {
 		return c.JSON(http.StatusBadRequest, domain.ResponseError{Message: err.Error()})
 	}
 

--- a/passthrough/delivery/http/passthrough_handler_test.go
+++ b/passthrough/delivery/http/passthrough_handler_test.go
@@ -1,6 +1,7 @@
 package http_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -8,8 +9,10 @@ import (
 	"strings"
 	"testing"
 
+	deliveryhttp "github.com/osmosis-labs/sqs/delivery/http"
 	"github.com/osmosis-labs/sqs/domain/mocks"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/orderbook/types"
 	"github.com/osmosis-labs/sqs/orderbook/usecase/orderbooktesting"
 	passthroughdelivery "github.com/osmosis-labs/sqs/passthrough/delivery/http"
@@ -112,6 +115,130 @@ func (s *PassthroughHandlerTestSuite) TestGetActiveOrders() {
 			// Check the response
 			s.Assert().Equal(tc.expectedStatusCode, rec.Code)
 			s.Assert().JSONEq(tc.expectedResponse, strings.TrimSpace(rec.Body.String()))
+		})
+	}
+}
+
+func (s *PassthroughHandlerTestSuite) TestGetActiveOrdersStream() {
+	eventData := func(data string) string {
+		data = strings.ReplaceAll(strings.ReplaceAll(data, "\n", ""), " ", "")
+
+		event := deliveryhttp.Event{
+			Data: []byte(data),
+		}
+
+		w := bytes.NewBuffer(nil)
+		err := event.MarshalTo(w)
+		s.Assert().NoError(err)
+
+		return w.String()
+	}
+
+	testCases := []struct {
+		name               string
+		queryParams        map[string]string
+		setupMocks         func(usecase *mocks.OrderbookUsecaseMock)
+		expectedStatusCode int
+		expectedResponse   string
+	}{
+		{
+			name:               "validation error: missing userOsmoAddress",
+			queryParams:        map[string]string{}, // missing userOsmoAddress
+			setupMocks:         func(usecase *mocks.OrderbookUsecaseMock) {},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   fmt.Sprintf(`{"message":"%s"}`+"\n", types.ErrUserOsmoAddressInvalid.Error()),
+		},
+		{
+			name: "validation error: invalid userOsmoAddress",
+			queryParams: map[string]string{
+				"userOsmoAddress": "notvalid",
+			},
+			setupMocks:         func(usecase *mocks.OrderbookUsecaseMock) {},
+			expectedStatusCode: http.StatusBadRequest,
+			expectedResponse:   fmt.Sprintf(`{"message":"%s"}`+"\n", types.ErrUserOsmoAddressInvalid.Error()),
+		},
+		{
+			name: "returns active orders stream",
+			queryParams: map[string]string{
+				"userOsmoAddress": "osmo1ugku28hwyexpljrrmtet05nd6kjlrvr9jz6z00",
+			},
+			setupMocks: func(usecase *mocks.OrderbookUsecaseMock) {
+				usecase.GetActiveOrdersStreamFunc = func(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult {
+					ordersCh := make(chan orderbookdomain.OrderbookResult)
+					go func(c chan orderbookdomain.OrderbookResult) {
+						c <- orderbookdomain.OrderbookResult{
+							LimitOrders: []orderbookdomain.LimitOrder{
+								s.NewLimitOrder().WithOrderID(1).LimitOrder,
+								s.NewLimitOrder().WithOrderID(2).LimitOrder,
+							},
+							IsBestEffort: false,
+							Error:        nil,
+						}
+						close(c)
+					}(ordersCh)
+					return ordersCh
+				}
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   eventData(s.MustReadFile("../../../orderbook/usecase/orderbooktesting/parsing/active_orders_response.json")),
+		},
+		{
+			name: "internal server error during stream",
+			queryParams: map[string]string{
+				"userOsmoAddress": "osmo1ev0vtddkl7jlwfawlk06yzncapw2x9quva4wzw",
+			},
+			setupMocks: func(usecase *mocks.OrderbookUsecaseMock) {
+				ordersCh := make(chan orderbookdomain.OrderbookResult)
+				usecase.GetActiveOrdersStreamFunc = func(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult {
+					go func() {
+						ordersCh <- orderbookdomain.OrderbookResult{
+							LimitOrders:  nil,
+							IsBestEffort: false,
+							Error:        assert.AnError,
+						}
+						close(ordersCh)
+					}()
+					return ordersCh
+				}
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedResponse:   "id: \ndata: {\"orders\":[],\"is_best_effort\":false}\n\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		s.Run(tc.name, func() {
+			e := echo.New()
+			req := httptest.NewRequest(echo.GET, "/", nil)
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			q := req.URL.Query()
+			for k, v := range tc.queryParams {
+				q.Add(k, v)
+			}
+			req.URL.RawQuery = q.Encode()
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			c.Request().Context().Done()
+			// Set up the mocks
+			usecase := mocks.OrderbookUsecaseMock{}
+			if tc.setupMocks != nil {
+				tc.setupMocks(&usecase)
+			}
+
+			// Initialize the handler with mocked usecase
+			handler := passthroughdelivery.PassthroughHandler{
+				OUsecase: &usecase,
+				Logger:   &log.NoOpLogger{},
+			}
+
+			// Call the method under test
+			err := handler.GetActiveOrdersStream(c)
+			s.Assert().NoError(err)
+
+			// Check the response
+			s.Assert().Equal(tc.expectedStatusCode, rec.Code)
+			s.Assert().Equal(tc.expectedResponse, rec.Body.String())
 		})
 	}
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -1,0 +1,11 @@
+package validator
+
+// Validator is any type capable to validate and having Validate method attached.
+type Validator interface {
+	Validate() error
+}
+
+// Validate validates type v.
+func Validate(v Validator) error {
+	return v.Validate()
+}


### PR DESCRIPTION
This PR implements SSE for Active Orders Query endpoint.

Implementation extends existing functionality by looking for `sse` URL param for existing endpoint, for example: `/passthrough/active-orders?userOsmoAddress=osmo1jgz4xmaw9yk9pjxd4h8c2zs0r0vmgyn88s8t6l&sse=1` When there is no `sse` passed, endpoint will return a list of orders as per its original functionlity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced Server-Sent Events (SSE) functionality for active orders, allowing real-time updates.
  - Added a new method for streaming active orders, enhancing dynamic interaction with order data.

- **Improvements**
  - Updated logging capabilities within the PassthroughHandler for better error tracking.
  - Streamlined request handling for active orders, improving error management.

- **Bug Fixes**
  - Enhanced error handling during the retrieval of active orders.

These changes improve the overall user experience by providing real-time data and more robust logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->