### PR TITLE
BE-594/domain/slices | Slices package

### DIFF
--- a/domain/slices/slices.go
+++ b/domain/slices/slices.go
@@ -1,0 +1,19 @@
+// Package slices provides utility functions for working with slices.
+package slices
+
+// Split splits given slice into chunks of specified size.
+// Returns a slice of slices, where each inner slice is a chunk of the original slice of given size.
+// The last chunk may be smaller than the specified size if the original slice length is not evenly divisible by the chunk size.
+func Split[T any](s []T, size int) [][]T {
+	var result [][]T
+
+	for l := 0; l < len(s); l += size {
+		h := l + size
+		if h > len(s) {
+			h = len(s)
+		}
+		result = append(result, s[l:h])
+	}
+
+	return result
+}

--- a/domain/slices/slices_test.go
+++ b/domain/slices/slices_test.go
@@ -1,0 +1,63 @@
+package slices_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/osmosis-labs/sqs/domain/slices"
+)
+
+func TestSplit(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []int
+		size     int
+		expected [][]int
+	}{
+		{
+			name:     "empty slice",
+			input:    []int{},
+			size:     3,
+			expected: nil,
+		},
+		{
+			name:     "slice smaller than chunk size",
+			input:    []int{1, 2},
+			size:     3,
+			expected: [][]int{{1, 2}},
+		},
+		{
+			name:     "slice equal to chunk size",
+			input:    []int{1, 2, 3},
+			size:     3,
+			expected: [][]int{{1, 2, 3}},
+		},
+		{
+			name:     "slice larger than chunk size",
+			input:    []int{1, 2, 3, 4, 5},
+			size:     2,
+			expected: [][]int{{1, 2}, {3, 4}, {5}},
+		},
+		{
+			name:     "slice multiple of chunk size",
+			input:    []int{1, 2, 3, 4, 5, 6},
+			size:     2,
+			expected: [][]int{{1, 2}, {3, 4}, {5, 6}},
+		},
+		{
+			name:     "chunk size of 1",
+			input:    []int{1, 2, 3},
+			size:     1,
+			expected: [][]int{{1}, {2}, {3}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := slices.Split(tt.input, tt.size)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Split(%v, %d) = %v, want %v", tt.input, tt.size, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR was opened as part of bigger claimbot feature to keep PRs small, focused and more manageable and implements slices package containing various helper functions for manipulating slices. Slices package is [directly](https://github.com/osmosis-labs/sqs/pull/524/files#diff-9c91025a0f9e383b452c4f91a803200bdeb323f4511b300b44e5ab6bdf19c628R132) used by claimbot plugin to split claim orders into chunks of predined size ( maximum of `100` defined by the contract ).