### PR TITLE
BE-594/domain/slices | Slices package

### DIFF
--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -22,6 +22,7 @@ import (
 
 	ingestrpcdelivry "github.com/osmosis-labs/sqs/ingest/delivery/grpc"
 	ingestusecase "github.com/osmosis-labs/sqs/ingest/usecase"
+	"github.com/osmosis-labs/sqs/ingest/usecase/plugins/orderbookclaimer"
 	"github.com/osmosis-labs/sqs/ingest/usecase/plugins/orderbookfiller"
 	orderbookrepository "github.com/osmosis-labs/sqs/orderbook/repository"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
@@ -280,6 +281,18 @@ func NewSideCarQueryServer(appCodec codec.Codec, config domain.Config, logger lo
 
 					logger.Info("Using keyring with address", zap.Stringer("address", keyring.GetAddress()))
 					currentPlugin = orderbookfiller.New(poolsUseCase, routerUsecase, tokensUseCase, passthroughGRPCClient, orderBookAPIClient, keyring, defaultQuoteDenom, logger)
+				}
+
+				if plugin.GetName() == orderbookplugindomain.OrderBookClaimerPluginName {
+					currentPlugin = orderbookclaimer.New(
+						orderBookUseCase,
+						poolsUseCase,
+						orderBookRepository,
+						orderBookAPIClient,
+						passthroughGRPCClient,
+						orderBookAPIClient,
+						logger,
+					)
 				}
 
 				// Register the plugin with the ingest use case

--- a/domain/config.go
+++ b/domain/config.go
@@ -156,8 +156,8 @@ var (
 			ServerConnectionTimeoutSeconds: 10,
 			Plugins: []Plugin{
 				&OrderBookPluginConfig{
-					Enabled: false,
-					Name:    orderbookplugindomain.OrderBookPluginName,
+					Enabled: true,
+					Name:    orderbookplugindomain.OrderBookClaimerPluginName,
 				},
 			},
 		},

--- a/domain/mvc/orderbook.go
+++ b/domain/mvc/orderbook.go
@@ -3,6 +3,7 @@ package mvc
 import (
 	"context"
 
+	"github.com/osmosis-labs/sqs/domain"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 )
@@ -21,4 +22,7 @@ type OrderBookUsecase interface {
 	// The caller should range over the channel, but note that channel is never closed since there may be multiple
 	// sender goroutines.
 	GetActiveOrdersStream(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult
+
+	// TODO
+	CreateFormattedLimitOrder(orderbook domain.CanonicalOrderBooksResult, order orderbookdomain.Order) (orderbookdomain.LimitOrder, error)
 }

--- a/domain/orderbook/grpcclient/orderbook_grpc_client.go
+++ b/domain/orderbook/grpcclient/orderbook_grpc_client.go
@@ -6,7 +6,6 @@ import (
 
 	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
-	orderbookplugindomain "github.com/osmosis-labs/sqs/domain/orderbook/plugin"
 
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 )
@@ -14,7 +13,7 @@ import (
 // OrderBookClient is an interface for fetching orders by tick from the orderbook contract.
 type OrderBookClient interface {
 	// GetOrdersByTick fetches orders by tick from the orderbook contract.
-	GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error)
+	GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) (orderbookdomain.Orders, error)
 
 	// GetActiveOrders fetches active orders by owner from the orderbook contract.
 	GetActiveOrders(ctx context.Context, contractAddress string, ownerAddress string) (orderbookdomain.Orders, uint64, error)
@@ -55,7 +54,7 @@ func New(wasmClient wasmtypes.QueryClient) *orderbookClientImpl {
 }
 
 // GetOrdersByTick implements OrderBookClient.
-func (o *orderbookClientImpl) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]orderbookplugindomain.Order, error) {
+func (o *orderbookClientImpl) GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) (orderbookdomain.Orders, error) {
 	ordersByTick := ordersByTick{Tick: tick}
 
 	var orders ordersByTickResponse

--- a/domain/orderbook/grpcclient/orderbook_query_payloads.go
+++ b/domain/orderbook/grpcclient/orderbook_query_payloads.go
@@ -2,7 +2,6 @@ package orderbookgrpcclientdomain
 
 import (
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
-	orderbookplugindomain "github.com/osmosis-labs/sqs/domain/orderbook/plugin"
 )
 
 // ordersByTick is a struct that represents the request payload for the orders_by_tick query.
@@ -17,7 +16,7 @@ type ordersByTickRequest struct {
 
 // ordersByTickResponse is a struct that represents the response payload for the orders_by_tick query.
 type ordersByTickResponse struct {
-	Orders []orderbookplugindomain.Order `json:"orders"`
+	Orders []orderbookdomain.Order `json:"orders"`
 }
 
 // unrealizedCancelsRequestPayload is a struct that represents the payload for the get_unrealized_cancels query.

--- a/domain/orderbook/order.go
+++ b/domain/orderbook/order.go
@@ -65,6 +65,17 @@ func (o Orders) TickID() []int64 {
 	return tickIDs
 }
 
+// TODO
+func (o Orders) OrderByDirection(direction string) Orders {
+	var result Orders
+	for _, v := range o {
+		if v.OrderDirection == direction {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
 // Asset represents orderbook asset returned by the orderbook contract.
 type Asset struct {
 	Symbol   string `json:"symbol"`

--- a/domain/orderbook/orderbook_repository.go
+++ b/domain/orderbook/orderbook_repository.go
@@ -5,6 +5,7 @@ type OrderBookRepository interface {
 	StoreTicks(poolID uint64, ticksMap map[int64]OrderbookTick)
 
 	// GetTicks returns the orderbook ticks for a given orderbook pool id.
+	// Bool indicates whether ticks were found for the given orderbook pool id.
 	GetAllTicks(poolID uint64) (map[int64]OrderbookTick, bool)
 
 	// GetTicks returns specific orderbook ticks for a given orderbook pool id.

--- a/domain/orderbook/orderbook_tick.go
+++ b/domain/orderbook/orderbook_tick.go
@@ -27,9 +27,29 @@ type TickState struct {
 }
 
 type TickValues struct {
-	TotalAmountOfLiquidity      string `json:"total_amount_of_liquidity"`
-	CumulativeTotalValue        string `json:"cumulative_total_value"`
+	// Total Amount of Liquidity at tick (TAL)
+	// - Every limit order placement increments this value.
+	// - Every swap at this tick decrements this value.
+	// - Every cancellation decrements this value.
+	TotalAmountOfLiquidity string `json:"total_amount_of_liquidity"`
+
+	// Cumulative Total Limits at tick (CTT)
+	// - Every limit order placement increments this value.
+	// - There might be an edge-case optimization to lower this value.
+	CumulativeTotalValue string `json:"cumulative_total_value"`
+
+	// Effective Total Amount Swapped at tick (ETAS)
+	// - Every swap increments ETAS by the swap amount.
+	// - There will be other ways to update ETAS as described below.
 	EffectiveTotalAmountSwapped string `json:"effective_total_amount_swapped"`
-	CumulativeRealizedCancels   string `json:"cumulative_realized_cancels"`
-	LastTickSyncEtas            string `json:"last_tick_sync_etas"`
+
+	// Cumulative Realized Cancellations at tick
+	// - Increases as cancellations are checkpointed in batches on the sumtree
+	// - Equivalent to the prefix sum at the tick's current ETAS after being synced
+	CumulativeRealizedCancels string `json:"cumulative_realized_cancels"`
+
+	// last_tick_sync_etas is the ETAS value after the most recent tick sync.
+	// It is used to skip tick syncs if ETAS has not changed since the previous
+	// sync.
+	LastTickSyncEtas string `json:"last_tick_sync_etas"`
 }

--- a/domain/orderbook/plugin/config.go
+++ b/domain/orderbook/plugin/config.go
@@ -2,5 +2,6 @@ package orderbookplugindomain
 
 const (
 	// OrderBookPluginName is the name of the orderbook plugin.
-	OrderBookPluginName = "orderbook"
+	OrderBookPluginName        = "orderbook"
+	OrderBookClaimerPluginName = "orderbookclaimer"
 )

--- a/domain/orderbook/plugin/orderbook_grpc_client.go
+++ b/domain/orderbook/plugin/orderbook_grpc_client.go
@@ -2,10 +2,12 @@ package orderbookplugindomain
 
 import (
 	"context"
+
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 )
 
 // OrderbookCWAPIClient is an interface for fetching orders by tick from the orderbook contract.
 type OrderbookCWAPIClient interface {
 	// GetOrdersByTick fetches orders by tick from the orderbook contract.
-	GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) ([]Order, error)
+	GetOrdersByTick(ctx context.Context, contractAddress string, tick int64) (orderbookdomain.Orders, error)
 }

--- a/domain/orderbook/plugin/orderbook_order.go
+++ b/domain/orderbook/plugin/orderbook_order.go
@@ -1,21 +1,12 @@
 package orderbookplugindomain
 
-// Order represents an order in the orderbook returned by the orderbook contract.
-type Order struct {
-	TickId         int64  `json:"tick_id"`
-	OrderId        int64  `json:"order_id"`
-	OrderDirection string `json:"order_direction"`
-	Owner          string `json:"owner"`
-	Quantity       string `json:"quantity"`
-	Etas           string `json:"etas"`
-	ClaimBounty    string `json:"claim_bounty"`
-	PlacedQuantity string `json:"placed_quantity"`
-	PlacedAt       string `json:"placed_at"`
-}
+import (
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
+)
 
 // OrdersResponse represents the response from the orderbook contract containing the orders for a given tick.
 type OrdersResponse struct {
-	Address   string  `json:"address"`
-	BidOrders []Order `json:"bid_orders"`
-	AskOrders []Order `json:"ask_orders"`
+	Address   string                  `json:"address"`
+	BidOrders []orderbookdomain.Order `json:"bid_orders"`
+	AskOrders []orderbookdomain.Order `json:"ask_orders"`
 }

--- a/domain/slices/slices.go
+++ b/domain/slices/slices.go
@@ -1,0 +1,19 @@
+// Package slices provides utility functions for working with slices.
+package slices
+
+// Split splits given slice into chunks of specified size.
+// Returns a slice of slices, where each inner slice is a chunk of the original slice of given size.
+// The last chunk may be smaller than the specified size if the original slice length is not evenly divisible by the chunk size.
+func Split[T any](s []T, size int) [][]T {
+	var result [][]T
+
+	for l := 0; l < len(s); l += size {
+		h := l + size
+		if h > len(s) {
+			h = len(s)
+		}
+		result = append(result, s[l:h])
+	}
+
+	return result
+}

--- a/domain/slices/slices_test.go
+++ b/domain/slices/slices_test.go
@@ -1,0 +1,63 @@
+package slices_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/osmosis-labs/sqs/domain/slices"
+)
+
+func TestSplit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []int
+		size     int
+		expected [][]int
+	}{
+		{
+			name:     "empty slice",
+			input:    []int{},
+			size:     3,
+			expected: nil,
+		},
+		{
+			name:     "slice smaller than chunk size",
+			input:    []int{1, 2},
+			size:     3,
+			expected: [][]int{{1, 2}},
+		},
+		{
+			name:     "slice equal to chunk size",
+			input:    []int{1, 2, 3},
+			size:     3,
+			expected: [][]int{{1, 2, 3}},
+		},
+		{
+			name:     "slice larger than chunk size",
+			input:    []int{1, 2, 3, 4, 5},
+			size:     2,
+			expected: [][]int{{1, 2}, {3, 4}, {5}},
+		},
+		{
+			name:     "slice multiple of chunk size",
+			input:    []int{1, 2, 3, 4, 5, 6},
+			size:     2,
+			expected: [][]int{{1, 2}, {3, 4}, {5, 6}},
+		},
+		{
+			name:     "chunk size of 1",
+			input:    []int{1, 2, 3},
+			size:     1,
+			expected: [][]int{{1}, {2}, {3}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := slices.Split(tt.input, tt.size)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Split(%v, %d) = %v, want %v", tt.input, tt.size, result, tt.expected)
+			}
+		})
+	}
+}

--- a/ingest/usecase/plugins/orderbookfiller/fillable_orders.go
+++ b/ingest/usecase/plugins/orderbookfiller/fillable_orders.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 
 	clmath "github.com/osmosis-labs/osmosis/v26/x/concentrated-liquidity/math"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	orderbookplugindomain "github.com/osmosis-labs/sqs/domain/orderbook/plugin"
 
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
@@ -132,7 +133,7 @@ func applyFee(amount osmomath.Int, fee osmomath.Dec) osmomath.Int {
 // Iterates over all ask orders, identifying their ticks.
 // Compares the order tick to the current tick. If ask order is below the market tick, it is fillable.
 // In that case, we determine the remaining ask liquidity on that tick, applying the price to get its value in the quote denom.
-func (o *orderbookFillerIngestPlugin) getFillableAskAmountInQuoteDenom(askOrders []orderbookplugindomain.Order, currentTick int64, tickRemainingLiqMap map[int64]cosmwasmpool.OrderbookTickLiquidity) (osmomath.Int, error) {
+func (o *orderbookFillerIngestPlugin) getFillableAskAmountInQuoteDenom(askOrders []orderbookdomain.Order, currentTick int64, tickRemainingLiqMap map[int64]cosmwasmpool.OrderbookTickLiquidity) (osmomath.Int, error) {
 	fillableAskAmountInQuoteDenom := osmomath.ZeroBigDec()
 
 	// Multiple orders may be placed on the same tick, so we need to keep track of which ticks we have processed
@@ -178,7 +179,7 @@ func (o *orderbookFillerIngestPlugin) getFillableAskAmountInQuoteDenom(askOrders
 // Iterates over all bid orders, identifying their ticks.
 // Compares the order tick to the current tick. If bid order is above the market tick, it is fillable.
 // In that case, we determine the remaining bi liquidity on that tick, applying the price to get its value in the base denom.
-func (o *orderbookFillerIngestPlugin) getFillableBidAmountInBaseDenom(bidOrders []orderbookplugindomain.Order, currentTick int64, tickRemainingLiqMap map[int64]cosmwasmpool.OrderbookTickLiquidity) (osmomath.Int, error) {
+func (o *orderbookFillerIngestPlugin) getFillableBidAmountInBaseDenom(bidOrders []orderbookdomain.Order, currentTick int64, tickRemainingLiqMap map[int64]cosmwasmpool.OrderbookTickLiquidity) (osmomath.Int, error) {
 	fillableBidAmountInBaseDenom := osmomath.ZeroBigDec()
 
 	// Multiple orders may be placed on the same tick, so we need to keep track of which ticks we have processed

--- a/ingest/usecase/plugins/orderbookfiller/tick_fetcher.go
+++ b/ingest/usecase/plugins/orderbookfiller/tick_fetcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/osmosis-labs/sqs/domain"
+	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	orderbookplugindomain "github.com/osmosis-labs/sqs/domain/orderbook/plugin"
 )
 
@@ -16,8 +17,8 @@ func (o *orderbookFillerIngestPlugin) fetchTicksForOrderbook(ctx context.Context
 	ticks := orderBookPool.GetSQSPoolModel().CosmWasmPoolModel.Data.Orderbook.Ticks
 
 	orderResult := orderbookplugindomain.OrdersResponse{
-		AskOrders: []orderbookplugindomain.Order{},
-		BidOrders: []orderbookplugindomain.Order{},
+		AskOrders: []orderbookdomain.Order{},
+		BidOrders: []orderbookdomain.Order{},
 	}
 	for _, tick := range ticks {
 		orders, err := o.orderbookCWAAPIClient.GetOrdersByTick(ctx, orderbook.ContractAddress, tick.TickId)

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -13,17 +13,6 @@ func (o *OrderbookUseCaseImpl) SetFetchActiveOrdersEveryDuration(duration time.D
 	fetchActiveOrdersDuration = duration
 }
 
-// CreateFormattedLimitOrder is an alias of createFormattedLimitOrder for testing purposes
-func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
-	poolID uint64,
-	order orderbookdomain.Order,
-	quoteAsset orderbookdomain.Asset,
-	baseAsset orderbookdomain.Asset,
-	orderbookAddress string,
-) (orderbookdomain.LimitOrder, error) {
-	return o.createFormattedLimitOrder(poolID, order, quoteAsset, baseAsset, orderbookAddress)
-}
-
 // ProcessOrderBookActiveOrders is an alias of processOrderBookActiveOrders for testing purposes
 func (o *OrderbookUseCaseImpl) ProcessOrderBookActiveOrders(ctx context.Context, orderBook domain.CanonicalOrderBooksResult, ownerAddress string) ([]orderbookdomain.LimitOrder, bool, error) {
 	return o.processOrderBookActiveOrders(ctx, orderBook, ownerAddress)


### PR DESCRIPTION
This PR was opened as part of bigger claimbot feature to keep PRs small, focused and more manageable and implements slices package containing various helper functions for manipulating slices. Slices pacakge is [directly](https://github.com/osmosis-labs/sqs/pull/524/files#diff-9c91025a0f9e383b452c4f91a803200bdeb323f4511b300b44e5ab6bdf19c628R132) used by claimbot plugin to split claim orders into chunks of predined size ( maximum of `100` defined by the contract ).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced `OrderBookClaimerPlugin` for enhanced order book processing.
  - Added `CreateFormattedLimitOrder` method to streamline order creation.
  - New utility function `Split` for slice manipulation.

- **Improvements**
  - Updated configuration to enable `OrderBookClaimerPlugin`.
  - Enhanced error handling and parameter naming for clarity in order processing methods.

- **Bug Fixes**
  - Resolved type inconsistencies in order handling across various components. 

- **Documentation**
  - Added comments for clarity in method functionalities and struct fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->