### PR TITLE
BE-682 | Set isBestEffort on error processing orderbook active orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 Unreleased
 
+- #608 - BE-682 | Set isBestEffort on error processing orderbook active orders
+
 ## v28.1.0
 
 - #599 - Decouple Node releases from SQS

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -242,7 +242,7 @@ func (o *OrderbookUseCaseImpl) GetActiveOrders(ctx context.Context, address stri
 				o.logger.Error(telemetry.ProcessingOrderbookActiveOrdersErrorMetricName, zap.Any("pool_id", result.PoolID), zap.Any("err", result.Error))
 			}
 
-			isBestEffort = isBestEffort || result.IsBestEffort
+			isBestEffort = isBestEffort || result.IsBestEffort || result.Error != nil
 
 			finalResults = append(finalResults, result.LimitOrders...)
 		case <-ctx.Done():

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -603,7 +603,7 @@ func (s *OrderbookUsecaseTestSuite) TestGetActiveOrders() {
 			expectedOrders: []orderbookdomain.LimitOrder{
 				s.NewLimitOrder().WithOrderID(1).WithOrderbookAddress("A").LimitOrder,
 			},
-			expectedIsBestEffort: false,
+			expectedIsBestEffort: true,
 		},
 	}
 


### PR DESCRIPTION
This pull request sets `isBestEffort` flag for the `active-orders`  when error is encountered making a call to `processOrderBookActiveOrders`. Such errors may to arise when for example SQS is having connection issues with the Node.

Before this fix SQS would return simply empty list in case of errors when  processing orderbook active orders, such as:

```json
{"orders":[],"is_best_effort":false}
```

In such cases client is not aware about such errors and possibly incomplete results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling in the active orders retrieval process by updating the logic for determining the `isBestEffort` flag to include error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->