### PR TITLE
Bump golang linter version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
           go-version-file: go.mod
       - name: Run golangci-lint
         if: env.GIT_DIFF
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
-          version: v1.54
+          version: v1.62
           skip-cache: true


### PR DESCRIPTION
## Summary

This updates the github action that runs golangci-lint and the linter to the last version