### PR TITLE
BE-682 | Set isBestEffort when there are no orderbooks in the system to process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 Unreleased
 
+- #609 - BE-682 | Set isBestEffort when there are no orderbooks in the system to process
 - #608 - BE-682 | Set isBestEffort on error processing orderbook active orders
 
 ## v28.1.0

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -215,6 +215,13 @@ func (o *OrderbookUseCaseImpl) GetActiveOrders(ctx context.Context, address stri
 		return nil, false, types.FailedGetAllCanonicalOrderbookPoolIDsError{Err: err}
 	}
 
+	// Where there are no orderbooks, return early with best effort flag set to true
+	// Such cases are not considered an error, but it may indicate that the SQS
+	// is not receiving any orderbook data from the Node.
+	if len(orderbooks) == 0 {
+		return nil, true, nil
+	}
+
 	results := make(chan orderbookdomain.OrderbookResult, len(orderbooks))
 
 	// Process orderbooks concurrently

--- a/orderbook/usecase/orderbook_usecase.go
+++ b/orderbook/usecase/orderbook_usecase.go
@@ -215,7 +215,7 @@ func (o *OrderbookUseCaseImpl) GetActiveOrders(ctx context.Context, address stri
 		return nil, false, types.FailedGetAllCanonicalOrderbookPoolIDsError{Err: err}
 	}
 
-	// Where there are no orderbooks, return early with best effort flag set to true
+	// When there are no orderbooks, return early with best effort flag set to true
 	// Such cases are not considered an error, but it may indicate that the SQS
 	// is not receiving any orderbook data from the Node.
 	if len(orderbooks) == 0 {

--- a/orderbook/usecase/orderbook_usecase_test.go
+++ b/orderbook/usecase/orderbook_usecase_test.go
@@ -467,6 +467,20 @@ func (s *OrderbookUsecaseTestSuite) TestGetActiveOrders() {
 			expectedError: &types.FailedGetAllCanonicalOrderbookPoolIDsError{},
 		},
 		{
+			name: "no canonical orderbook pool IDs",
+			setupContext: func() context.Context {
+				return context.Background()
+			},
+			setupMocks: func(usecase *orderbookusecase.OrderbookUseCaseImpl, orderbookrepository *mocks.OrderbookRepositoryMock, grpcclient *mocks.OrderbookGRPCClientMock, poolsUsecase *mocks.PoolsUsecaseMock, tokensusecase *mocks.TokensUsecaseMock) {
+				poolsUsecase.GetAllCanonicalOrderbookPoolIDsFunc = func() ([]domain.CanonicalOrderBooksResult, error) {
+					return nil, nil
+				}
+			},
+			address:              "osmo1npsku4qlqav6udkvgfk9eran4s4edzu69vzdm6",
+			expectedError:        nil,
+			expectedIsBestEffort: true,
+		},
+		{
 			name: "context is done before processing all orderbooks",
 			setupContext: func() context.Context {
 				ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
Sets best effort flag for active-orders when there are no orderbooks in the system ingested yet that may indicate issues with no data incoming from the Node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced system behavior when no orderbooks are available
	- Improved handling of orderbook processing scenarios

- **Documentation**
	- Updated changelog to reflect new system handling approach for orderbook processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->