### PR TITLE
BE-687 | Cache for different swap methods

### DIFF
--- a/domain/mocks/router_usecase_mock.go
+++ b/domain/mocks/router_usecase_mock.go
@@ -28,7 +28,7 @@ type RouterUsecaseMock struct {
 	GetCandidateRoutesFunc                       func(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string) (ingesttypes.CandidateRoutes, error)
 	GetTakerFeeFunc                              func(poolID uint64) ([]ingesttypes.TakerFeeForPair, error)
 	SetTakerFeesFunc                             func(takerFees ingesttypes.TakerFeeMap)
-	GetCachedCandidateRoutesFunc                 func(ctx context.Context, tokenInDenom, tokenOutDenom string) (ingesttypes.CandidateRoutes, bool, error)
+	GetCachedCandidateRoutesFunc                 func(ctx context.Context, method domain.TokenSwapMethod, tokenInDenom, tokenOutDenom string) (ingesttypes.CandidateRoutes, bool, error)
 	StoreRouterStateFilesFunc                    func() error
 	GetRouterStateFunc                           func() (domain.RouterState, error)
 	GetSortedPoolsFunc                           func() []ingesttypes.PoolI
@@ -136,9 +136,9 @@ func (m *RouterUsecaseMock) SetTakerFees(takerFees ingesttypes.TakerFeeMap) {
 	}
 }
 
-func (m *RouterUsecaseMock) GetCachedCandidateRoutes(ctx context.Context, tokenInDenom, tokenOutDenom string) (ingesttypes.CandidateRoutes, bool, error) {
+func (m *RouterUsecaseMock) GetCachedCandidateRoutes(ctx context.Context, method domain.TokenSwapMethod, tokenInDenom, tokenOutDenom string) (ingesttypes.CandidateRoutes, bool, error) {
 	if m.GetCachedCandidateRoutesFunc != nil {
-		return m.GetCachedCandidateRoutesFunc(ctx, tokenInDenom, tokenOutDenom)
+		return m.GetCachedCandidateRoutesFunc(ctx, method, tokenInDenom, tokenOutDenom)
 	}
 	return ingesttypes.CandidateRoutes{}, false, nil
 }

--- a/domain/mvc/router.go
+++ b/domain/mvc/router.go
@@ -88,7 +88,7 @@ type RouterUsecase interface {
 	// It does not recompute the routes if they are not present in cache.
 	// Since we may cache zero routes, it returns false if the routes are not present in cache. Returns true otherwise.
 	// Returns error if cache is disabled.
-	GetCachedCandidateRoutes(ctx context.Context, tokenInDenom, tokenOutDenom string) (ingesttypes.CandidateRoutes, bool, error)
+	GetCachedCandidateRoutes(ctx context.Context, method domain.TokenSwapMethod, tokenInDenom, tokenOutDenom string) (ingesttypes.CandidateRoutes, bool, error)
 	// StoreRoutes stores all router state in the files locally. Used for debugging.
 	StoreRouterStateFiles() error
 

--- a/router/delivery/http/router_handler.go
+++ b/router/delivery/http/router_handler.go
@@ -315,7 +315,7 @@ func (a *RouterHandler) GetCachedCandidateRoutes(c echo.Context) error {
 		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
 	}
 
-	routes, _, err := a.RUsecase.GetCachedCandidateRoutes(ctx, tokenIn, tokenOutDenom)
+	routes, _, err := a.RUsecase.GetCachedCandidateRoutes(ctx, domain.TokenSwapMethodExactIn, tokenIn, tokenOutDenom)
 	if err != nil {
 		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
 	}

--- a/router/usecase/export_test.go
+++ b/router/usecase/export_test.go
@@ -49,16 +49,16 @@ func ConvertRankedToCandidateRoutes(rankedRoutes []route.RouteImpl) ingesttypes.
 	return convertRankedToCandidateRoutes(rankedRoutes)
 }
 
-func FormatRankedRouteCacheKey(tokenInDenom string, tokenOutDenom string, tokenIOrderOfMagnitude int) string {
-	return formatRankedRouteCacheKey(tokenInDenom, tokenOutDenom, tokenIOrderOfMagnitude)
+func FormatRankedRouteCacheKey(method domain.TokenSwapMethod, tokenInDenom string, tokenOutDenom string, tokenIOrderOfMagnitude int) string {
+	return formatRankedRouteCacheKey(method, tokenInDenom, tokenOutDenom, tokenIOrderOfMagnitude)
 }
 
-func FormatRouteCacheKey(tokenInDenom string, tokenOutDenom string) string {
-	return formatRouteCacheKey(tokenInDenom, tokenOutDenom)
+func FormatRouteCacheKey(method domain.TokenSwapMethod, tokenInDenom string, tokenOutDenom string) string {
+	return formatRouteCacheKey(method, tokenInDenom, tokenOutDenom)
 }
 
-func FormatCandidateRouteCacheKey(tokenInDenom string, tokenOutDenom string) string {
-	return formatCandidateRouteCacheKey(tokenInDenom, tokenOutDenom)
+func FormatCandidateRouteCacheKey(method domain.TokenSwapMethod, tokenInDenom string, tokenOutDenom string) string {
+	return formatCandidateRouteCacheKey(method, tokenInDenom, tokenOutDenom)
 }
 
 func SortPools(pools []ingesttypes.PoolI, transmuterCodeIDs map[uint64]struct{}, totalTVL osmomath.Int, preferredPoolIDsMap map[uint64]struct{}, logger log.Logger) []ingesttypes.PoolI {
@@ -77,16 +77,16 @@ func CutRoutesForSplits(maxSplitRoutes int, routes []route.RouteImpl) []route.Ro
 	return cutRoutesForSplits(maxSplitRoutes, routes)
 }
 
-func (r *routerUseCaseImpl) SetCandidateRouteCacheToMock(tokenInDenom, tokenOutDenom string) {
-	r.candidateRouteCache.Set(formatCandidateRouteCacheKey(tokenInDenom, tokenOutDenom), ingesttypes.CandidateRoutes{
+func (r *routerUseCaseImpl) SetCandidateRouteCacheToMock(method domain.TokenSwapMethod, tokenInDenom, tokenOutDenom string) {
+	r.candidateRouteCache.Set(formatCandidateRouteCacheKey(method, tokenInDenom, tokenOutDenom), ingesttypes.CandidateRoutes{
 		// Note: some mock dummy values
 		Routes: []ingesttypes.CandidateRoute{
 			{}, {},
 		}}, 0)
 }
 
-func (r *routerUseCaseImpl) SetRankedRouteCacheToMock(tokenInDenom, tokenOutDenom string, orderOfMagnitude int) {
-	r.rankedRouteCache.Set(formatRankedRouteCacheKey(tokenInDenom, tokenOutDenom, orderOfMagnitude), ingesttypes.CandidateRoutes{
+func (r *routerUseCaseImpl) SetRankedRouteCacheToMock(method domain.TokenSwapMethod, tokenInDenom, tokenOutDenom string, orderOfMagnitude int) {
+	r.rankedRouteCache.Set(formatRankedRouteCacheKey(method, tokenInDenom, tokenOutDenom, orderOfMagnitude), ingesttypes.CandidateRoutes{
 		// Note: some mock dummy values
 		Routes: []ingesttypes.CandidateRoute{
 			{}, {},

--- a/router/usecase/optimized_routes.go
+++ b/router/usecase/optimized_routes.go
@@ -59,9 +59,9 @@ func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteOutGivenIn(ctx contex
 		// Note: the zero length check occurred at the start of function.
 		tokenOutDenom := routes[0].GetTokenOutDenom()
 
-		r.candidateRouteCache.Delete(formatCandidateRouteCacheKey(tokenIn.Denom, tokenOutDenom))
+		r.candidateRouteCache.Delete(formatCandidateRouteCacheKey(domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom))
 		tokenInOrderOfMagnitude := GetPrecomputeOrderOfMagnitude(tokenIn.Amount)
-		r.rankedRouteCache.Delete(formatRankedRouteCacheKey(tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude))
+		r.rankedRouteCache.Delete(formatRankedRouteCacheKey(domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude))
 
 		return nil, nil, errors[0]
 	}
@@ -124,9 +124,9 @@ func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteInGivenOut(ctx contex
 		// Note: the zero length check occurred at the start of function.
 		tokenOutDenom := routes[0].GetTokenOutDenom()
 
-		r.candidateRouteCache.Delete(formatCandidateRouteCacheKey(tokenOut.Denom, tokenOutDenom))
+		r.candidateRouteCache.Delete(formatCandidateRouteCacheKey(domain.TokenSwapMethodExactOut, tokenOut.Denom, tokenOutDenom))
 		tokenInOrderOfMagnitude := GetPrecomputeOrderOfMagnitude(tokenOut.Amount)
-		r.rankedRouteCache.Delete(formatRankedRouteCacheKey(tokenOut.Denom, tokenOutDenom, tokenInOrderOfMagnitude))
+		r.rankedRouteCache.Delete(formatRankedRouteCacheKey(domain.TokenSwapMethodExactOut, tokenOut.Denom, tokenOutDenom, tokenInOrderOfMagnitude))
 
 		return nil, nil, errors[0]
 	}

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -832,7 +832,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuote_Mainnet_UOSMOU
 // are correctly ranked by amounts out.
 // Lastly, validates, that the candidate and ranked route cache gets invalidated if
 // all routes error.
-func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteOutGivenOut() {
+func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteOutGivenIn() {
 	// Setup mock router use case
 	mainnetState := s.SetupMainnetState()
 	usecase := s.SetupRouterAndPoolsUsecase(mainnetState)
@@ -980,8 +980,8 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteOutGivenOut() {
 		s.Run(tc.name, func() {
 
 			// Pre-set cache
-			routerUseCase.SetCandidateRouteCacheToMock(defaultTokenIn.Denom, tokenOutDenom)
-			routerUseCase.SetRankedRouteCacheToMock(defaultTokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude)
+			routerUseCase.SetCandidateRouteCacheToMock(domain.TokenSwapMethodExactIn, defaultTokenIn.Denom, tokenOutDenom)
+			routerUseCase.SetRankedRouteCacheToMock(domain.TokenSwapMethodExactIn, defaultTokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude)
 
 			// Construct routes from mock pools
 			routes := []route.RouteImpl{}
@@ -1182,8 +1182,8 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteInGivenOut() {
 		s.Run(tc.name, func() {
 
 			// Pre-set cache
-			routerUseCase.SetCandidateRouteCacheToMock(defaultTokenOut.Denom, tokenOutDenom)
-			routerUseCase.SetRankedRouteCacheToMock(defaultTokenOut.Denom, tokenOutDenom, tokenOutOrderOfMagnitude)
+			routerUseCase.SetCandidateRouteCacheToMock(domain.TokenSwapMethodExactOut, defaultTokenOut.Denom, tokenOutDenom)
+			routerUseCase.SetRankedRouteCacheToMock(domain.TokenSwapMethodExactOut, defaultTokenOut.Denom, tokenOutDenom, tokenOutOrderOfMagnitude)
 
 			// Construct routes from mock pools
 			routes := []route.RouteImpl{}

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -993,10 +993,10 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteOutGivenIn() {
 			quote, rankedRoutes, sytErr := routerUseCase.EstimateAndRankSingleRouteQuoteOutGivenIn(context.Background(), routes, defaultTokenIn, &log.NoOpLogger{})
 
 			// Get cache results
-			_, foundcandidateRoutes, err := routerUseCase.GetCachedCandidateRoutes(context.Background(), defaultTokenIn.Denom, tokenOutDenom)
+			_, foundcandidateRoutes, err := routerUseCase.GetCachedCandidateRoutes(context.Background(), domain.TokenSwapMethodExactIn, defaultTokenIn.Denom, tokenOutDenom)
 			s.Require().NoError(err)
 
-			cachedRankedRoutes, err := routerUseCase.GetCachedRankedRoutes(context.Background(), defaultTokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude)
+			cachedRankedRoutes, err := routerUseCase.GetCachedRankedRoutes(context.Background(), domain.TokenSwapMethodExactIn, defaultTokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude)
 			s.Require().NoError(err)
 
 			if tc.expectedError != nil {
@@ -1195,10 +1195,10 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteInGivenOut() {
 			quote, rankedRoutes, sytErr := routerUseCase.EstimateAndRankSingleRouteQuoteInGivenOut(context.Background(), routes, defaultTokenOut, &log.NoOpLogger{})
 
 			// Get cache results
-			_, foundcandidateRoutes, err := routerUseCase.GetCachedCandidateRoutes(context.Background(), defaultTokenOut.Denom, tokenOutDenom)
+			_, foundcandidateRoutes, err := routerUseCase.GetCachedCandidateRoutes(context.Background(), domain.TokenSwapMethodExactOut, defaultTokenOut.Denom, tokenOutDenom)
 			s.Require().NoError(err)
 
-			cachedRankedRoutes, err := routerUseCase.GetCachedRankedRoutes(context.Background(), defaultTokenOut.Denom, tokenOutDenom, tokenOutOrderOfMagnitude)
+			cachedRankedRoutes, err := routerUseCase.GetCachedRankedRoutes(context.Background(), domain.TokenSwapMethodExactOut, defaultTokenOut.Denom, tokenOutDenom, tokenOutOrderOfMagnitude)
 			s.Require().NoError(err)
 
 			if tc.expectedError != nil {

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -114,7 +114,7 @@ func (r *routerUseCaseImpl) GetOptimalQuoteOutGivenIn(ctx context.Context, token
 		// This is used for caching ranked routes as these might differ depending on the amount swapped in.
 		tokenInOrderOfMagnitude := GetPrecomputeOrderOfMagnitude(tokenIn.Amount)
 
-		candidateRankedRoutes, err = r.GetCachedRankedRoutes(ctx, tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude)
+		candidateRankedRoutes, err = r.GetCachedRankedRoutes(ctx, domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude)
 		if err != nil {
 			return nil, err
 		}
@@ -602,7 +602,7 @@ func (r *routerUseCaseImpl) GetTakerFee(poolID uint64) ([]ingesttypes.TakerFeeFo
 }
 
 // GetCachedCandidateRoutes implements mvc.RouterUsecase.
-func (r *routerUseCaseImpl) GetCachedCandidateRoutes(ctx context.Context, tokenInDenom string, tokenOutDenom string) (ingesttypes.CandidateRoutes, bool, error) {
+func (r *routerUseCaseImpl) GetCachedCandidateRoutes(ctx context.Context, method domain.TokenSwapMethod, tokenInDenom string, tokenOutDenom string) (ingesttypes.CandidateRoutes, bool, error) {
 	if !r.defaultConfig.RouteCacheEnabled {
 		return ingesttypes.CandidateRoutes{}, false, nil
 	}
@@ -613,7 +613,7 @@ func (r *routerUseCaseImpl) GetCachedCandidateRoutes(ctx context.Context, tokenI
 		return ingesttypes.CandidateRoutes{}, false, err
 	}
 
-	cachedCandidateRoutes, found := r.candidateRouteCache.Get(formatCandidateRouteCacheKey(domain.TokenSwapMethodExactIn, tokenInDenom, tokenOutDenom))
+	cachedCandidateRoutes, found := r.candidateRouteCache.Get(formatCandidateRouteCacheKey(method, tokenInDenom, tokenOutDenom))
 	if !found {
 		// Increase cache misses
 		domain.SQSRoutesCacheMissesCounter.WithLabelValues(requestURLPath, candidateRouteCacheLabel).Inc()
@@ -635,7 +635,7 @@ func (r *routerUseCaseImpl) GetCachedCandidateRoutes(ctx context.Context, tokenI
 }
 
 // GetCachedRankedRoutes implements mvc.RouterUsecase.
-func (r *routerUseCaseImpl) GetCachedRankedRoutes(ctx context.Context, tokenInDenom string, tokenOutDenom string, tokenInOrderOfMagnitude int) (ingesttypes.CandidateRoutes, error) {
+func (r *routerUseCaseImpl) GetCachedRankedRoutes(ctx context.Context, method domain.TokenSwapMethod, tokenInDenom string, tokenOutDenom string, tokenInOrderOfMagnitude int) (ingesttypes.CandidateRoutes, error) {
 	if !r.defaultConfig.RouteCacheEnabled {
 		return ingesttypes.CandidateRoutes{}, nil
 	}
@@ -646,7 +646,7 @@ func (r *routerUseCaseImpl) GetCachedRankedRoutes(ctx context.Context, tokenInDe
 		return ingesttypes.CandidateRoutes{}, err
 	}
 
-	cachedRankedRoutes, found := r.rankedRouteCache.Get(formatRankedRouteCacheKey(domain.TokenSwapMethodExactIn, tokenInDenom, tokenOutDenom, tokenInOrderOfMagnitude))
+	cachedRankedRoutes, found := r.rankedRouteCache.Get(formatRankedRouteCacheKey(method, tokenInDenom, tokenOutDenom, tokenInOrderOfMagnitude))
 	if !found {
 		// Increase cache misses
 		domain.SQSRoutesCacheMissesCounter.WithLabelValues(requestURLPath, rankedRouteCacheLabel).Inc()
@@ -677,7 +677,7 @@ func (r *routerUseCaseImpl) handleCandidateRoutes(ctx context.Context, tokenIn s
 	// Check cache for routes if enabled
 	var isFoundCached bool
 	if !candidateRouteSearchOptions.DisableCache {
-		candidateRoutes, isFoundCached, err = r.GetCachedCandidateRoutes(ctx, tokenIn.Denom, tokenOutDenom)
+		candidateRoutes, isFoundCached, err = r.GetCachedCandidateRoutes(ctx, domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom)
 		if err != nil {
 			return ingesttypes.CandidateRoutes{}, err
 		}

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -381,12 +381,12 @@ func (r *routerUseCaseImpl) computeAndRankRoutesByDirectQuote(ctx context.Contex
 		if len(candidateRoutes.Routes) > 0 {
 			domain.SQSRoutesCacheWritesCounter.WithLabelValues(requestURLPath, candidateRouteCacheLabel).Inc()
 
-			r.candidateRouteCache.Set(formatCandidateRouteCacheKey(tokenIn.Denom, tokenOutDenom), candidateRoutes, time.Duration(routingOptions.CandidateRouteCacheExpirySeconds)*time.Second)
+			r.candidateRouteCache.Set(formatCandidateRouteCacheKey(domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom), candidateRoutes, time.Duration(routingOptions.CandidateRouteCacheExpirySeconds)*time.Second)
 		} else {
 			// If no candidate routes found, cache them for quarter of the duration
-			r.candidateRouteCache.Set(formatCandidateRouteCacheKey(tokenIn.Denom, tokenOutDenom), candidateRoutes, time.Duration(routingOptions.CandidateRouteCacheExpirySeconds/4)*time.Second)
+			r.candidateRouteCache.Set(formatCandidateRouteCacheKey(domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom), candidateRoutes, time.Duration(routingOptions.CandidateRouteCacheExpirySeconds/4)*time.Second)
 
-			r.rankedRouteCache.Set(formatRankedRouteCacheKey(tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude), candidateRoutes, time.Duration(routingOptions.RankedRouteCacheExpirySeconds/4)*time.Second)
+			r.rankedRouteCache.Set(formatRankedRouteCacheKey(domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude), candidateRoutes, time.Duration(routingOptions.RankedRouteCacheExpirySeconds/4)*time.Second)
 
 			return nil, nil, fmt.Errorf("no candidate routes found")
 		}
@@ -421,7 +421,7 @@ func (r *routerUseCaseImpl) computeAndRankRoutesByDirectQuote(ctx context.Contex
 
 		if !routingOptions.DisableCache {
 			domain.SQSRoutesCacheWritesCounter.WithLabelValues(requestURLPath, rankedRouteCacheLabel).Inc()
-			r.rankedRouteCache.Set(formatRankedRouteCacheKey(tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude), convertedCandidateRoutes, time.Duration(routingOptions.RankedRouteCacheExpirySeconds)*time.Second)
+			r.rankedRouteCache.Set(formatRankedRouteCacheKey(domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude), convertedCandidateRoutes, time.Duration(routingOptions.RankedRouteCacheExpirySeconds)*time.Second)
 		}
 	}
 
@@ -613,7 +613,7 @@ func (r *routerUseCaseImpl) GetCachedCandidateRoutes(ctx context.Context, tokenI
 		return ingesttypes.CandidateRoutes{}, false, err
 	}
 
-	cachedCandidateRoutes, found := r.candidateRouteCache.Get(formatCandidateRouteCacheKey(tokenInDenom, tokenOutDenom))
+	cachedCandidateRoutes, found := r.candidateRouteCache.Get(formatCandidateRouteCacheKey(domain.TokenSwapMethodExactIn, tokenInDenom, tokenOutDenom))
 	if !found {
 		// Increase cache misses
 		domain.SQSRoutesCacheMissesCounter.WithLabelValues(requestURLPath, candidateRouteCacheLabel).Inc()
@@ -646,7 +646,7 @@ func (r *routerUseCaseImpl) GetCachedRankedRoutes(ctx context.Context, tokenInDe
 		return ingesttypes.CandidateRoutes{}, err
 	}
 
-	cachedRankedRoutes, found := r.rankedRouteCache.Get(formatRankedRouteCacheKey(tokenInDenom, tokenOutDenom, tokenInOrderOfMagnitude))
+	cachedRankedRoutes, found := r.rankedRouteCache.Get(formatRankedRouteCacheKey(domain.TokenSwapMethodExactIn, tokenInDenom, tokenOutDenom, tokenInOrderOfMagnitude))
 	if !found {
 		// Increase cache misses
 		domain.SQSRoutesCacheMissesCounter.WithLabelValues(requestURLPath, rankedRouteCacheLabel).Inc()
@@ -707,7 +707,7 @@ func (r *routerUseCaseImpl) handleCandidateRoutes(ctx context.Context, tokenIn s
 			}
 
 			r.logger.Debug("persisting routes", zap.Int("num_routes", len(candidateRoutes.Routes)))
-			r.candidateRouteCache.Set(formatCandidateRouteCacheKey(tokenIn.Denom, tokenOutDenom), candidateRoutes, time.Duration(cacheDurationSeconds)*time.Second)
+			r.candidateRouteCache.Set(formatCandidateRouteCacheKey(domain.TokenSwapMethodExactIn, tokenIn.Denom, tokenOutDenom), candidateRoutes, time.Duration(cacheDurationSeconds)*time.Second)
 		}
 	}
 
@@ -776,18 +776,18 @@ func (r *routerUseCaseImpl) GetRouterState() (domain.RouterState, error) {
 }
 
 // formatRouteCacheKey formats the given token in and token out denoms to a string.
-func formatRouteCacheKey(tokenInDenom string, tokenOutDenom string) string {
-	return fmt.Sprintf("%s%s%s", tokenInDenom, denomSeparatorChar, tokenOutDenom)
+func formatRouteCacheKey(method domain.TokenSwapMethod, tokenInDenom string, tokenOutDenom string) string {
+	return fmt.Sprintf("%d%s%s%s", method, tokenInDenom, denomSeparatorChar, tokenOutDenom)
 }
 
 // formatRankedRouteCacheKey formats the given token in and token out denoms and order of magnitude to a string.
-func formatRankedRouteCacheKey(tokenInDenom string, tokenOutDenom string, tokenIOrderOfMagnitude int) string {
-	return fmt.Sprintf("%s%s%d", formatRouteCacheKey(tokenInDenom, tokenOutDenom), denomSeparatorChar, tokenIOrderOfMagnitude)
+func formatRankedRouteCacheKey(method domain.TokenSwapMethod, tokenInDenom string, tokenOutDenom string, tokenIOrderOfMagnitude int) string {
+	return fmt.Sprintf("%s%s%d", formatRouteCacheKey(method, tokenInDenom, tokenOutDenom), denomSeparatorChar, tokenIOrderOfMagnitude)
 }
 
 // formatCandidateRouteCacheKey formats the given token in and token out denoms to a string.
-func formatCandidateRouteCacheKey(tokenInDenom string, tokenOutDenom string) string {
-	return fmt.Sprintf("cr%s", formatRouteCacheKey(tokenInDenom, tokenOutDenom))
+func formatCandidateRouteCacheKey(method domain.TokenSwapMethod, tokenInDenom string, tokenOutDenom string) string {
+	return fmt.Sprintf("cr%s", formatRouteCacheKey(method, tokenInDenom, tokenOutDenom))
 }
 
 // convertRankedToCandidateRoutes converts the given ranked routes to candidate routes.

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -283,7 +283,7 @@ func (s *RouterTestSuite) TestHandleRoutes() {
 			candidateRouteCache := cache.New()
 
 			if !tc.shouldSkipAddToCache {
-				candidateRouteCache.Set(usecase.FormatCandidateRouteCacheKey(tokenInDenom, tokenOutDenom), tc.repositoryRoutes, time.Hour)
+				candidateRouteCache.Set(usecase.FormatCandidateRouteCacheKey(domain.TokenSwapMethodExactIn, tokenInDenom, tokenOutDenom), tc.repositoryRoutes, time.Hour)
 			}
 
 			poolsUseCaseMock := &mocks.PoolsUsecaseMock{}
@@ -788,13 +788,13 @@ func (s *RouterTestSuite) TestGetOptimalQuote_Cache_Overwrites() {
 
 			// Pre-set candidate route cache
 			if len(tc.preCachedCandidateRoutes.Routes) > 0 {
-				candidateRouteCache.Set(usecase.FormatCandidateRouteCacheKey(defaultTokenInDenom, defaultTokenOutDenom), tc.preCachedCandidateRoutes, tc.cacheExpiryDuration)
+				candidateRouteCache.Set(usecase.FormatCandidateRouteCacheKey(domain.TokenSwapMethodExactIn, defaultTokenInDenom, defaultTokenOutDenom), tc.preCachedCandidateRoutes, tc.cacheExpiryDuration)
 			}
 
 			// Pre-set ranked route cache
 			if len(tc.preCachedRankedRoutes.Routes) > 0 {
 				tokeInOrderOfMagnitude := usecase.GetPrecomputeOrderOfMagnitude(tc.amountIn)
-				rankedRouteCache.Set(usecase.FormatRankedRouteCacheKey(defaultTokenInDenom, defaultTokenOutDenom, tokeInOrderOfMagnitude), tc.preCachedRankedRoutes, tc.cacheExpiryDuration)
+				rankedRouteCache.Set(usecase.FormatRankedRouteCacheKey(domain.TokenSwapMethodExactIn, defaultTokenInDenom, defaultTokenOutDenom, tokeInOrderOfMagnitude), tc.preCachedRankedRoutes, tc.cacheExpiryDuration)
 			}
 
 			// Mock router use case.

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -332,7 +332,7 @@ func (s *RouterTestSuite) TestHandleRoutes() {
 				return
 			}
 
-			cachedCandidateRoutes, isCached, err := routerUseCaseImpl.GetCachedCandidateRoutes(ctx, tokenInDenom, tokenOutDenom)
+			cachedCandidateRoutes, isCached, err := routerUseCaseImpl.GetCachedCandidateRoutes(ctx, domain.TokenSwapMethodExactIn, tokenInDenom, tokenOutDenom)
 
 			if tc.isCacheConfigDisabled {
 				s.Require().NoError(err)


### PR DESCRIPTION
This PR is a follow up from [discussion](https://github.com/osmosis-labs/sqs/pull/613/files#r1953790276) on previous PR.

Proposed solution updates cache to accept swap method to avoid collisions caching different types swap routes.

Considered alternatives:

- Accept swap method ( current proposal ): increases memory usage, ripple effect of the change in the code base
- For in given out read cache returning out given in and invert results: adds more complexity in the clients using cache ( including tests ) and complexity in terms of mental load, will complicate debugging related with InGivenOut cache.
- Create  dedicated [cache](https://github.com/osmosis-labs/sqs/blob/2f71882506ae9f7d9edc96fcfb62a227cc3a74c0/router/usecase/router_usecase.go#L387) instances for each type: ripple effect of the change in the code base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced cache management for route estimation by incorporating token swap methods, allowing for more precise handling of routing data.
	- Updated method signatures to include a token swap method parameter for improved cache key specificity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->