### PR TITLE
BE-723 | Fix 0 liquidity pools for candidate routes

### DIFF
--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-
 	"time"
 
 	tenderminapi "cosmossdk.io/api/cosmos/base/tendermint/v1beta1"
@@ -167,6 +166,8 @@ func NewSideCarQueryServer(ctx context.Context, appCodec codec.Codec, config dom
 	if err != nil {
 		return nil, err
 	}
+
+	routerRepository.SetPoolHandler(poolsUseCase)
 
 	// Initialize candidate route searcher
 	candidateRouteSearcher := routerUseCase.NewCandidateRouteFinder(routerRepository, logger)

--- a/router/repository/memory_router_repository.go
+++ b/router/repository/memory_router_repository.go
@@ -13,6 +13,7 @@ import (
 	"github.com/osmosis-labs/sqs/log"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	sqsosmomath "github.com/osmosis-labs/sqs/domain/osmomath"
 )
 
 // BaseFeeRepository represents the contract for a repository handling base fee information
@@ -48,6 +49,7 @@ type candidateRoutes map[string]*domain.CandidateRouteDenomData
 type routerRepo struct {
 	takerFeeMap              sync.Map
 	candidateRouteSearchData atomic.Value
+	poolHandler              mvc.PoolHandler
 	mu                       sync.Mutex
 
 	baseFeeMx sync.RWMutex
@@ -56,7 +58,7 @@ type routerRepo struct {
 	logger log.Logger
 }
 
-func New(logger log.Logger) RouterRepository {
+func New(logger log.Logger) *routerRepo {
 	repository := &routerRepo{
 		takerFeeMap: sync.Map{},
 		baseFeeMx:   sync.RWMutex{},
@@ -67,6 +69,10 @@ func New(logger log.Logger) RouterRepository {
 	repository.candidateRouteSearchData.Store(make(candidateRoutes))
 
 	return repository
+}
+
+func (r *routerRepo) SetPoolHandler(poolHandler mvc.PoolHandler) {
+	r.poolHandler = poolHandler
 }
 
 // GetBaseFee implements RouterRepository.
@@ -177,6 +183,25 @@ func (r *routerRepo) SetCandidateRouteSearchData(data map[string]*domain.Candida
 
 	maps.Copy(newData, oldData)
 
+	// Some of the pools from the block data may not have a liquidity cap set or it's set to 0.
+	// Here we manually update the liquidity cap for such candidate routes based on the pool data so
+	// that we can still route over such pools.
+	for denom, value := range newData {
+		for i := range value.SortedPools {
+			if value.SortedPools[i].PoolLiquidityCap == 0 {
+				p, _, err := r.poolHandler.GetPools(domain.WithPoolIDFilter([]uint64{value.SortedPools[i].ID}))
+				if len(p) == 0 || err != nil {
+					continue // no pool found
+				}
+
+				if p[0].GetLiquidityCap().GT(osmomath.ZeroInt()) {
+					newData[denom].SortedPools[i].PoolLiquidityCap = sqsosmomath.SafeUint64(p[0].GetLiquidityCap())
+				}
+			}
+		}
+	}
+
+	// Update new data with block data
 	for denom, value := range data {
 		newData[denom] = value
 	}


### PR DESCRIPTION
**Background:**
In order to compute a price for a token we need to compute a route. To compute a route we need to compute a price of tokens for the pools to compute their liquidity. This cyclic dependency is solved by initially setting a low value for expected minimum pool liquidity to `0`, which is initially `0`  to compute a route for a token and derive initial price that will be used to compute actual liquidity of the pool where this token is present.

**No routes found:**
When we initialize candidate routes some of them will have capitalization set to  `0` in the beginning and we update candidate routes based on data received in the block. E.g. If there's so denom `A` in the block, we will not update canidate routes related with this denom.  Now, initially we compute a route min capitalization of `0`  is used  enabling to compute a price for the token and later to be used computing pools capitalization it self. Pools capitalization later directly affects min capitalization parameter for calculating next routes. 
Example:  Pool `ID=2242` has cap of `$409742`, and price `$0.15` that was computed using min capitalization of `0`,  let's say there was no single trade with denom for this pool since SQS was started, that means that candidate route is stuck with capitalization of `0` and no routes will be found over this pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved pool data handling by automatically updating liquidity caps for pools with missing information.

- **Bug Fixes**
  - Enhanced accuracy of candidate route data by ensuring liquidity caps are refreshed when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->