### PR TITLE
BE-602 | Add metric for logging height of the block being processed

### DIFF
--- a/domain/telemetry.go
+++ b/domain/telemetry.go
@@ -3,6 +3,14 @@ package domain
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
+	// sqs_ingest_usecase_process_block_height
+	//
+	// counter that measures the height of a block being processed in ingest usecase
+	//
+	// Has the following labels:
+	// * height - the height of the block being processed
+	SQSIngestUsecaseProcessBlockHeightMetricName = "sqs_ingest_usecase_process_block_height"
+
 	// sqs_ingest_usecase_process_block_duration
 	//
 	// gauge that measures the duration of processing a block in milliseconds in ingest usecase
@@ -142,6 +150,13 @@ var (
 	//
 	// counter that measures the number of pricing coingecko cache misses
 	SQSPricingCoingeckoCacheMissesCounterMetricName = "sqs_pricing_coingecko_cache_misses_total"
+
+	SQSIngestHandlerProcessBlockHeightGauge = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: SQSIngestUsecaseProcessBlockHeightMetricName,
+			Help: "counter that measures the height of a block being processed in ingest usecase",
+		},
+	)
 
 	SQSIngestHandlerProcessBlockDurationGauge = prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -293,6 +308,7 @@ var (
 )
 
 func init() {
+	prometheus.MustRegister(SQSIngestHandlerProcessBlockHeightGauge)
 	prometheus.MustRegister(SQSIngestHandlerProcessBlockDurationGauge)
 	prometheus.MustRegister(SQSIngestHandlerProcessBlockErrorCounter)
 	prometheus.MustRegister(SQSIngestHandlerProcessOrderbookPoolErrorCounter)

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -199,6 +199,7 @@ func (p *ingestUseCase) ProcessBlockData(ctx context.Context, height uint64, tak
 	go p.executeEndBlockProcessPlugins(ctx, height, uniqueBlockPoolMetadata)
 
 	// Observe the processing duration with height
+	domain.SQSIngestHandlerProcessBlockHeightGauge.Set(float64(height))
 	domain.SQSIngestHandlerProcessBlockDurationGauge.Set(float64(time.Since(startProcessingTime).Milliseconds()))
 
 	return nil


### PR DESCRIPTION
Adds new Prometheus Gauge for logging height of the block being processed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new metric for monitoring block height during SQS ingestion, enhancing observability.
- **Bug Fixes**
	- Ensured core functionality remains unchanged while implementing the new metric.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->