### PR TITLE
BE-636-get-incentive | Pool Incentive helper method

### DIFF
--- a/domain/mocks/pool_mock.go
+++ b/domain/mocks/pool_mock.go
@@ -4,14 +4,15 @@ import (
 	"context"
 
 	"cosmossdk.io/math"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
+	api "github.com/osmosis-labs/sqs/pkg/api/v1beta1/pools"
 	"github.com/osmosis-labs/sqs/sqsdomain"
 	"github.com/osmosis-labs/sqs/sqsdomain/cosmwasmpool"
 	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
 
-	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/osmosis/v27/x/gamm/pool-models/balancer"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v27/x/poolmanager/types"
 )
@@ -32,6 +33,7 @@ type MockRoutablePool struct {
 	TakerFee          osmomath.Dec
 	SpreadFactor      osmomath.Dec
 	mockedTokenOut    sdk.Coin
+	IncentiveType     api.IncentiveType
 
 	APRData  sqspassthroughdomain.PoolAPRDataStatusWrap
 	FeesData sqspassthroughdomain.PoolFeesDataStatusWrap
@@ -175,6 +177,10 @@ func (mp *MockRoutablePool) ChargeTakerFeeExactIn(tokenIn sdk.Coin) (tokenInAfte
 // GetTakerFee implements sqsdomain.PoolI.
 func (mp *MockRoutablePool) GetTakerFee() math.LegacyDec {
 	return mp.TakerFee
+}
+
+func (mp *MockRoutablePool) Incentive() api.IncentiveType {
+	return mp.IncentiveType
 }
 
 var _ sqsdomain.PoolI = &MockRoutablePool{}

--- a/sqsdomain/pools_test.go
+++ b/sqsdomain/pools_test.go
@@ -1,0 +1,91 @@
+package sqsdomain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	api "github.com/osmosis-labs/sqs/pkg/api/v1beta1/pools"
+	sqspassthroughdomain "github.com/osmosis-labs/sqs/sqsdomain/passthroughdomain"
+)
+
+func TestPoolWrapper_Incentive(t *testing.T) {
+	tests := []struct {
+		name     string
+		aprData  sqspassthroughdomain.PoolAPRDataStatusWrap
+		expected api.IncentiveType
+	}{
+		{
+			name: "Superfluid Incentive",
+			aprData: sqspassthroughdomain.PoolAPRDataStatusWrap{
+				PoolAPR: sqspassthroughdomain.PoolAPR{
+					SuperfluidAPR: sqspassthroughdomain.PoolDataRange{Lower: 1, Upper: 2},
+					OsmosisAPR:    sqspassthroughdomain.PoolDataRange{Lower: 0, Upper: 0},
+				},
+			},
+			expected: api.IncentiveType_SUPERFLUID,
+		},
+		{
+			name: "Osmosis Incentive",
+			aprData: sqspassthroughdomain.PoolAPRDataStatusWrap{
+				PoolAPR: sqspassthroughdomain.PoolAPR{
+					SuperfluidAPR: sqspassthroughdomain.PoolDataRange{Lower: 0, Upper: 0},
+					OsmosisAPR:    sqspassthroughdomain.PoolDataRange{Lower: 1, Upper: 2},
+					BoostAPR:      sqspassthroughdomain.PoolDataRange{Lower: 0, Upper: 0},
+				},
+			},
+			expected: api.IncentiveType_OSMOSIS,
+		},
+		{
+			name: "Boost Incentive",
+			aprData: sqspassthroughdomain.PoolAPRDataStatusWrap{
+				PoolAPR: sqspassthroughdomain.PoolAPR{
+					BoostAPR: sqspassthroughdomain.PoolDataRange{Lower: 1, Upper: 2},
+				},
+			},
+			expected: api.IncentiveType_BOOST,
+		},
+		{
+			name: "No Incentive",
+			aprData: sqspassthroughdomain.PoolAPRDataStatusWrap{
+				PoolAPR: sqspassthroughdomain.PoolAPR{
+					SuperfluidAPR: sqspassthroughdomain.PoolDataRange{Lower: 0, Upper: 0},
+					OsmosisAPR:    sqspassthroughdomain.PoolDataRange{Lower: 0, Upper: 0},
+					BoostAPR:      sqspassthroughdomain.PoolDataRange{Lower: 0, Upper: 0},
+				},
+			},
+			expected: api.IncentiveType_NONE,
+		},
+		{
+			name: "Multiple Incentives - Superfluid Priority",
+			aprData: sqspassthroughdomain.PoolAPRDataStatusWrap{
+				PoolAPR: sqspassthroughdomain.PoolAPR{
+					SuperfluidAPR: sqspassthroughdomain.PoolDataRange{Lower: 1, Upper: 2},
+					OsmosisAPR:    sqspassthroughdomain.PoolDataRange{Lower: 1, Upper: 2},
+					BoostAPR:      sqspassthroughdomain.PoolDataRange{Lower: 1, Upper: 2},
+				},
+			},
+			expected: api.IncentiveType_SUPERFLUID,
+		},
+		{
+			name: "Multiple Incentives - Osmosis Priority",
+			aprData: sqspassthroughdomain.PoolAPRDataStatusWrap{
+				PoolAPR: sqspassthroughdomain.PoolAPR{
+					SuperfluidAPR: sqspassthroughdomain.PoolDataRange{Lower: 0, Upper: 0},
+					OsmosisAPR:    sqspassthroughdomain.PoolDataRange{Lower: 1, Upper: 2},
+					BoostAPR:      sqspassthroughdomain.PoolDataRange{Lower: 1, Upper: 2},
+				},
+			},
+			expected: api.IncentiveType_OSMOSIS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := &PoolWrapper{
+				APRData: tt.aprData,
+			}
+			assert.Equal(t, tt.expected, pool.Incentive())
+		})
+	}
+}


### PR DESCRIPTION
This PR represents a smaller, more focused part of bigger PR https://github.com/osmosis-labs/sqs/pull/553 implementing sorting, filtering, pagination and search functionality for /pools endpoint. For bigger implementation picture refer to mentioned PR and for more context please refer to [BE-636](https://linear.app/osmosis/issue/BE-636/add-pagination-sorting-query-filtering-for-pools-endpoint).

This PR adds Incentive helper method for Pool computing and returning its incentive type used for [WithMarketIncentives](https://github.com/osmosis-labs/sqs/pull/553/files#diff-8185ee09355d9b346041a29c4115a08ff810d0bbc2e3f1ecd3428b1b1087f548R125) filter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `IncentiveType` field to enhance the `MockRoutablePool` functionality.
	- Added an `Incentive()` method to retrieve incentive types based on APR data in the `PoolI` interface and its implementation.
  
- **Bug Fixes**
	- Improved handling of incentive types to ensure accurate returns based on APR conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->