### PR TITLE
deps: remove sqs from sqsdomain

### DIFF
--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -49,6 +49,7 @@ import (
 	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/middleware"
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 
 	routerHttpDelivery "github.com/osmosis-labs/sqs/router/delivery/http"
 	routerUseCase "github.com/osmosis-labs/sqs/router/usecase"
@@ -216,7 +217,7 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 
 	// Iniitialize data fetcher for pool APRs
 	fetchPoolAPRsCallback := datafetchers.GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient, logger)
-	var aprFetcher datafetchers.MapFetcher[uint64, passthroughdomain.PoolAPR] = datafetchers.NewMapFetcher(fetchPoolAPRsCallback, time.Minute*time.Duration(passthroughConfig.APRFetchIntervalMinutes))
+	var aprFetcher datafetchers.MapFetcher[uint64, sqspassthroughdomain.PoolAPR] = datafetchers.NewMapFetcher(fetchPoolAPRsCallback, time.Minute*time.Duration(passthroughConfig.APRFetchIntervalMinutes))
 	// Register the APR fetcher with the passthrough use case
 	poolsUseCase.RegisterAPRFetcher(aprFetcher)
 

--- a/domain/mocks/pool_mock.go
+++ b/domain/mocks/pool_mock.go
@@ -7,9 +7,9 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/domain"
-	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v26/x/gamm/pool-models/balancer"
@@ -33,30 +33,30 @@ type MockRoutablePool struct {
 	SpreadFactor      osmomath.Dec
 	mockedTokenOut    sdk.Coin
 
-	APRData  passthroughdomain.PoolAPRDataStatusWrap
-	FeesData passthroughdomain.PoolFeesDataStatusWrap
+	APRData  sqspassthroughdomain.PoolAPRDataStatusWrap
+	FeesData sqspassthroughdomain.PoolFeesDataStatusWrap
 
 	PoolLiquidityCap      osmomath.Int
 	PoolLiquidityCapError string
 }
 
 // GetAPRData implements sqsdomain.PoolI.
-func (mp *MockRoutablePool) GetAPRData() passthroughdomain.PoolAPRDataStatusWrap {
+func (mp *MockRoutablePool) GetAPRData() sqspassthroughdomain.PoolAPRDataStatusWrap {
 	return mp.APRData
 }
 
 // GetFeesData implements sqsdomain.PoolI.
-func (mp *MockRoutablePool) GetFeesData() passthroughdomain.PoolFeesDataStatusWrap {
+func (mp *MockRoutablePool) GetFeesData() sqspassthroughdomain.PoolFeesDataStatusWrap {
 	return mp.FeesData
 }
 
 // SetAPRData implements sqsdomain.PoolI.
-func (mp *MockRoutablePool) SetAPRData(aprData passthroughdomain.PoolAPRDataStatusWrap) {
+func (mp *MockRoutablePool) SetAPRData(aprData sqspassthroughdomain.PoolAPRDataStatusWrap) {
 	mp.APRData = aprData
 }
 
 // SetFeesData implements sqsdomain.PoolI.
-func (mp *MockRoutablePool) SetFeesData(feesData passthroughdomain.PoolFeesDataStatusWrap) {
+func (mp *MockRoutablePool) SetFeesData(feesData sqspassthroughdomain.PoolFeesDataStatusWrap) {
 	mp.FeesData = feesData
 }
 

--- a/domain/passthrough/numia_http_client.go
+++ b/domain/passthrough/numia_http_client.go
@@ -3,12 +3,13 @@ package passthroughdomain
 import (
 	"net/http"
 
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 	"github.com/osmosis-labs/sqs/sqsutil/sqshttp"
 )
 
 type NumiaHTTPClient interface {
 	// GetPoolAPRsRange returns the APR data of the pools as ranges
-	GetPoolAPRsRange() ([]PoolAPR, error)
+	GetPoolAPRsRange() ([]sqspassthroughdomain.PoolAPR, error)
 }
 
 type NumiaHTTPClientImpl struct {
@@ -30,8 +31,8 @@ func NewNumiaHTTPClient(url string) *NumiaHTTPClientImpl {
 }
 
 // GetPoolAPRsRange implements NumiaHTTPClient.
-func (n *NumiaHTTPClientImpl) GetPoolAPRsRange() ([]PoolAPR, error) {
-	poolAPR, err := sqshttp.Get[[]PoolAPR](n.client, n.url, poolAPRRangeEndpoint)
+func (n *NumiaHTTPClientImpl) GetPoolAPRsRange() ([]sqspassthroughdomain.PoolAPR, error) {
+	poolAPR, err := sqshttp.Get[[]sqspassthroughdomain.PoolAPR](n.client, n.url, poolAPRRangeEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/domain/passthrough/timeseries_http_client.go
+++ b/domain/passthrough/timeseries_http_client.go
@@ -3,11 +3,12 @@ package passthroughdomain
 import (
 	"net/http"
 
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 	"github.com/osmosis-labs/sqs/sqsutil/sqshttp"
 )
 
 type TimeSeriesHTTPClient interface {
-	GetPoolFees() (*PoolFees, error)
+	GetPoolFees() (*sqspassthroughdomain.PoolFees, error)
 }
 
 type TimeSeriesHTTPClientImpl struct {
@@ -29,8 +30,8 @@ func NewTimeSeriesHTTPClient(url string) *TimeSeriesHTTPClientImpl {
 }
 
 // GetPoolFees implements TimeSeriesHTTPClient.
-func (t *TimeSeriesHTTPClientImpl) GetPoolFees() (*PoolFees, error) {
-	poolFees, err := sqshttp.Get[PoolFees](t.client, t.url, feesEndpoint)
+func (t *TimeSeriesHTTPClientImpl) GetPoolFees() (*sqspassthroughdomain.PoolFees, error) {
+	poolFees, err := sqshttp.Get[sqspassthroughdomain.PoolFees](t.client, t.url, feesEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
-	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v26/x/poolmanager/types"
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 )
 
 // ResponseError represent the response error struct
@@ -39,8 +39,8 @@ type PoolResponse struct {
 	LiquidityCap      osmomath.Int `json:"liquidity_cap"`
 	LiquidityCapError string       `json:"liquidity_cap_error"`
 
-	APRData  passthroughdomain.PoolAPRDataStatusWrap  `json:"apr_data,omitempty"`
-	FeesData passthroughdomain.PoolFeesDataStatusWrap `json:"fees_data,omitempty"`
+	APRData  sqspassthroughdomain.PoolAPRDataStatusWrap  `json:"apr_data,omitempty"`
+	FeesData sqspassthroughdomain.PoolFeesDataStatusWrap `json:"fees_data,omitempty"`
 }
 
 const resourcePrefix = "/pools"

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
-	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 	routerrepo "github.com/osmosis-labs/sqs/router/repository"
 	"github.com/osmosis-labs/sqs/router/usecase/pools"
 	"github.com/osmosis-labs/sqs/router/usecase/route"
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	cosmwasmpoolmodel "github.com/osmosis-labs/osmosis/v26/x/cosmwasmpool/model"
@@ -54,8 +54,8 @@ type poolsUseCase struct {
 
 	cosmWasmPoolsParams cosmwasmdomain.CosmWasmPoolsParams
 
-	aprPrefetcher      datafetchers.MapFetcher[uint64, passthroughdomain.PoolAPR]
-	poolFeesPrefetcher datafetchers.MapFetcher[uint64, passthroughdomain.PoolFee]
+	aprPrefetcher      datafetchers.MapFetcher[uint64, sqspassthroughdomain.PoolAPR]
+	poolFeesPrefetcher datafetchers.MapFetcher[uint64, sqspassthroughdomain.PoolFee]
 
 	logger log.Logger
 }
@@ -508,12 +508,12 @@ func (p *poolsUseCase) GetAllCanonicalOrderbookPoolIDs() ([]domain.CanonicalOrde
 }
 
 // RegisterAPRFetcher registers the APR fetcher for the passthrough use case.
-func (p *poolsUseCase) RegisterAPRFetcher(aprFetcher datafetchers.MapFetcher[uint64, passthroughdomain.PoolAPR]) {
+func (p *poolsUseCase) RegisterAPRFetcher(aprFetcher datafetchers.MapFetcher[uint64, sqspassthroughdomain.PoolAPR]) {
 	p.aprPrefetcher = aprFetcher
 }
 
 // RegisterPoolFeesFetcher registers the pool fees fetcher for the passthrough use case.
-func (p *poolsUseCase) RegisterPoolFeesFetcher(poolFeesFetcher datafetchers.MapFetcher[uint64, passthroughdomain.PoolFee]) {
+func (p *poolsUseCase) RegisterPoolFeesFetcher(poolFeesFetcher datafetchers.MapFetcher[uint64, sqspassthroughdomain.PoolFee]) {
 	p.poolFeesPrefetcher = poolFeesFetcher
 }
 
@@ -655,7 +655,7 @@ func (p *poolsUseCase) setPoolAPRAndFeeDataIfConfigured(pool sqsdomain.PoolI, op
 		}
 
 		// Set APR data
-		pool.SetAPRData(passthroughdomain.PoolAPRDataStatusWrap{
+		pool.SetAPRData(sqspassthroughdomain.PoolAPRDataStatusWrap{
 			PoolAPR: poolAPRData,
 			IsStale: isStale,
 			IsError: err != nil,
@@ -669,7 +669,7 @@ func (p *poolsUseCase) setPoolAPRAndFeeDataIfConfigured(pool sqsdomain.PoolI, op
 		}
 
 		// Set pool fee data
-		pool.SetFeesData(passthroughdomain.PoolFeesDataStatusWrap{
+		pool.SetFeesData(sqspassthroughdomain.PoolFeesDataStatusWrap{
 			PoolFee: poolFeeData,
 			IsStale: isStale,
 			IsError: err != nil,

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -19,7 +19,7 @@ import (
 	gammtypes "github.com/osmosis-labs/osmosis/v26/x/gamm/types"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v26/x/poolmanager/types"
 	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
-	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mocks"
@@ -57,15 +57,15 @@ var (
 	defaultError = fmt.Errorf("forced error")
 
 	// Default APR and fee data
-	defaultAPRData = passthroughdomain.PoolAPRDataStatusWrap{PoolAPR: passthroughdomain.PoolAPR{
+	defaultAPRData = sqspassthroughdomain.PoolAPRDataStatusWrap{PoolAPR: sqspassthroughdomain.PoolAPR{
 		PoolID: defaultPoolID,
-		SwapFees: passthroughdomain.PoolDataRange{
+		SwapFees: sqspassthroughdomain.PoolDataRange{
 			Lower: 0.01,
 			Upper: 0.02,
 		},
 	}}
-	defaultFeeData = passthroughdomain.PoolFeesDataStatusWrap{
-		PoolFee: passthroughdomain.PoolFee{
+	defaultFeeData = sqspassthroughdomain.PoolFeesDataStatusWrap{
+		PoolFee: sqspassthroughdomain.PoolFee{
 			PoolID: fmt.Sprintf("%d", defaultPoolID),
 		},
 	}
@@ -758,26 +758,26 @@ func (s *PoolsUsecaseTestSuite) TestGetPools() {
 func (s *PoolsUsecaseTestSuite) TestSetPoolAPRAndFeeDataIfConfigured() {
 	var (
 		// Helper functions to modify the APR and fee data
-		withIsAPRStale = func(aprData passthroughdomain.PoolAPRDataStatusWrap) passthroughdomain.PoolAPRDataStatusWrap {
+		withIsAPRStale = func(aprData sqspassthroughdomain.PoolAPRDataStatusWrap) sqspassthroughdomain.PoolAPRDataStatusWrap {
 			aprData.IsStale = true
 			return aprData
 		}
-		withIsAPRError = func(aprData passthroughdomain.PoolAPRDataStatusWrap) passthroughdomain.PoolAPRDataStatusWrap {
+		withIsAPRError = func(aprData sqspassthroughdomain.PoolAPRDataStatusWrap) sqspassthroughdomain.PoolAPRDataStatusWrap {
 			aprData.IsError = true
 			return aprData
 		}
-		withIsFeeStale = func(feeData passthroughdomain.PoolFeesDataStatusWrap) passthroughdomain.PoolFeesDataStatusWrap {
+		withIsFeeStale = func(feeData sqspassthroughdomain.PoolFeesDataStatusWrap) sqspassthroughdomain.PoolFeesDataStatusWrap {
 			feeData.IsStale = true
 			return feeData
 		}
-		withIsFeeError = func(feeData passthroughdomain.PoolFeesDataStatusWrap) passthroughdomain.PoolFeesDataStatusWrap {
+		withIsFeeError = func(feeData sqspassthroughdomain.PoolFeesDataStatusWrap) sqspassthroughdomain.PoolFeesDataStatusWrap {
 			feeData.IsError = true
 			return feeData
 		}
 
 		// Empty APR and fee data
-		emptyAPRData = passthroughdomain.PoolAPRDataStatusWrap{}
-		emptyFeeData = passthroughdomain.PoolFeesDataStatusWrap{}
+		emptyAPRData = sqspassthroughdomain.PoolAPRDataStatusWrap{}
+		emptyFeeData = sqspassthroughdomain.PoolFeesDataStatusWrap{}
 	)
 
 	testCases := []struct {
@@ -792,8 +792,8 @@ func (s *PoolsUsecaseTestSuite) TestSetPoolAPRAndFeeDataIfConfigured() {
 		isAPRDataStale bool
 		isFeeDataStale bool
 
-		expectedAPRData  passthroughdomain.PoolAPRDataStatusWrap
-		expectedFeesData passthroughdomain.PoolFeesDataStatusWrap
+		expectedAPRData  sqspassthroughdomain.PoolAPRDataStatusWrap
+		expectedFeesData sqspassthroughdomain.PoolFeesDataStatusWrap
 	}{
 		{
 			name: "no APR or fees data configured",
@@ -985,17 +985,17 @@ func (s *PoolsUsecaseTestSuite) newDefaultPoolsUseCase() *usecase.PoolsUsecase {
 }
 
 // Returns a mock APR fetcher that can be used to test the APR data fetching logic.
-func getMockAPRFetcher(shouldForceAPRFetcherError, isAPRDataStale bool) *mocks.MapFetcherMock[uint64, passthroughdomain.PoolAPR] {
-	return &mocks.MapFetcherMock[uint64, passthroughdomain.PoolAPR]{
+func getMockAPRFetcher(shouldForceAPRFetcherError, isAPRDataStale bool) *mocks.MapFetcherMock[uint64, sqspassthroughdomain.PoolAPR] {
+	return &mocks.MapFetcherMock[uint64, sqspassthroughdomain.PoolAPR]{
 		// Mock GetByKey
-		GetByKeyFn: func(key uint64) (passthroughdomain.PoolAPR, time.Time, bool, error) {
+		GetByKeyFn: func(key uint64) (sqspassthroughdomain.PoolAPR, time.Time, bool, error) {
 			var err error
 			if shouldForceAPRFetcherError {
 				err = defaultError
 			}
 
 			if key != defaultPoolID {
-				return passthroughdomain.PoolAPR{}, defaultTime, isAPRDataStale, err
+				return sqspassthroughdomain.PoolAPR{}, defaultTime, isAPRDataStale, err
 			}
 
 			return defaultAPRData.PoolAPR, defaultTime, isAPRDataStale, err
@@ -1004,17 +1004,17 @@ func getMockAPRFetcher(shouldForceAPRFetcherError, isAPRDataStale bool) *mocks.M
 }
 
 // Returns a mock fees fetcher that can be used to test the fees data fetching logic.
-func getMockFeesFetcher(shouldForceFeesFetcherError, isFeeDataStale bool) *mocks.MapFetcherMock[uint64, passthroughdomain.PoolFee] {
-	return &mocks.MapFetcherMock[uint64, passthroughdomain.PoolFee]{
+func getMockFeesFetcher(shouldForceFeesFetcherError, isFeeDataStale bool) *mocks.MapFetcherMock[uint64, sqspassthroughdomain.PoolFee] {
+	return &mocks.MapFetcherMock[uint64, sqspassthroughdomain.PoolFee]{
 		// Mock GetByKey
-		GetByKeyFn: func(key uint64) (passthroughdomain.PoolFee, time.Time, bool, error) {
+		GetByKeyFn: func(key uint64) (sqspassthroughdomain.PoolFee, time.Time, bool, error) {
 			var err error
 			if shouldForceFeesFetcherError {
 				err = defaultError
 			}
 
 			if key != defaultPoolID {
-				return passthroughdomain.PoolFee{}, defaultTime, isFeeDataStale, err
+				return sqspassthroughdomain.PoolFee{}, defaultTime, isFeeDataStale, err
 			}
 
 			return defaultFeeData.PoolFee, defaultTime, isFeeDataStale, err

--- a/sqsdomain/go.mod
+++ b/sqsdomain/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/osmosis-labs/osmosis/osmomath v0.0.13
 	github.com/osmosis-labs/osmosis/v26 v26.0.0-rc1
-	github.com/osmosis-labs/sqs v0.19.2-rc2.0.20240826173240-e5733bb3700d
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.65.0
 	google.golang.org/protobuf v1.34.2

--- a/sqsdomain/go.sum
+++ b/sqsdomain/go.sum
@@ -615,8 +615,6 @@ github.com/osmosis-labs/osmosis/x/epochs v0.0.5-0.20240825083448-87db4447a1ff h1
 github.com/osmosis-labs/osmosis/x/epochs v0.0.5-0.20240825083448-87db4447a1ff/go.mod h1:7ylCTvH4gEtZ5E8paiwSjmOzOKOOls8Br45W9uwWnP0=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20240825083448-87db4447a1ff h1:OZGMwv/Km6xnIB16d4zghFf0x7K9JlWqRaxgOVBIv7Y=
 github.com/osmosis-labs/osmosis/x/ibc-hooks v0.0.0-20240825083448-87db4447a1ff/go.mod h1:AXHoG4L1AMDCMEGeSdzcy7ik2mBt5fTyzEAWlGt+aSc=
-github.com/osmosis-labs/sqs v0.19.2-rc2.0.20240826173240-e5733bb3700d h1:vf1KUnWuk54yzMxjbfU1aufHR45ELi80NG3gFr8ebks=
-github.com/osmosis-labs/sqs v0.19.2-rc2.0.20240826173240-e5733bb3700d/go.mod h1:HkapP4mxLZJLlKAjzLAyZcjgvXT7FA6cQZ8P2l+F8ow=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=

--- a/sqsdomain/passthroughdomain/passthrough_pools_data.go
+++ b/sqsdomain/passthroughdomain/passthrough_pools_data.go
@@ -1,4 +1,4 @@
-package passthroughdomain
+package sqspassthroughdomain
 
 // PoolAPRDataStatusWrap is a wrapper for PoolAPRData that includes status flags.
 type PoolAPRDataStatusWrap struct {

--- a/sqsdomain/passthroughdomain/pool_apr.go
+++ b/sqsdomain/passthroughdomain/pool_apr.go
@@ -1,4 +1,4 @@
-package passthroughdomain
+package sqspassthroughdomain
 
 import (
 	"fmt"

--- a/sqsdomain/passthroughdomain/pool_fees.go
+++ b/sqsdomain/passthroughdomain/pool_fees.go
@@ -1,4 +1,4 @@
-package passthroughdomain
+package sqspassthroughdomain
 
 import (
 	"github.com/osmosis-labs/sqs/sqsdomain/json"

--- a/sqsdomain/pools.go
+++ b/sqsdomain/pools.go
@@ -11,8 +11,8 @@ import (
 	"github.com/osmosis-labs/osmosis/osmomath"
 	clqueryproto "github.com/osmosis-labs/osmosis/v26/x/concentrated-liquidity/client/queryproto"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v26/x/poolmanager/types"
-	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 )
 
 // PoolI represents a generalized Pool interface.
@@ -42,9 +42,9 @@ type PoolI interface {
 	// GetLiquidityCapError returns the pool liquidity capitalization error.
 	GetLiquidityCapError() string
 
-	GetAPRData() passthroughdomain.PoolAPRDataStatusWrap
+	GetAPRData() sqspassthroughdomain.PoolAPRDataStatusWrap
 
-	GetFeesData() passthroughdomain.PoolFeesDataStatusWrap
+	GetFeesData() sqspassthroughdomain.PoolFeesDataStatusWrap
 
 	// SetTickModel sets the tick model for the pool
 	// If this is not a concentrated pool, errors
@@ -58,10 +58,10 @@ type PoolI interface {
 	SetLiquidityCapError(liquidityCapError string)
 
 	// SetAPRData sets the APR data for the pool
-	SetAPRData(aprData passthroughdomain.PoolAPRDataStatusWrap)
+	SetAPRData(aprData sqspassthroughdomain.PoolAPRDataStatusWrap)
 
 	// SetFeesData sets the fees data for the pool
-	SetFeesData(feesData passthroughdomain.PoolFeesDataStatusWrap)
+	SetFeesData(feesData sqspassthroughdomain.PoolFeesDataStatusWrap)
 
 	// Validate validates the pool
 	// Returns nil if the pool is valid
@@ -90,11 +90,11 @@ type SQSPool struct {
 }
 
 type PoolWrapper struct {
-	ChainModel poolmanagertypes.PoolI                   `json:"underlying_pool"`
-	SQSModel   SQSPool                                  `json:"sqs_model"`
-	APRData    passthroughdomain.PoolAPRDataStatusWrap  `json:"apr_data,omitempty"`
-	FeesData   passthroughdomain.PoolFeesDataStatusWrap `json:"fees_data,omitempty"`
-	TickModel  *TickModel                               `json:"tick_model,omitempty"`
+	ChainModel poolmanagertypes.PoolI                      `json:"underlying_pool"`
+	SQSModel   SQSPool                                     `json:"sqs_model"`
+	APRData    sqspassthroughdomain.PoolAPRDataStatusWrap  `json:"apr_data,omitempty"`
+	FeesData   sqspassthroughdomain.PoolFeesDataStatusWrap `json:"fees_data,omitempty"`
+	TickModel  *TickModel                                  `json:"tick_model,omitempty"`
 }
 
 var _ PoolI = &PoolWrapper{}
@@ -207,21 +207,21 @@ func (p *PoolWrapper) SetLiquidityCapError(liquidityCapError string) {
 }
 
 // SetAPRData implements PoolI.
-func (p *PoolWrapper) SetAPRData(aprData passthroughdomain.PoolAPRDataStatusWrap) {
+func (p *PoolWrapper) SetAPRData(aprData sqspassthroughdomain.PoolAPRDataStatusWrap) {
 	p.APRData = aprData
 }
 
 // SetFeesData implements PoolI.
-func (p *PoolWrapper) SetFeesData(feesData passthroughdomain.PoolFeesDataStatusWrap) {
+func (p *PoolWrapper) SetFeesData(feesData sqspassthroughdomain.PoolFeesDataStatusWrap) {
 	p.FeesData = feesData
 }
 
 // GetAPRData implements PoolI.
-func (p *PoolWrapper) GetAPRData() passthroughdomain.PoolAPRDataStatusWrap {
+func (p *PoolWrapper) GetAPRData() sqspassthroughdomain.PoolAPRDataStatusWrap {
 	return p.APRData
 }
 
 // GetFeesData implements PoolI.
-func (p *PoolWrapper) GetFeesData() passthroughdomain.PoolFeesDataStatusWrap {
+func (p *PoolWrapper) GetFeesData() sqspassthroughdomain.PoolFeesDataStatusWrap {
 	return p.FeesData
 }

--- a/sqsutil/datafetchers/numia_apr_fetcher.go
+++ b/sqsutil/datafetchers/numia_apr_fetcher.go
@@ -6,14 +6,15 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 	passthroughdomain "github.com/osmosis-labs/sqs/domain/passthrough"
 	"github.com/osmosis-labs/sqs/log"
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 	"go.uber.org/zap"
 )
 
 // GetFetchPoolAPRsFromNumiaCb returns a callback to fetch pool APRs from Numia.
 // It increments the error counter if the pool APRs fetching fails.
 // It returns a callback function that returns the pool APRs on success.
-func GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClient, logger log.Logger) func() (map[uint64]passthroughdomain.PoolAPR, error) {
-	return func() (map[uint64]passthroughdomain.PoolAPR, error) {
+func GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClient, logger log.Logger) func() (map[uint64]sqspassthroughdomain.PoolAPR, error) {
+	return func() (map[uint64]sqspassthroughdomain.PoolAPR, error) {
 		// Fetch pool APRs from the passthrough grpc client
 		poolAPRs, err := numiaHTTPClient.GetPoolAPRsRange()
 		if err != nil {
@@ -25,7 +26,7 @@ func GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClie
 		}
 
 		// Convert to map
-		poolAPRsMap := make(map[uint64]passthroughdomain.PoolAPR, len(poolAPRs))
+		poolAPRsMap := make(map[uint64]sqspassthroughdomain.PoolAPR, len(poolAPRs))
 		for _, poolAPR := range poolAPRs {
 			poolAPRsMap[poolAPR.PoolID] = poolAPR
 		}
@@ -37,8 +38,8 @@ func GetFetchPoolAPRsFromNumiaCb(numiaHTTPClient passthroughdomain.NumiaHTTPClie
 // GetFetchPoolPoolFeesFromTimeseries returns a callback to fetch pool fees from timeseries data stack.
 // It increments the error counter if the pool fees fetching fails.
 // It returns a callback function that returns the pool fees on success.
-func GetFetchPoolPoolFeesFromTimeseries(timeseriesHTTPClient passthroughdomain.TimeSeriesHTTPClient, logger log.Logger) func() (map[uint64]passthroughdomain.PoolFee, error) {
-	return func() (map[uint64]passthroughdomain.PoolFee, error) {
+func GetFetchPoolPoolFeesFromTimeseries(timeseriesHTTPClient passthroughdomain.TimeSeriesHTTPClient, logger log.Logger) func() (map[uint64]sqspassthroughdomain.PoolFee, error) {
+	return func() (map[uint64]sqspassthroughdomain.PoolFee, error) {
 		// Fetch pool APRs from the passthrough grpc client
 		poolFees, err := timeseriesHTTPClient.GetPoolFees()
 		if err != nil {
@@ -50,7 +51,7 @@ func GetFetchPoolPoolFeesFromTimeseries(timeseriesHTTPClient passthroughdomain.T
 			return nil, err
 		}
 
-		poolFeesMap := make(map[uint64]passthroughdomain.PoolFee, len(poolFees.Data))
+		poolFeesMap := make(map[uint64]sqspassthroughdomain.PoolFee, len(poolFees.Data))
 		for _, poolFee := range poolFees.Data {
 			// Convert pool ID to uint64
 			poolID, err := strconv.ParseUint(poolFee.PoolID, 10, 64)


### PR DESCRIPTION
- Remove sqs from sqsdomain so that we do not accidentally cause non-existent tag issues to clients that import `sqsdomain` 

https://osmosis-network.slack.com/archives/C060VCJAVBL/p1727353457634799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Updated data types for pool APR and fees to enhance modularity and clarity.

- **Bug Fixes**
  - Resolved inconsistencies in data fetching methods related to pool APRs and fees.

- **Refactor**
  - Transitioned references from the `passthroughdomain` package to the `sqspassthroughdomain` package across multiple components.

- **Chores**
  - Removed outdated dependencies to streamline the project’s dependency management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->