### PR TITLE
BE-704 | Disable Coingecko for E2E tests suite

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           SQS_ENVIRONMENTS: ${{ github.event.inputs.environment }}
           SQS_API_KEY: ${{ secrets.SQS_API_KEY }}
-          COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
+          # COINGECKO_API_KEY: ${{ secrets.COINGECKO_API_KEY }}
           
   scheduled_integration_test:
     if: github.event_name == 'schedule'


### PR DESCRIPTION
Disable Coingecko for E2E tests suite due API limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Disabled the use of the COINGECKO_API_KEY environment variable in the manual integration test workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->