### PR TITLE
BE-707 | Skip processing quote requests when system is not healthy

### DIFF
--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -247,7 +247,7 @@ func NewSideCarQueryServer(ctx context.Context, appCodec codec.Codec, config dom
 		types.NewQueryClient(grpcClient),
 		config.ChainID,
 	)
-	routerHttpDelivery.NewRouterHandler(e, routerUsecase, tokensUseCase, quoteSimulator, logger)
+	routerHttpDelivery.NewRouterHandler(e, routerUsecase, tokensUseCase, quoteSimulator, chainInfoUseCase, logger)
 
 	// Create a Numia HTTP client
 	passthroughConfig := config.Passthrough

--- a/router/delivery/http/middleware/quote_chain_state_validator.go
+++ b/router/delivery/http/middleware/quote_chain_state_validator.go
@@ -1,0 +1,30 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/domain/mvc"
+
+	"github.com/labstack/echo/v4"
+)
+
+// QuoteChainStateValidatorMiddleware is a middleware that checks the chain readiness before processing the quote requests.
+// It ensures that SQS has data to process for the quote requests and will not cache empty or outdated quote data resulting in incorrect quotes.
+// NOTE: This approach is safe as it is not relying on external chain info data but rather is using the data that is already available in the SQS,
+// meaning that if Node would go down, the SQS will be able to return already cached quotes - as it works without the middleware.
+func QuoteChainStateValidatorMiddleware(chainUsecase mvc.ChainInfoUsecase) func(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			_, err := chainUsecase.GetLatestHeight()
+			if err != nil {
+				return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: "no candidate routes found"})
+			}
+			err = chainUsecase.ValidateCandidateRouteSearchDataUpdates()
+			if err != nil {
+				return c.JSON(http.StatusInternalServerError, domain.ResponseError{Message: "no candidate routes found"})
+			}
+			return next(c)
+		}
+	}
+}

--- a/router/delivery/http/middleware/quote_chain_state_validator_test.go
+++ b/router/delivery/http/middleware/quote_chain_state_validator_test.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/osmosis-labs/sqs/domain/mocks"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuoteChainStateValidatorMiddleware(t *testing.T) {
+	tests := []struct {
+		name                 string
+		getLatestHeightErr   error
+		validateUpdatesErr   error
+		expectedStatusCode   int
+		expectedResponseBody string
+	}{
+		{
+			name:               "Success",
+			expectedStatusCode: http.StatusOK,
+		},
+		{
+			name:                 "GetLatestHeight Error",
+			getLatestHeightErr:   errors.New("failed to get latest height"),
+			expectedStatusCode:   http.StatusInternalServerError,
+			expectedResponseBody: `{"message":"no candidate routes found"}`,
+		},
+		{
+			name:                 "ValidateCandidateRouteSearchDataUpdates Error",
+			validateUpdatesErr:   errors.New("failed to validate updates"),
+			expectedStatusCode:   http.StatusInternalServerError,
+			expectedResponseBody: `{"message":"no candidate routes found"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			mockChainUsecase := &mocks.ChainInfoUsecaseMock{
+				GetLatestHeightFunc: func() (uint64, error) {
+					return 0, tt.getLatestHeightErr
+				},
+				ValidateCandidateRouteSearchDataUpdatesFunc: func() error {
+					return tt.validateUpdatesErr
+				},
+			}
+
+			middleware := QuoteChainStateValidatorMiddleware(mockChainUsecase)
+
+			// Test
+			handler := middleware(func(c echo.Context) error {
+				return c.String(http.StatusOK, "OK")
+			})
+
+			err := handler(c)
+
+			// Assert
+			if tt.expectedStatusCode == http.StatusOK {
+				assert.NoError(t, err)
+				assert.Equal(t, http.StatusOK, rec.Code)
+				assert.Equal(t, "OK", rec.Body.String())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedStatusCode, rec.Code)
+				assert.JSONEq(t, tt.expectedResponseBody, rec.Body.String())
+			}
+		})
+	}
+}

--- a/router/delivery/http/router_handler.go
+++ b/router/delivery/http/router_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	"github.com/osmosis-labs/sqs/log"
+	"github.com/osmosis-labs/sqs/router/delivery/http/middleware"
 	"github.com/osmosis-labs/sqs/router/types"
 )
 
@@ -29,23 +30,22 @@ type RouterHandler struct {
 
 const routerResource = "/router"
 
-var (
-	oneDec = osmomath.OneDec()
-)
+var oneDec = osmomath.OneDec()
 
 func formatRouterResource(resource string) string {
 	return routerResource + resource
 }
 
 // NewRouterHandler will initialize the pools/ resources endpoint
-func NewRouterHandler(e *echo.Echo, us mvc.RouterUsecase, tu mvc.TokensUsecase, qs domain.QuoteSimulator, logger log.Logger) {
+func NewRouterHandler(e *echo.Echo, us mvc.RouterUsecase, tu mvc.TokensUsecase, qs domain.QuoteSimulator, chainUsecase mvc.ChainInfoUsecase, logger log.Logger) {
 	handler := &RouterHandler{
 		RUsecase:       us,
 		TUsecase:       tu,
 		QuoteSimulator: qs,
 		logger:         logger,
 	}
-	e.GET(formatRouterResource("/quote"), handler.GetOptimalQuote)
+
+	e.GET(formatRouterResource("/quote"), handler.GetOptimalQuote, middleware.QuoteChainStateValidatorMiddleware(chainUsecase))
 	e.GET(formatRouterResource("/routes"), handler.GetCandidateRoutes)
 	e.GET(formatRouterResource("/cached-routes"), handler.GetCachedCandidateRoutes)
 	e.GET(formatRouterResource("/spot-price-pool/:id"), handler.GetSpotPriceForPool)


### PR DESCRIPTION
This PR introduces a middleware for `/router/quote` endpoint that would return early instead of computing a quote when system haven't received data required for computation from the Node resulting in cached empty results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a blockchain state validation layer that ensures quote requests are processed only when the underlying data is current, helping prevent stale or empty quote results.
  
- **Refactor**
  - Enhanced the quote endpoint’s routing logic to seamlessly integrate the new validation, resulting in more robust handling and clearer error responses when data isn’t ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->