### PR TITLE
BE-594/CreateFormattedLimitOrder | OrderbookUsecase CreateFormattedLimitOrder

### DIFF
--- a/domain/mocks/orderbook_usecase_mock.go
+++ b/domain/mocks/orderbook_usecase_mock.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"context"
 
+	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	"github.com/osmosis-labs/sqs/sqsdomain"
@@ -12,10 +13,11 @@ var _ mvc.OrderBookUsecase = &OrderbookUsecaseMock{}
 
 // OrderbookUsecaseMock is a mock implementation of the RouterUsecase interface
 type OrderbookUsecaseMock struct {
-	ProcessPoolFunc           func(ctx context.Context, pool sqsdomain.PoolI) error
-	GetAllTicksFunc           func(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool)
-	GetActiveOrdersFunc       func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
-	GetActiveOrdersStreamFunc func(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult
+	ProcessPoolFunc               func(ctx context.Context, pool sqsdomain.PoolI) error
+	GetAllTicksFunc               func(poolID uint64) (map[int64]orderbookdomain.OrderbookTick, bool)
+	GetActiveOrdersFunc           func(ctx context.Context, address string) ([]orderbookdomain.LimitOrder, bool, error)
+	GetActiveOrdersStreamFunc     func(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult
+	CreateFormattedLimitOrderFunc func(orderbook domain.CanonicalOrderBooksResult, order orderbookdomain.Order) (orderbookdomain.LimitOrder, error)
 }
 
 func (m *OrderbookUsecaseMock) ProcessPool(ctx context.Context, pool sqsdomain.PoolI) error {
@@ -42,6 +44,18 @@ func (m *OrderbookUsecaseMock) GetActiveOrders(ctx context.Context, address stri
 func (m *OrderbookUsecaseMock) GetActiveOrdersStream(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult {
 	if m.GetActiveOrdersStreamFunc != nil {
 		return m.GetActiveOrdersStreamFunc(ctx, address)
+	}
+	panic("unimplemented")
+}
+func (m *OrderbookUsecaseMock) WithCreateFormattedLimitOrder(order orderbookdomain.LimitOrder, err error) {
+	m.CreateFormattedLimitOrderFunc = func(domain.CanonicalOrderBooksResult, orderbookdomain.Order) (orderbookdomain.LimitOrder, error) {
+		return order, err
+	}
+}
+
+func (m *OrderbookUsecaseMock) CreateFormattedLimitOrder(orderbook domain.CanonicalOrderBooksResult, order orderbookdomain.Order) (orderbookdomain.LimitOrder, error) {
+	if m.CreateFormattedLimitOrderFunc != nil {
+		return m.CreateFormattedLimitOrderFunc(orderbook, order)
 	}
 	panic("unimplemented")
 }

--- a/domain/mvc/orderbook.go
+++ b/domain/mvc/orderbook.go
@@ -3,6 +3,7 @@ package mvc
 import (
 	"context"
 
+	"github.com/osmosis-labs/sqs/domain"
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 )
@@ -21,4 +22,7 @@ type OrderBookUsecase interface {
 	// The caller should range over the channel, but note that channel is never closed since there may be multiple
 	// sender goroutines.
 	GetActiveOrdersStream(ctx context.Context, address string) <-chan orderbookdomain.OrderbookResult
+
+	// CreateFormattedLimitOrder creates a formatted limit order from the given orderbook and order.
+	CreateFormattedLimitOrder(orderbook domain.CanonicalOrderBooksResult, order orderbookdomain.Order) (orderbookdomain.LimitOrder, error)
 }

--- a/orderbook/usecase/export_test.go
+++ b/orderbook/usecase/export_test.go
@@ -13,17 +13,6 @@ func (o *OrderbookUseCaseImpl) SetFetchActiveOrdersEveryDuration(duration time.D
 	fetchActiveOrdersDuration = duration
 }
 
-// CreateFormattedLimitOrder is an alias of createFormattedLimitOrder for testing purposes
-func (o *OrderbookUseCaseImpl) CreateFormattedLimitOrder(
-	poolID uint64,
-	order orderbookdomain.Order,
-	quoteAsset orderbookdomain.Asset,
-	baseAsset orderbookdomain.Asset,
-	orderbookAddress string,
-) (orderbookdomain.LimitOrder, error) {
-	return o.createFormattedLimitOrder(poolID, order, quoteAsset, baseAsset, orderbookAddress)
-}
-
 // ProcessOrderBookActiveOrders is an alias of processOrderBookActiveOrders for testing purposes
 func (o *OrderbookUseCaseImpl) ProcessOrderBookActiveOrders(ctx context.Context, orderBook domain.CanonicalOrderBooksResult, ownerAddress string) ([]orderbookdomain.LimitOrder, bool, error) {
 	return o.processOrderBookActiveOrders(ctx, orderBook, ownerAddress)


### PR DESCRIPTION
This PR refactors `OrderbookUsecase` to expose `CreateFormattedLimitOrder` as public method. That allows to reuse existing code for dealing with limit orders such as for example computing fill percentage of the orders. `CreateFormattedLimitOrder` is exactly for that purpose used in the claimbot [here](https://github.com/osmosis-labs/sqs/pull/524/files#diff-80b5c2dcaf125715c6fe9ea7cc7bb7ed806b1323e8721647fef1eaa8b659e1c6R172).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for creating formatted limit orders, enhancing order processing capabilities.
	- Added functionality to set predefined behaviors for testing limit order creation.

- **Bug Fixes**
	- Improved error handling and consistency in parameter naming for better clarity and maintainability.

- **Refactor**
	- Updated method signatures and refactored existing methods for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->