### PR TITLE
chore: remove toolchain go1.23.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/osmosis-labs/sqs
 
 go 1.22.7
 
-toolchain go1.23.3
-
 require (
 	cosmossdk.io/math v1.5.0
 	cosmossdk.io/store v1.1.1
@@ -113,7 +111,7 @@ require (
 	github.com/cockroachdb/redact v1.1.5 // indirect
 	github.com/cometbft/cometbft-db v0.14.1 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
-	github.com/cosmos/cosmos-proto v1.0.0-beta.5
+	github.com/cosmos/cosmos-proto v1.0.0-beta.5 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gogogateway v1.2.0 // indirect
 	github.com/cosmos/gogoproto v1.7.0

--- a/go.work
+++ b/go.work
@@ -1,5 +1,3 @@
 go 1.22.7
 
-toolchain go1.23.3
-
 use .


### PR DESCRIPTION
toolchain go1.23.3 is incompatible with a pubsub dependency. As a result, if one cleans their mod cache and redownloads the dependencies, they might start having issues building.

The problem has been observed on Macs. This change has been confirmed to resolved the issue in both cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined internal dependency management and streamlined build configuration.
	- These behind-the-scenes updates improve overall stability and maintainability without altering end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->