### PR TITLE
chore: Fillbot read config.json

### DIFF
--- a/ingest/usecase/plugins/orderbook/fillbot/docker-compose.yml
+++ b/ingest/usecase/plugins/orderbook/fillbot/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command:
       - start
       - --home=/osmosis/.osmosisd
-    image: osmolabs/osmosis:26.0.2
+    image: osmolabs/osmosis:27.0.1
     container_name: osmosis
     restart: always
     ports:
@@ -60,6 +60,8 @@ services:
     command:
       - --host
       - sqs-fill-bot
+      - --config
+      - /etc/config.json
     build:
       context: ../../../../../
       dockerfile: Dockerfile
@@ -71,6 +73,7 @@ services:
       - 9092:9092
     volumes:
       - ${OSMOSIS_KEYRING_PATH}:${OSMOSIS_KEYRING_PATH}
+      - ../../../../../config.json:/etc/config.json
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Updates `docker-compose.yaml` for fillbot to read configuration from `config.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Upgraded the `osmosis` service to a new version, potentially enhancing performance and features.
	- Improved configuration management for the `osmosis-sqs` service with the addition of external configuration file support.

- **Bug Fixes**
	- Resolved issues related to configuration handling in the `osmosis-sqs` service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->