### PR TITLE
chore: bump the gas multiplier

### DIFF
--- a/domain/cosmos/tx/msg_simulator.go
+++ b/domain/cosmos/tx/msg_simulator.go
@@ -132,7 +132,7 @@ func (c *txGasCalulator) SimulateMsgs(encodingConfig cosmosclient.TxConfig, acco
 	txFactory = txFactory.WithAccountNumber(account.AccountNumber)
 	txFactory = txFactory.WithSequence(account.Sequence)
 	txFactory = txFactory.WithChainID(chainID)
-	txFactory = txFactory.WithGasAdjustment(1.05)
+	txFactory = txFactory.WithGasAdjustment(1.15)
 
 	// Estimate transaction
 	gasResult, adjustedGasUsed, err := c.calculateGas(


### PR DESCRIPTION
Bumps the gas multiplier on our claim bot, seem to be running out of gas a bit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced gas estimation during transaction simulations with an increased adjustment factor.
  
- **Bug Fixes**
	- Improved accuracy of gas calculations for transaction simulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->