### PR TITLE
SQS-417 | Fix orderbook order Quantity parsing

### DIFF
--- a/domain/orderbook/order.go
+++ b/domain/orderbook/order.go
@@ -2,7 +2,6 @@ package orderbookdomain
 
 import (
 	"fmt"
-	"strconv"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
@@ -34,12 +33,12 @@ type Order struct {
 
 // Status returns the status of the order based on the percent filled.
 func (o Order) Status(percentFilled float64) (OrderStatus, error) {
-	quantity, err := strconv.Atoi(o.Quantity)
+	quantity, err := osmomath.NewDecFromStr(o.Quantity)
 	if err != nil {
 		return "", fmt.Errorf("error parsing quantity: %w", err)
 	}
 
-	if quantity == 0 || percentFilled == 1 {
+	if quantity.IsZero() || percentFilled == 1 {
 		return StatusFilled, nil
 	}
 

--- a/domain/orderbook/order_test.go
+++ b/domain/orderbook/order_test.go
@@ -1,0 +1,77 @@
+package orderbookdomain_test
+
+import (
+	"testing"
+
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderStatus(t *testing.T) {
+	tests := []struct {
+		name          string
+		order         orderbookdomain.Order
+		percentFilled float64
+		expected      orderbookdomain.OrderStatus
+		expectError   bool
+	}{
+		{
+			name:          "Valid quantity, percentFilled = 0",
+			order:         orderbookdomain.Order{Quantity: "100.0"},
+			percentFilled: 0,
+			expected:      orderbookdomain.StatusOpen,
+			expectError:   false,
+		},
+		{
+			name:          "Valid quantity, percentFilled = 1",
+			order:         orderbookdomain.Order{Quantity: "100.0"},
+			percentFilled: 1,
+			expected:      orderbookdomain.StatusFilled,
+			expectError:   false,
+		},
+		{
+			name:          "Valid quantity, percentFilled < 1",
+			order:         orderbookdomain.Order{Quantity: "100.0"},
+			percentFilled: 0.5,
+			expected:      orderbookdomain.StatusPartiallyFilled,
+			expectError:   false,
+		},
+		{
+			name:          "Zero quantity",
+			order:         orderbookdomain.Order{Quantity: "0"},
+			percentFilled: 1,
+			expected:      orderbookdomain.StatusFilled,
+			expectError:   false,
+		},
+		{
+			name:          "Invalid quantity string",
+			order:         orderbookdomain.Order{Quantity: "invalid"},
+			percentFilled: 1,
+			expectError:   true,
+		},
+		{
+			name:          "Empty quantity string",
+			order:         orderbookdomain.Order{Quantity: ""},
+			percentFilled: 1,
+			expectError:   true,
+		},
+		{
+			name:          "Out of range quantity string",
+			order:         orderbookdomain.Order{Quantity: "101960000000000000000"},
+			expected:      orderbookdomain.StatusFilled,
+			percentFilled: 1,
+			expectError:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, err := tt.order.Status(tt.percentFilled)
+			if tt.expectError {
+				assert.Error(t, err)
+			}
+			assert.Equal(t, tt.expected, status)
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes order Quantity parsing that previously caused an error and made some orders not appear in the returned list 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced order status determination with improved quantity parsing, now supporting decimal representation for better accuracy.

- **Bug Fixes**
	- Updated comparison logic for order quantity to ensure more precise status assessment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->