### PR TITLE
Add first block boolean to block metadata and improve ingest log

### DIFF
--- a/domain/ingester.go
+++ b/domain/ingester.go
@@ -29,6 +29,8 @@ type BlockPoolMetadata struct {
 	UpdatedDenoms map[string]struct{}
 	// PoolIDs are the IDs of all pools updated within a block.
 	PoolIDs map[uint64]struct{}
+	// IsFirstBlock is true if this is the first block being processed after the ingester starts.
+	IsFirstBlock bool
 }
 
 // EndBlockProcessPlugin is a plugin that is called at the end of the block.

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -146,7 +146,7 @@ func (p *ingestUseCase) ProcessBlockData(ctx context.Context, height uint64, tak
 	}
 
 	// Sort and store pools.
-	p.logger.Info("sorting pools", zap.Uint64("height", height), zap.Duration("duration_since_start", time.Since(startProcessingTime)))
+	p.logger.Info("sorting pools", zap.Uint64("height", height), zap.Int("num_pools", len(allPools)), zap.Duration("duration_since_start", time.Since(startProcessingTime)))
 
 	p.sortAndStorePools(allPools)
 
@@ -164,6 +164,9 @@ func (p *ingestUseCase) ProcessBlockData(ctx context.Context, height uint64, tak
 		// and let any subsequent block wait before starting its computation
 		// to avoid overloading the system.
 		defer p.firstBlockWg.Done()
+
+		// Set the first block flag.
+		uniqueBlockPoolMetadata.IsFirstBlock = true
 
 		// Pre-compute the prices for all tokens
 		p.defaultQuotePriceUpdateWorker.UpdatePricesSync(height, uniqueBlockPoolMetadata)


### PR DESCRIPTION
- New boolean is helpful for plugins
- Also added a log to improve observability 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a state indicator that flags when the very first block is processed, ensuring specific operations trigger only once after startup.
  - Enhanced logging details during pool processing to improve traceability by reporting additional metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->