### PR TITLE
chore: Claimbot bump to v27

### DIFF
--- a/ingest/usecase/plugins/orderbook/claimbot/docker-compose.yml
+++ b/ingest/usecase/plugins/orderbook/claimbot/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     command:
       - start
       - --home=/osmosis/.osmosisd
-    image: osmolabs/osmosis:26.0.2
+    image: osmolabs/osmosis:27.0.1
     container_name: osmosis
     restart: always
     ports:


### PR DESCRIPTION
Updates docker-compose.yaml to update Node version to v27.