### PR TITLE
BE-586 | Fix fillbot docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ __debug_bin*
 debug.test*
 
 # Local env for the order book filler
-ingest/usecase/plugins/orderbookfiller/.env
+ingest/usecase/plugins/orderbook/fillbot/.env
 config_orderbook_fill_plugin.json
 
 .envrc

--- a/Makefile
+++ b/Makefile
@@ -228,7 +228,10 @@ datadog-agent-start:
 				-e DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT=0.0.0.0:4317 \
 				gcr.io/datadoghq/agent:latest
 
-#### Order Book Fill Bot Plugin
+
+#### Orderbook plugins ####
+####
+#### Orderbook Fill Bot Plugin
 
 # Starts the full-scale order fill bot.
 # - Creates a copy of the config.json file with the updated
@@ -236,7 +239,7 @@ datadog-agent-start:
 # Starts node and SQS in the background.
 # - Starts DataDog service
 # Use ./ingest/usecase/plugins/orderbook/fillbot/.env to configure the keyring.
-orderbook-filler-start:
+orderbook-fillbot-start:
 	./ingest/usecase/plugins/orderbook/fillbot/create_copy_config.sh
 	cd ./ingest/usecase/plugins/orderbook/fillbot && docker compose up -d
 	cd ../../../../
@@ -244,7 +247,7 @@ orderbook-filler-start:
 	sleep 10 && osmosisd status
 	sleep 10 && docker logs -f osmosis-sqs
 
-orderbook-filler-stop:
+orderbook-fillbot-stop:
 	cd ./ingest/usecase/plugins/orderbook/fillbot && docker compose down
 	cd ../../../../
 	echo "Order Book Filler Bot Stopped"	

--- a/ingest/usecase/plugins/orderbook/fillbot/README.md
+++ b/ingest/usecase/plugins/orderbook/fillbot/README.md
@@ -76,8 +76,8 @@ of POC implementation. In the future, this can be improved to support multiple b
 ## Starting (via docker compose)
 
 1. Ensure that the "Configuration" section is complete.
-2. From project root, `cd` into `ingest/usecase/plugins/orderbookfiller`
+2. From project root, `cd` into `ingest/usecase/plugins/orderbook/fillbot`
 3. Update `.env` with your environment variables.
-4. Run `make orderbook-filler-start`
+4. Run `make orderbook-fillbot-start`
 5. Run `osmosisd status` to check that the node is running and caught up to tip.
 6. Curl `/healthcheck` to check that SQS is running `curl http://localhost:9092/healthcheck`

--- a/ingest/usecase/plugins/orderbook/fillbot/docker-compose.yml
+++ b/ingest/usecase/plugins/orderbook/fillbot/docker-compose.yml
@@ -56,12 +56,12 @@ services:
       - SQS_GRPC_TENDERMINT_RPC_ENDPOINT=http://osmosis:26657
       - SQS_GRPC_GATEWAY_ENDPOINT=osmosis:9090
       - SQS_OTEL_ENVIRONMENT=sqs-fill-bot
-      - SQS_GRPC_INGESTER_PLUGINS_ORDERBOOK_ENABLED=true
+      - SQS_GRPC_INGESTER_PLUGINS_ORDERBOOK_FILLBOT_PLUGIN_ENABLED=true
     command:
       - --host
       - sqs-fill-bot
     build:
-      context: ../../../../
+      context: ../../../../../
       dockerfile: Dockerfile
     depends_on:
       - osmosis

--- a/ingest/usecase/plugins/orderbook/fillbot/docker-compose.yml
+++ b/ingest/usecase/plugins/orderbook/fillbot/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command:
       - start
       - --home=/osmosis/.osmosisd
-    image: osmolabs/osmosis-dev:v25.x-c775cee7-1722825184
+    image: osmolabs/osmosis:26.0.2
     container_name: osmosis
     restart: always
     ports:
@@ -56,7 +56,7 @@ services:
       - SQS_GRPC_TENDERMINT_RPC_ENDPOINT=http://osmosis:26657
       - SQS_GRPC_GATEWAY_ENDPOINT=osmosis:9090
       - SQS_OTEL_ENVIRONMENT=sqs-fill-bot
-      - SQS_GRPC_INGESTER_PLUGINS_ORDERBOOK_FILLBOT_PLUGIN_ENABLED=true
+      - SQS_GRPC_INGESTER_PLUGINS_ORDERBOOK_ENABLED=true
     command:
       - --host
       - sqs-fill-bot


### PR DESCRIPTION
Fixes errors running fillbot via docker-compose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `.gitignore` file to reflect changes in directory structure and added a new ignored configuration file.
	- Renamed Makefile targets for order book plugins to enhance consistency.
	- Corrected directory paths and command names in the README for the Order Book Filler Plugin.
	- Updated the service image version and adjusted the build context path in the `docker-compose.yml` for the orderbook fillbot service, along with minor formatting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->