### PR TITLE
BE-636-domain-packages | Add number package, introduce http helper

### DIFF
--- a/delivery/http/helper.go
+++ b/delivery/http/helper.go
@@ -1,0 +1,23 @@
+package http
+
+import (
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ParseBooleanQueryParam parses a boolean query parameter.
+// Returns false if the parameter is not present.
+// Errors if the value is not a valid boolean.
+// Returns the boolean value and an error if any.
+func ParseBooleanQueryParam(c echo.Context, paramName string) (paramValue bool, err error) {
+	paramValueStr := c.QueryParam(paramName)
+	if paramValueStr != "" {
+		paramValue, err = strconv.ParseBool(paramValueStr)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return paramValue, nil
+}

--- a/delivery/http/helper_test.go
+++ b/delivery/http/helper_test.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseBooleanQueryParam(t *testing.T) {
+	tests := []struct {
+		name          string
+		queryParam    string
+		expectedValue bool
+		expectedError bool
+	}{
+		{"True value", "param=true", true, false},
+		{"False value", "param=false", false, false},
+		{"1 as true", "param=1", true, false},
+		{"0 as false", "param=0", false, false},
+		{"Empty value", "", false, false},
+		{"Invalid value", "param=invalid", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/?"+tt.queryParam, nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			// Test
+			value, err := ParseBooleanQueryParam(c, "param")
+
+			// Assert
+			if tt.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedValue, value)
+			}
+		})
+	}
+}

--- a/domain/number/number.go
+++ b/domain/number/number.go
@@ -1,0 +1,51 @@
+// Package number provides utility functions for working with numbers.
+package number
+
+import (
+	"strconv"
+	"strings"
+)
+
+// ParseNumbers parses a comma-separated list of numbers into a slice of unit64.
+func ParseNumbers(numbersParam string) ([]uint64, error) {
+	var numbers []uint64
+	numStrings := splitAndTrim(numbersParam, ",")
+
+	for _, numStr := range numStrings {
+		num, err := strconv.ParseUint(numStr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		numbers = append(numbers, num)
+	}
+
+	return numbers, nil
+}
+
+// ParseNumberType parses a comma-separated list of numbers into a slice of the specified type.
+func ParseNumberType[T any](numbersParam string, parseFn func(s string) (T, error)) ([]T, error) {
+	numStrings := splitAndTrim(numbersParam, ",")
+
+	var numbers []T
+	for _, numStr := range numStrings {
+		num, err := parseFn(numStr)
+		if err != nil {
+			return nil, err
+		}
+		numbers = append(numbers, num)
+	}
+
+	return numbers, nil
+}
+
+// splitAndTrim splits a string by a separator and trims the resulting strings.
+func splitAndTrim(s, sep string) []string {
+	var result []string
+	for _, val := range strings.Split(s, sep) {
+		trimmed := strings.TrimSpace(val)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/domain/number/number_test.go
+++ b/domain/number/number_test.go
@@ -1,0 +1,159 @@
+package number
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseNumbers(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []uint64
+		wantErr bool
+	}{
+		{
+			name:  "valid numbers",
+			input: "1, 2, 3, 4, 5",
+			want:  []uint64{1, 2, 3, 4, 5},
+		},
+		{
+			name:  "single number",
+			input: "42",
+			want:  []uint64{42},
+		},
+		{
+			name:  "large numbers",
+			input: "1000000, 2000000, 3000000",
+			want:  []uint64{1000000, 2000000, 3000000},
+		},
+		{
+			name:    "invalid number",
+			input:   "1, 2, 3, abc, 5",
+			wantErr: true,
+		},
+		{
+			name:  "numbers with extra spaces",
+			input: "  1  ,  2  ,  3  ",
+			want:  []uint64{1, 2, 3},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "only commas",
+			input: ",,,",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseNumbers(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseNumberType(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		parseFunc   func(string) (any, error)
+		expected    any
+		expectError bool
+	}{
+		{
+			name:  "Parse uint64 numbers",
+			input: "1, 2, 3",
+			parseFunc: func(s string) (any, error) {
+				return strconv.ParseUint(s, 10, 64)
+			},
+			expected:    []uint64{1, 2, 3},
+			expectError: false,
+		},
+		{
+			name:  "Parse int numbers",
+			input: "-1, 0, 1",
+			parseFunc: func(s string) (any, error) {
+				return strconv.Atoi(s)
+			},
+			expected:    []int{-1, 0, 1},
+			expectError: false,
+		},
+		{
+			name:  "Parse float64 numbers",
+			input: "1.1, 2.2, 3.3",
+			parseFunc: func(s string) (any, error) {
+				return strconv.ParseFloat(s, 64)
+			},
+			expected:    []float64{1.1, 2.2, 3.3},
+			expectError: false,
+		},
+		{
+			name:  "Invalid input for uint64",
+			input: "1, 2, -3",
+			parseFunc: func(s string) (any, error) {
+				return strconv.ParseUint(s, 10, 64)
+			},
+			expected:    []uint64{},
+			expectError: true,
+		},
+		{
+			name:  "Empty input",
+			input: "",
+			parseFunc: func(s string) (any, error) {
+				return strconv.Atoi(s)
+			},
+			expected:    nil,
+			expectError: false,
+		},
+		{
+			name:  "Input with spaces",
+			input: "  1  ,  2  ,  3  ",
+			parseFunc: func(s string) (any, error) {
+				return strconv.Atoi(s)
+			},
+			expected:    []int{1, 2, 3},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result any
+			var err error
+
+			switch tt.expected.(type) {
+			case []uint64:
+				result, err = ParseNumberType(tt.input, func(s string) (uint64, error) {
+					return strconv.ParseUint(s, 10, 64)
+				})
+			case []int:
+				result, err = ParseNumberType(tt.input, func(s string) (int, error) {
+					return strconv.Atoi(s)
+				})
+			case []float64:
+				result, err = ParseNumberType(tt.input, func(s string) (float64, error) {
+					return strconv.ParseFloat(s, 64)
+				})
+			}
+
+			if tt.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}

--- a/domain/router_handlet_test.go
+++ b/domain/router_handlet_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/domain/number"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,7 +25,7 @@ func TestParseNumbers(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualNumbers, actualError := domain.ParseNumbers(testCase.input)
+		actualNumbers, actualError := number.ParseNumbers(testCase.input)
 
 		if testCase.expectedError {
 			require.Error(t, actualError)

--- a/domain/util.go
+++ b/domain/util.go
@@ -1,44 +1,5 @@
 package domain
 
-import (
-	"strconv"
-	"strings"
-
-	"github.com/labstack/echo/v4"
-)
-
-// ParseNumbers parses a comma-separated list of numbers into a slice of unit64.
-func ParseNumbers(numbersParam string) ([]uint64, error) {
-	var numbers []uint64
-	numStrings := splitAndTrim(numbersParam, ",")
-
-	for _, numStr := range numStrings {
-		num, err := strconv.ParseUint(numStr, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		numbers = append(numbers, num)
-	}
-
-	return numbers, nil
-}
-
-// ParseBooleanQueryParam parses a boolean query parameter.
-// Returns false if the parameter is not present.
-// Errors if the value is not a valid boolean.
-// Returns the boolean value and an error if any.
-func ParseBooleanQueryParam(c echo.Context, paramName string) (paramValue bool, err error) {
-	paramValueStr := c.QueryParam(paramName)
-	if paramValueStr != "" {
-		paramValue, err = strconv.ParseBool(paramValueStr)
-		if err != nil {
-			return false, err
-		}
-	}
-
-	return paramValue, nil
-}
-
 // ValidateInputDenoms returns nil of two denoms are valid, otherwise an error.
 // This is to be used as a parameter validation for queries.
 // For example, token in denom must not equal token out denom for quotes.
@@ -51,18 +12,6 @@ func ValidateInputDenoms(denomA, denomB string) error {
 	}
 
 	return nil
-}
-
-// splitAndTrim splits a string by a separator and trims the resulting strings.
-func splitAndTrim(s, sep string) []string {
-	var result []string
-	for _, val := range strings.Split(s, sep) {
-		trimmed := strings.TrimSpace(val)
-		if trimmed != "" {
-			result = append(result, trimmed)
-		}
-	}
-	return result
 }
 
 // Generic function to extract keys from any map.

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -8,8 +8,10 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
 
+	deliveryhttp "github.com/osmosis-labs/sqs/delivery/http"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
+	"github.com/osmosis-labs/sqs/domain/number"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
@@ -75,7 +77,7 @@ func (a *PoolsHandler) GetPools(c echo.Context) error {
 	// Get pool ID parameters as strings.
 	poolIDsStr := c.QueryParam("IDs")
 	minLiquidityCapStr := c.QueryParam("min_liquidity_cap")
-	withMarketIncentives, err := domain.ParseBooleanQueryParam(c, "with_market_incentives")
+	withMarketIncentives, err := deliveryhttp.ParseBooleanQueryParam(c, "with_market_incentives")
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ResponseError{Message: err.Error()})
 	}
@@ -85,7 +87,7 @@ func (a *PoolsHandler) GetPools(c echo.Context) error {
 	)
 
 	// Parse numbers
-	poolIDs, err := domain.ParseNumbers(poolIDsStr)
+	poolIDs, err := number.ParseNumbers(poolIDsStr)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ResponseError{Message: err.Error()})
 	}

--- a/router/types/get_direct_custom_quote_request.go
+++ b/router/types/get_direct_custom_quote_request.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/osmosis-labs/sqs/delivery/http"
 	"github.com/osmosis-labs/sqs/domain"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -25,7 +26,7 @@ type GetDirectCustomQuoteRequest struct {
 // It returns an error if the request is invalid.
 func (r *GetDirectCustomQuoteRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	var err error
-	r.ApplyExponents, err = domain.ParseBooleanQueryParam(c, "applyExponents")
+	r.ApplyExponents, err = http.ParseBooleanQueryParam(c, "applyExponents")
 	if err != nil {
 		return err
 	}

--- a/router/types/get_quote_request.go
+++ b/router/types/get_quote_request.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/delivery/http"
 	"github.com/osmosis-labs/sqs/domain"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -28,12 +29,12 @@ type GetQuoteRequest struct {
 // It returns an error if the request is invalid.
 func (r *GetQuoteRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	var err error
-	r.SingleRoute, err = domain.ParseBooleanQueryParam(c, "singleRoute")
+	r.SingleRoute, err = http.ParseBooleanQueryParam(c, "singleRoute")
 	if err != nil {
 		return err
 	}
 
-	r.ApplyExponents, err = domain.ParseBooleanQueryParam(c, "applyExponents")
+	r.ApplyExponents, err = http.ParseBooleanQueryParam(c, "applyExponents")
 	if err != nil {
 		return err
 	}
@@ -68,7 +69,7 @@ func (r *GetQuoteRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	r.SimulatorAddress = simulatorAddress
 	r.SlippageToleranceMultiplier = slippageToleranceDec
 
-	r.AppendBaseFee, err = domain.ParseBooleanQueryParam(c, "appendBaseFee")
+	r.AppendBaseFee, err = http.ParseBooleanQueryParam(c, "appendBaseFee")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR represents a smaller, more focused part of bigger PR https://github.com/osmosis-labs/sqs/pull/553 implementing sorting, filtering, pagination and search functionality for /pools endpoint. For bigger implementation picture refer to mentioned PR and for more context please refer to [BE-636](https://linear.app/osmosis/issue/BE-636/add-pagination-sorting-query-filtering-for-pools-endpoint).

To address cyclic import issues we move several utility functions to more focused packages. This issue arrised when [pools/http.go](https://github.com/osmosis-labs/sqs/pull/553/files#diff-c9710df631adba9dd9e7a51141f82e7818f1ccb41501a06e180dd7cac3af1bc4R8) imported `domain` package and at the same time `domain` package imported [api.GetPoolsRequestFilter](https://github.com/osmosis-labs/sqs/pull/553/files#diff-8185ee09355d9b346041a29c4115a08ff810d0bbc2e3f1ecd3428b1b1087f548R91). To resolve this issue we did following:

- `domain.ParseBooleanQueryParam`is moved to `http.ParseBooleanQueryParam`. As side effect `domain` package is now not aware of `http` layer and it's dependencies.
- `domain.ParseNumbers` to is moved to `number.ParseNumbers`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced new utility functions for parsing boolean query parameters and handling numerical data.
  
- **Bug Fixes**
	- Updated parsing logic for query parameters in various handlers to improve consistency and reliability.

- **Refactor**
	- Centralized parsing logic by replacing previous implementations with new functions from the `delivery/http` package.
	- Enhanced clarity in number parsing within the application.

These updates aim to streamline data handling and improve the overall functionality of the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->