### PR TITLE
BE-723 | Introduce context param for CandidateRouteSearcher

### DIFF
--- a/domain/candidate_routes.go
+++ b/domain/candidate_routes.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"context"
+
 	"github.com/osmosis-labs/sqs/domain/osmomath"
 	ingesttypes "github.com/osmosis-labs/sqs/ingest/types"
 
@@ -71,12 +73,12 @@ type CandidateRouteSearcher interface {
 	// FindCandidateRoutesOutGivenIn finds candidate routes for a given tokenIn and tokenOutDenom
 	// using the given options.
 	// Returns the candidate routes and an error if any.
-	FindCandidateRoutesOutGivenIn(tokenIn sdk.Coin, tokenOutDenom string, options CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error)
+	FindCandidateRoutesOutGivenIn(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, options CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error)
 
 	// FindCandidateRoutesInGivenOut finds candidate routes for a given tokenOut and tokenInDenom
 	// using the given options.
 	// Returns the candidate routes and an error if any.
-	FindCandidateRoutesInGivenOut(tokenOut sdk.Coin, tokenInDenom string, options CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error)
+	FindCandidateRoutesInGivenOut(ctx context.Context, tokenOut sdk.Coin, tokenInDenom string, options CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error)
 }
 
 // CandidateRouteDenomData represents data structure that contains pool data

--- a/domain/mocks/candidate_route_finder_mock.go
+++ b/domain/mocks/candidate_route_finder_mock.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"context"
+
 	"github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/domain"
 	ingesttypes "github.com/osmosis-labs/sqs/ingest/types"
@@ -14,11 +16,11 @@ type CandidateRouteFinderMock struct {
 var _ domain.CandidateRouteSearcher = CandidateRouteFinderMock{}
 
 // FindCandidateRoutesOutGivenIn implements domain.CandidateRouteSearcher.
-func (c CandidateRouteFinderMock) FindCandidateRoutesOutGivenIn(tokenIn types.Coin, tokenOutDenom string, options domain.CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error) {
+func (c CandidateRouteFinderMock) FindCandidateRoutesOutGivenIn(ctx context.Context, tokenIn types.Coin, tokenOutDenom string, options domain.CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error) {
 	return c.Routes, c.Error
 }
 
 // FindCandidateRoutesInGivenOut implements domain.CandidateRouteSearcher.
-func (c CandidateRouteFinderMock) FindCandidateRoutesInGivenOut(tokenOut types.Coin, tokenInDenom string, options domain.CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error) {
+func (c CandidateRouteFinderMock) FindCandidateRoutesInGivenOut(ctx context.Context, tokenOut types.Coin, tokenInDenom string, options domain.CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error) {
 	return c.Routes, c.Error
 }

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"context"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
@@ -37,7 +39,7 @@ func NewCandidateRouteFinder(candidateRouteDataHolder mvc.CandidateRouteSearchDa
 }
 
 // FindCandidateRoutesOutGivenIn implements domain.CandidateRouteFinder.
-func (c candidateRouteFinder) FindCandidateRoutesOutGivenIn(tokenIn sdk.Coin, tokenOutDenom string, options domain.CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error) {
+func (c candidateRouteFinder) FindCandidateRoutesOutGivenIn(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string, options domain.CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error) {
 	routes := make([]candidateRouteWrapper, 0, options.MaxRoutes)
 
 	// Preallocate constant visited map size to avoid reallocations.
@@ -226,10 +228,10 @@ func (c candidateRouteFinder) FindCandidateRoutesOutGivenIn(tokenIn sdk.Coin, to
 }
 
 // FindCandidateRoutesOutGivenIn implements domain.CandidateRouteFinder.
-func (c candidateRouteFinder) FindCandidateRoutesInGivenOut(tokenOut sdk.Coin, tokenInDenom string, options domain.CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error) {
+func (c candidateRouteFinder) FindCandidateRoutesInGivenOut(ctx context.Context, tokenOut sdk.Coin, tokenInDenom string, options domain.CandidateRouteSearchOptions) (ingesttypes.CandidateRoutes, error) {
 	// Fetching the candidate routes as for the exact amount of token in swap method
 	// That will be the same as the exact amount out swap method with inverted token denominations
-	routes, err := c.FindCandidateRoutesOutGivenIn(tokenOut, tokenInDenom, options)
+	routes, err := c.FindCandidateRoutesOutGivenIn(ctx, tokenOut, tokenInDenom, options)
 	if err != nil {
 		return ingesttypes.CandidateRoutes{}, err
 	}

--- a/router/usecase/candidate_routes_bench_test.go
+++ b/router/usecase/candidate_routes_bench_test.go
@@ -1,6 +1,7 @@
 package usecase_test
 
 import (
+	"context"
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -35,10 +36,12 @@ func BenchmarkCandidateRouteSearcherFindCandidateRoutesOutGivenIn(b *testing.B) 
 
 	b.ResetTimer()
 
+	ctx := context.Background()
+
 	// Run the benchmark
 	for i := 0; i < b.N; i++ {
 		// System under test
-		_, err := usecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(tokenIn, tokenOutDenom, candidateRouteOptions)
+		_, err := usecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(ctx, tokenIn, tokenOutDenom, candidateRouteOptions)
 		s.Require().NoError(err)
 		if err != nil {
 			b.Errorf("FindCandidateRoutes returned an error: %v", err)
@@ -72,10 +75,12 @@ func BenchmarkCandidateRouteSearcherFindCandidateRoutesInGivenOut(b *testing.B) 
 
 	b.ResetTimer()
 
+	ctx := context.Background()
+
 	// Run the benchmark
 	for i := 0; i < b.N; i++ {
 		// System under test
-		_, err := usecase.CandidateRouteSearcher.FindCandidateRoutesInGivenOut(tokenIn, tokenOutDenom, candidateRouteOptions)
+		_, err := usecase.CandidateRouteSearcher.FindCandidateRoutesInGivenOut(ctx, tokenIn, tokenOutDenom, candidateRouteOptions)
 		s.Require().NoError(err)
 		if err != nil {
 			b.Errorf("FindCandidateRoutes returned an error: %v", err)

--- a/router/usecase/candidate_routes_test.go
+++ b/router/usecase/candidate_routes_test.go
@@ -1,6 +1,7 @@
 package usecase_test
 
 import (
+	"context"
 	"slices"
 	"testing"
 
@@ -167,7 +168,7 @@ func (s *RouterTestSuite) TestCandidateRouteSearcherOutGivenIn_HappyPath() {
 			expectedMinPoolLiquidityCapInt := osmomath.NewInt(int64(routerConfig.MinPoolLiquidityCap))
 
 			// System under test
-			candidateRoutes, err := usecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(tc.tokenIn, tc.tokenOutDenom, candidateRouteOptions)
+			candidateRoutes, err := usecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(context.Background(), tc.tokenIn, tc.tokenOutDenom, candidateRouteOptions)
 			s.Require().NoError(err)
 
 			// Validate that number of routes found is equal to the expected number of routes.
@@ -370,7 +371,7 @@ func (s *RouterTestSuite) TestCandidateRouteSearcherInGivenOut_HappyPath() {
 			expectedMinPoolLiquidityCapInt := osmomath.NewInt(int64(routerConfig.MinPoolLiquidityCap))
 
 			// System under test
-			candidateRoutes, err := usecase.CandidateRouteSearcher.FindCandidateRoutesInGivenOut(tc.tokenOut, tc.tokenInDenom, candidateRouteOptions)
+			candidateRoutes, err := usecase.CandidateRouteSearcher.FindCandidateRoutesInGivenOut(context.Background(), tc.tokenOut, tc.tokenInDenom, candidateRouteOptions)
 			s.Require().NoError(err)
 
 			// Validate that number of routes found is equal to the expected number of routes.
@@ -445,7 +446,7 @@ func (s *RouterTestSuite) TestCandidateRouteSearcherOutGivenIn_SkipPoolOption() 
 	const expectedPoolID = uint64(1)
 
 	// System under test #1
-	candidateRoutes, err := usecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(oneOSMOIn, ATOM, candidateRouteOptions)
+	candidateRoutes, err := usecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(context.Background(), oneOSMOIn, ATOM, candidateRouteOptions)
 	s.Require().NoError(err)
 
 	// Contains default pool ID
@@ -465,7 +466,7 @@ func (s *RouterTestSuite) TestCandidateRouteSearcherOutGivenIn_SkipPoolOption() 
 	}
 
 	// System under test #2
-	candidateRoutes, err = usecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(oneOSMOIn, ATOM, candidateRouteOptions)
+	candidateRoutes, err = usecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(context.Background(), oneOSMOIn, ATOM, candidateRouteOptions)
 	s.Require().NoError(err)
 
 	didFindExpectedPoolID = foundExpectedPoolID(expectedPoolID, candidateRoutes.Routes)
@@ -492,7 +493,7 @@ func (s *RouterTestSuite) TestCandidateRouteSearcherInGivenOut_SkipPoolOption() 
 	const expectedPoolID = uint64(1)
 
 	// System under test #1
-	candidateRoutes, err := usecase.CandidateRouteSearcher.FindCandidateRoutesInGivenOut(oneOSMOIn, ATOM, candidateRouteOptions)
+	candidateRoutes, err := usecase.CandidateRouteSearcher.FindCandidateRoutesInGivenOut(context.Background(), oneOSMOIn, ATOM, candidateRouteOptions)
 	s.Require().NoError(err)
 
 	// Contains default pool ID
@@ -512,7 +513,7 @@ func (s *RouterTestSuite) TestCandidateRouteSearcherInGivenOut_SkipPoolOption() 
 	}
 
 	// System under test #2
-	candidateRoutes, err = usecase.CandidateRouteSearcher.FindCandidateRoutesInGivenOut(oneOSMOIn, ATOM, candidateRouteOptions)
+	candidateRoutes, err = usecase.CandidateRouteSearcher.FindCandidateRoutesInGivenOut(context.Background(), oneOSMOIn, ATOM, candidateRouteOptions)
 	s.Require().NoError(err)
 
 	didFindExpectedPoolID = foundExpectedPoolID(expectedPoolID, candidateRoutes.Routes)

--- a/router/usecase/dynamic_splits_test.go
+++ b/router/usecase/dynamic_splits_test.go
@@ -55,7 +55,7 @@ func (s *RouterTestSuite) setupSplitsMainnetTestCase(displayDenomIn string, amou
 		MinPoolLiquidityCap: config.MinPoolLiquidityCap,
 	}
 	// Get candidate routes
-	candidateRoutes, err := useCases.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(tokenIn, chainDenomOut, options)
+	candidateRoutes, err := useCases.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(context.Background(), tokenIn, chainDenomOut, options)
 	s.Require().NoError(err)
 
 	// TODO: consider moving to interface.

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -245,7 +245,7 @@ func (r *routerUseCaseImpl) GetSimpleQuote(ctx context.Context, tokenIn sdk.Coin
 		MaxPoolsPerRoute:    options.MaxPoolsPerRoute,
 		MinPoolLiquidityCap: options.MinPoolLiquidityCap,
 	}
-	candidateRoutes, err := r.candidateRouteSearcher.FindCandidateRoutesOutGivenIn(tokenIn, tokenOutDenom, candidateRouteSearchOptions)
+	candidateRoutes, err := r.candidateRouteSearcher.FindCandidateRoutesOutGivenIn(ctx, tokenIn, tokenOutDenom, candidateRouteSearchOptions)
 	if err != nil {
 		r.logger.Error("error getting candidate routes for pricing", zap.Error(err))
 		return nil, err
@@ -686,7 +686,7 @@ func (r *routerUseCaseImpl) handleCandidateRoutes(ctx context.Context, tokenIn s
 		r.logger.Debug("calculating routes")
 
 		start := time.Now()
-		candidateRoutes, err = r.candidateRouteSearcher.FindCandidateRoutesOutGivenIn(tokenIn, tokenOutDenom, candidateRouteSearchOptions)
+		candidateRoutes, err = r.candidateRouteSearcher.FindCandidateRoutesOutGivenIn(ctx, tokenIn, tokenOutDenom, candidateRouteSearchOptions)
 		if err != nil {
 			r.logger.Error("error getting candidate routes for pricing", zap.Error(err))
 			return ingesttypes.CandidateRoutes{}, err

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -892,7 +892,7 @@ func (s *RouterTestSuite) TestGetCandidateRoutes_Chain_FindUnsupportedRoutes() {
 			MaxPoolsPerRoute:    config.Router.MaxPoolsPerRoute,
 		}
 
-		routes, err := mainnetUsecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(sdk.NewCoin(chainDenom, one), USDC, options)
+		routes, err := mainnetUsecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(context.Background(), sdk.NewCoin(chainDenom, one), USDC, options)
 		if err != nil {
 			fmt.Printf("Error for %s  -- %s -- %v\n", chainDenom, tokenMeta.HumanDenom, err)
 			errorCounter++
@@ -932,7 +932,7 @@ func (s *RouterTestSuite) TestGetCandidateRoutes_Chain_FindUnsupportedRoutes() {
 			continue
 		}
 
-		routes, err := mainnetUsecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(sdk.NewCoin(chainDenom, one), USDC, options)
+		routes, err := mainnetUsecase.CandidateRouteSearcher.FindCandidateRoutesOutGivenIn(context.Background(), sdk.NewCoin(chainDenom, one), USDC, options)
 		if err != nil {
 			fmt.Printf("Error for %s  -- %s -- %v\n", chainDenom, tokenMeta.HumanDenom, err)
 			errorCounter++


### PR DESCRIPTION
Adds context param for CandidateRouteSearcher for  carrying various request-scoped values. At this stage it was found to be useful for debugging for example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated certain route-finding methods to accept context parameters, enabling improved request handling and cancellation support.
  - Adjusted internal usage to ensure context is consistently propagated throughout related operations.

- **Tests**
  - Updated mock implementations to match the revised method signatures with context parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->