### PR TITLE
BE-586 | Orders, LimitOrder helper methods

### DIFF
--- a/domain/orderbook/order.go
+++ b/domain/orderbook/order.go
@@ -65,6 +65,18 @@ func (o Orders) TickID() []int64 {
 	return tickIDs
 }
 
+// OrderByDirection filters orders by given direction and returns resulting slice.
+// Original slice is not mutated.
+func (o Orders) OrderByDirection(direction string) Orders {
+	var result Orders
+	for _, v := range o {
+		if v.OrderDirection == direction {
+			result = append(result, v)
+		}
+	}
+	return result
+}
+
 // Asset represents orderbook asset returned by the orderbook contract.
 type Asset struct {
 	Symbol   string `json:"symbol"`
@@ -92,6 +104,12 @@ type LimitOrder struct {
 	QuoteAsset       Asset        `json:"quote_asset"`
 	BaseAsset        Asset        `json:"base_asset"`
 	PlacedTx         *string      `json:"placed_tx,omitempty"`
+}
+
+// IsClaimable reports whether the limit order is filled above the given
+// threshold to be considered as claimable.
+func (o LimitOrder) IsClaimable(threshold osmomath.Dec) bool {
+	return o.PercentFilled.GT(threshold) && o.PercentFilled.LTE(osmomath.OneDec())
 }
 
 // OrderbookResult represents orderbook orders result.

--- a/domain/orderbook/order_test.go
+++ b/domain/orderbook/order_test.go
@@ -5,6 +5,8 @@ import (
 
 	orderbookdomain "github.com/osmosis-labs/sqs/domain/orderbook"
 
+	"github.com/osmosis-labs/osmosis/osmomath"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -72,6 +74,114 @@ func TestOrderStatus(t *testing.T) {
 				assert.Error(t, err)
 			}
 			assert.Equal(t, tt.expected, status)
+		})
+	}
+}
+
+func TestOrdersByDirection(t *testing.T) {
+	testCases := []struct {
+		name           string
+		orders         orderbookdomain.Orders
+		direction      string
+		expectedOrders orderbookdomain.Orders
+	}{
+		{
+			name: "Filter buy orders",
+			orders: orderbookdomain.Orders{
+				{OrderDirection: "buy", OrderId: 1},
+				{OrderDirection: "sell", OrderId: 2},
+				{OrderDirection: "buy", OrderId: 3},
+			},
+			direction: "buy",
+			expectedOrders: orderbookdomain.Orders{
+				{OrderDirection: "buy", OrderId: 1},
+				{OrderDirection: "buy", OrderId: 3},
+			},
+		},
+		{
+			name: "Filter sell orders",
+			orders: orderbookdomain.Orders{
+				{OrderDirection: "buy", OrderId: 1},
+				{OrderDirection: "sell", OrderId: 2},
+				{OrderDirection: "buy", OrderId: 3},
+				{OrderDirection: "sell", OrderId: 4},
+			},
+			direction: "sell",
+			expectedOrders: orderbookdomain.Orders{
+				{OrderDirection: "sell", OrderId: 2},
+				{OrderDirection: "sell", OrderId: 4},
+			},
+		},
+		{
+			name: "No matching orders",
+			orders: orderbookdomain.Orders{
+				{OrderDirection: "buy", OrderId: 1},
+				{OrderDirection: "buy", OrderId: 2},
+			},
+			direction:      "sell",
+			expectedOrders: nil,
+		},
+		{
+			name:           "Empty orders slice",
+			orders:         orderbookdomain.Orders{},
+			direction:      "buy",
+			expectedOrders: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.orders.OrderByDirection(tc.direction)
+			assert.Equal(t, tc.expectedOrders, result)
+		})
+	}
+}
+
+func TestLimitOrder_IsClaimable(t *testing.T) {
+	tests := []struct {
+		name      string
+		order     orderbookdomain.LimitOrder
+		threshold osmomath.Dec
+		want      bool
+	}{
+		{
+			name: "Fully filled order",
+			order: orderbookdomain.LimitOrder{
+				PercentFilled: osmomath.NewDec(1),
+			},
+			threshold: osmomath.NewDecWithPrec(4, 1), // 0.4
+			want:      true,
+		},
+		{
+			name: "Partially filled order above threshold",
+			order: orderbookdomain.LimitOrder{
+				PercentFilled: osmomath.NewDecWithPrec(75, 2), // 0.75
+			},
+			threshold: osmomath.NewDecWithPrec(6, 1), // 0.6
+			want:      true,
+		},
+		{
+			name: "Partially filled order below threshold",
+			order: orderbookdomain.LimitOrder{
+				PercentFilled: osmomath.NewDecWithPrec(85, 2), // 0.85
+			},
+			threshold: osmomath.NewDecWithPrec(9, 1), // 0.9
+			want:      false,
+		},
+		{
+			name: "Unfilled order",
+			order: orderbookdomain.LimitOrder{
+				PercentFilled: osmomath.NewDec(0),
+			},
+			threshold: osmomath.NewDecWithPrec(1, 1), // 0.1
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.order.IsClaimable(tt.threshold)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
Introduces filtering by direction helper method for `Orders` and helper method for `LimitOrder` to determine whether the given LimitOrder is claimable or not. 

Orginally those methods were introduced and used in Claimbot implementation, for example [here](https://github.com/osmosis-labs/sqs/pull/524/files#diff-80b5c2dcaf125715c6fe9ea7cc7bb7ed806b1323e8721647fef1eaa8b659e1c6R182).