### PR TITLE
BE-636-backwards-compatibility | Backwards compatibility support

### DIFF
--- a/pkg/api/v1beta1/pools/http.go
+++ b/pkg/api/v1beta1/pools/http.go
@@ -57,6 +57,14 @@ func (r *GetPoolsRequest) UnmarshalHTTPRequest(c echo.Context) error {
 	return nil
 }
 
+// IsLegacy checks if request contains deprecated query parameters.
+// It's used to determine backward compatibility.
+func (r *GetPoolsRequest) IsLegacy(c echo.Context) bool {
+	return c.QueryParam(queryIDs) != "" ||
+		c.QueryParam(queryMinLiquidityCap) != "" ||
+		c.QueryParam(queryWithMarketIncentives) != ""
+}
+
 // IsPresent checks if the pagination request is present in the HTTP request.
 func (r *GetPoolsRequestFilter) IsPresent(c echo.Context) bool {
 	return c.QueryParam(queryIDs) != "" ||

--- a/pools/delivery/http/pools_handler.go
+++ b/pools/delivery/http/pools_handler.go
@@ -105,7 +105,7 @@ func (a *PoolsHandler) GetPools(c echo.Context) error {
 	}
 
 	// Convert pools to the appropriate format
-	resultPools := convertPoolsToResponse(&req, pools, total)
+	resultPools := convertPoolsToResponse(c, &req, pools, total)
 
 	return c.JSON(http.StatusOK, resultPools)
 }
@@ -210,10 +210,14 @@ func convertPoolToResponse(pool sqsdomain.PoolI) PoolResponse {
 }
 
 // convertPoolsToResponse converts the given pools to the appropriate response type.
-func convertPoolsToResponse(req *api.GetPoolsRequest, p []sqsdomain.PoolI, total uint64) *GetPoolsResponse {
+func convertPoolsToResponse(c echo.Context, req *api.GetPoolsRequest, p []sqsdomain.PoolI, total uint64) any {
 	pools := make([]PoolResponse, 0, len(p))
 	for _, pool := range p {
 		pools = append(pools, convertPoolToResponse(pool))
+	}
+
+	if req.IsLegacy(c) {
+		return pools // backward compatibility
 	}
 
 	return &GetPoolsResponse{


### PR DESCRIPTION
Adds backwards compatibility support for /pools endpoint allowing independent deployment of SQS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to check for legacy query parameters in pool requests, enhancing backward compatibility.
	- Updated response handling to accommodate both legacy and new request types, improving user experience.

- **Bug Fixes**
	- Clarified deprecated query parameters in the request handling to guide users toward updated usage.

- **Refactor**
	- Modified function signatures to include context for improved request processing and compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->