### PR TITLE
BE-659 | Update required labels

### DIFF
--- a/.github/workflows/required-labels.yml
+++ b/.github/workflows/required-labels.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
     branches:
-      - "v26.x"
+      - "v27.x"
 
 jobs:
   backport_labels:
@@ -26,4 +26,4 @@ jobs:
         with: #Require one of the following labels
           mode: exactly
           count: 1
-          labels: "A:backport/v27.x"
+          labels: "A:backport/v28.x"


### PR DESCRIPTION
Pipeline: require backport to v28.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration for required labels to reflect new versioning and label requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->