### PR TITLE
BE-594/keyring | Read from file backend when multiple backends are available

### DIFF
--- a/domain/keyring/osmosis_keyring.go
+++ b/domain/keyring/osmosis_keyring.go
@@ -56,6 +56,9 @@ func New() (*keyringImpl, error) {
 	}
 
 	keyringConfig := keyring.Config{
+		AllowedBackends: []keyring.BackendType{
+			keyring.FileBackend,
+		},
 		ServiceName:              keyringServiceName,
 		FileDir:                  keyringPathEnv,
 		KeychainTrustApplication: true,
@@ -64,16 +67,15 @@ func New() (*keyringImpl, error) {
 		},
 	}
 
-	// Open the keyring
 	openKeyring, err := keyring.Open(keyringConfig)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to open keyring [ %s ]: %w", keyringPathEnv, err)
 	}
 
 	// Get the keyring record
 	openRecord, err := openKeyring.Get(keyringKeyName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Unable to get keyring record [ %s ]: %w", keyringKeyName, err)
 	}
 
 	// Unmarshal the keyring record


### PR DESCRIPTION
Fixes issue where when multiple backends are available on the system. On such systems keyring attempts to read credentials from first available backend which may be not file backend. At the moment we are using only file backend for test keyring. For example in [fillbot](https://github.com/osmosis-labs/sqs/tree/v26.x/ingest/usecase/plugins/orderbookfiller).

Additionally, improves returned logging messages to make debugging easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced keyring configuration by restricting backend options to only `FileBackend`.
  
- **Bug Fixes**
	- Improved error handling with more descriptive messages for keyring operations, aiding in easier diagnosis of issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->