### PR TITLE
BE-724 | Fix spot price calculation for orderbooks

### DIFF
--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -194,6 +194,9 @@ func NewSideCarQueryServer(ctx context.Context, appCodec codec.Codec, config dom
 		return nil, err
 	}
 
+	// Set the default quote denom on the tokens use case
+	tokensUseCase.SetDefaultQuoteDenom(defaultQuoteDenom)
+
 	// Get liquidity pricer
 	liquidityPricer := pricingWorker.NewLiquidityPricer(defaultQuoteDenom, tokensUseCase.GetChainScalingFactorByDenomMut)
 

--- a/domain/mocks/quote_mock.go
+++ b/domain/mocks/quote_mock.go
@@ -58,7 +58,7 @@ func (m *MockQuote) GetRoute() []domain.SplitRoute {
 }
 
 // PrepareResult implements domain.Quote.
-func (m *MockQuote) PrepareResult(ctx context.Context, scalingFactor math.LegacyDec, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.SplitRoute, math.LegacyDec, error) {
+func (m *MockQuote) PrepareResult(ctx context.Context, scalingFactor math.LegacyDec, spotPriceCalculator domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.SplitRoute, math.LegacyDec, error) {
 	panic("unimplemented")
 }
 

--- a/domain/mocks/quote_mock.go
+++ b/domain/mocks/quote_mock.go
@@ -58,7 +58,7 @@ func (m *MockQuote) GetRoute() []domain.SplitRoute {
 }
 
 // PrepareResult implements domain.Quote.
-func (m *MockQuote) PrepareResult(ctx context.Context, scalingFactor math.LegacyDec, logger log.Logger) ([]domain.SplitRoute, math.LegacyDec, error) {
+func (m *MockQuote) PrepareResult(ctx context.Context, scalingFactor math.LegacyDec, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.SplitRoute, math.LegacyDec, error) {
 	panic("unimplemented")
 }
 

--- a/domain/mocks/quote_mock.go
+++ b/domain/mocks/quote_mock.go
@@ -58,7 +58,7 @@ func (m *MockQuote) GetRoute() []domain.SplitRoute {
 }
 
 // PrepareResult implements domain.Quote.
-func (m *MockQuote) PrepareResult(ctx context.Context, scalingFactor math.LegacyDec, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.SplitRoute, math.LegacyDec, error) {
+func (m *MockQuote) PrepareResult(ctx context.Context, scalingFactor math.LegacyDec, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.SplitRoute, math.LegacyDec, error) {
 	panic("unimplemented")
 }
 

--- a/domain/mocks/route_mock.go
+++ b/domain/mocks/route_mock.go
@@ -16,8 +16,8 @@ type RouteMock struct {
 	GetPoolsFunc                         func() []domain.RoutablePool
 	GetTokenOutDenomFunc                 func() string
 	GetTokenInDenomFunc                  func() string
-	PrepareResultPoolsExactAmountInFunc  func(ctx context.Context, tokenIn types.Coin, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
-	PrepareResultPoolsExactAmountOutFunc func(ctx context.Context, tokenOut types.Coin, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
+	PrepareResultPoolsExactAmountInFunc  func(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
+	PrepareResultPoolsExactAmountOutFunc func(ctx context.Context, tokenOut types.Coin, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
 	StringFunc                           func() string
 
 	GetAmountInFunc  func() math.Int
@@ -79,16 +79,17 @@ func (r *RouteMock) GetTokenInDenom() string {
 }
 
 // PrepareResultPoolsOutGivenIn implements domain.Route.
-func (r *RouteMock) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn types.Coin, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
+func (r *RouteMock) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
 	if r.PrepareResultPoolsExactAmountInFunc != nil {
-		return r.PrepareResultPoolsExactAmountInFunc(ctx, tokenIn, logger)
+		return r.PrepareResultPoolsExactAmountInFunc(ctx, tokenIn, spotPriceCalcultor, logger)
 	}
 
 	panic("unimplemented")
 }
-func (r *RouteMock) PrepareResultPoolsExactAmountOut(ctx context.Context, tokenIn types.Coin, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
+
+func (r *RouteMock) PrepareResultPoolsExactAmountOut(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
 	if r.PrepareResultPoolsExactAmountOutFunc != nil {
-		return r.PrepareResultPoolsExactAmountOutFunc(ctx, tokenIn, logger)
+		return r.PrepareResultPoolsExactAmountOutFunc(ctx, tokenIn, spotPriceCalcultor, logger)
 	}
 
 	panic("unimplemented")
@@ -119,5 +120,7 @@ func (r *RouteMock) GetAmountOut() math.Int {
 	panic("unimplemented")
 }
 
-var _ domain.Route = &RouteMock{}
-var _ domain.SplitRoute = &RouteMock{}
+var (
+	_ domain.Route      = &RouteMock{}
+	_ domain.SplitRoute = &RouteMock{}
+)

--- a/domain/mocks/route_mock.go
+++ b/domain/mocks/route_mock.go
@@ -16,8 +16,8 @@ type RouteMock struct {
 	GetPoolsFunc                         func() []domain.RoutablePool
 	GetTokenOutDenomFunc                 func() string
 	GetTokenInDenomFunc                  func() string
-	PrepareResultPoolsExactAmountInFunc  func(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
-	PrepareResultPoolsExactAmountOutFunc func(ctx context.Context, tokenOut types.Coin, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
+	PrepareResultPoolsExactAmountInFunc  func(ctx context.Context, tokenIn types.Coin, spotPriceCalculator domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
+	PrepareResultPoolsExactAmountOutFunc func(ctx context.Context, tokenOut types.Coin, spotPriceCalculator domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
 	StringFunc                           func() string
 
 	GetAmountInFunc  func() math.Int
@@ -79,17 +79,17 @@ func (r *RouteMock) GetTokenInDenom() string {
 }
 
 // PrepareResultPoolsOutGivenIn implements domain.Route.
-func (r *RouteMock) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
+func (r *RouteMock) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn types.Coin, spotPriceCalculator domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
 	if r.PrepareResultPoolsExactAmountInFunc != nil {
-		return r.PrepareResultPoolsExactAmountInFunc(ctx, tokenIn, spotPriceCalcultor, logger)
+		return r.PrepareResultPoolsExactAmountInFunc(ctx, tokenIn, spotPriceCalculator, logger)
 	}
 
 	panic("unimplemented")
 }
 
-func (r *RouteMock) PrepareResultPoolsExactAmountOut(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
+func (r *RouteMock) PrepareResultPoolsExactAmountOut(ctx context.Context, tokenIn types.Coin, spotPriceCalculator domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
 	if r.PrepareResultPoolsExactAmountOutFunc != nil {
-		return r.PrepareResultPoolsExactAmountOutFunc(ctx, tokenIn, spotPriceCalcultor, logger)
+		return r.PrepareResultPoolsExactAmountOutFunc(ctx, tokenIn, spotPriceCalculator, logger)
 	}
 
 	panic("unimplemented")

--- a/domain/mocks/route_mock.go
+++ b/domain/mocks/route_mock.go
@@ -16,8 +16,8 @@ type RouteMock struct {
 	GetPoolsFunc                         func() []domain.RoutablePool
 	GetTokenOutDenomFunc                 func() string
 	GetTokenInDenomFunc                  func() string
-	PrepareResultPoolsExactAmountInFunc  func(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
-	PrepareResultPoolsExactAmountOutFunc func(ctx context.Context, tokenOut types.Coin, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
+	PrepareResultPoolsExactAmountInFunc  func(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
+	PrepareResultPoolsExactAmountOutFunc func(ctx context.Context, tokenOut types.Coin, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error)
 	StringFunc                           func() string
 
 	GetAmountInFunc  func() math.Int
@@ -79,7 +79,7 @@ func (r *RouteMock) GetTokenInDenom() string {
 }
 
 // PrepareResultPoolsOutGivenIn implements domain.Route.
-func (r *RouteMock) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
+func (r *RouteMock) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
 	if r.PrepareResultPoolsExactAmountInFunc != nil {
 		return r.PrepareResultPoolsExactAmountInFunc(ctx, tokenIn, spotPriceCalcultor, logger)
 	}
@@ -87,7 +87,7 @@ func (r *RouteMock) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn ty
 	panic("unimplemented")
 }
 
-func (r *RouteMock) PrepareResultPoolsExactAmountOut(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
+func (r *RouteMock) PrepareResultPoolsExactAmountOut(ctx context.Context, tokenIn types.Coin, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, math.LegacyDec, math.LegacyDec, error) {
 	if r.PrepareResultPoolsExactAmountOutFunc != nil {
 		return r.PrepareResultPoolsExactAmountOutFunc(ctx, tokenIn, spotPriceCalcultor, logger)
 	}

--- a/domain/mocks/tokens_usecase_mock.go
+++ b/domain/mocks/tokens_usecase_mock.go
@@ -31,6 +31,7 @@ type TokensUsecaseMock struct {
 	UpdateAssetsAtHeightIntervalSyncFunc func(height uint64) error
 	SetTokenRegistryLoaderFunc           func(loader domain.TokenRegistryLoader)
 	ClearPoolDenomMetadataFunc           func()
+	CalcSpotPriceFunc                    func(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
 }
 
 var _ mvc.TokensUsecase = &TokensUsecaseMock{}
@@ -171,4 +172,12 @@ func (m *TokensUsecaseMock) ClearPoolDenomMetadata() {
 		m.ClearPoolDenomMetadataFunc()
 	}
 	panic("unimplemented")
+}
+
+// CalcSpotPrice implements mvc.TokensUsecase.
+func (m *TokensUsecaseMock) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+	if m.CalcSpotPriceFunc != nil {
+		return m.CalcSpotPriceFunc(ctx, baseDenom, quoteDenom)
+	}
+	return osmomath.BigDec{}, nil
 }

--- a/domain/mocks/tokens_usecase_mock.go
+++ b/domain/mocks/tokens_usecase_mock.go
@@ -32,6 +32,7 @@ type TokensUsecaseMock struct {
 	SetTokenRegistryLoaderFunc           func(loader domain.TokenRegistryLoader)
 	ClearPoolDenomMetadataFunc           func()
 	CalcSpotPriceFunc                    func(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
+	CalcScalingFactorFunc                func(baseDenom string, quoteDenom string) (osmomath.BigDec, error)
 }
 
 var _ mvc.TokensUsecase = &TokensUsecaseMock{}
@@ -178,6 +179,14 @@ func (m *TokensUsecaseMock) ClearPoolDenomMetadata() {
 func (m *TokensUsecaseMock) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	if m.CalcSpotPriceFunc != nil {
 		return m.CalcSpotPriceFunc(ctx, baseDenom, quoteDenom)
+	}
+	return osmomath.BigDec{}, nil
+}
+
+// CalcScalingFactor implements mvc.TokensUsecase.
+func (m *TokensUsecaseMock) CalcScalingFactor(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+	if m.CalcScalingFactorFunc != nil {
+		return m.CalcScalingFactorFunc(baseDenom, quoteDenom)
 	}
 	return osmomath.BigDec{}, nil
 }

--- a/domain/mvc/tokens.go
+++ b/domain/mvc/tokens.go
@@ -1,7 +1,6 @@
 package mvc
 
 import (
-	"context"
 	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -51,18 +50,10 @@ type TokensUsecase interface {
 	GetSpotPriceScalingFactorByDenom(baseDenom, quoteDenom string) (osmomath.Dec, error)
 
 	// CalcSpotPrice calculates the spot price between two denoms.
-	// Price is derived from the chain prices across all pools between the two denoms.
-	// Returns error if any of the prices is not found or if the quote denom price is zero.
-	CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
+	domain.SpotPriceQuoteCalculator
 
 	// GetPrices returns prices for all given base and quote denoms given a pricing source type or, otherwise, error, if any.
-	// The options configure some customization with regards to how prices are computed.
-	// By default, the prices are computes by using cache and the default min liquidity parameter set via config.
-	// The options are capable of overriding the defaults.
-	// The outer map consists of base denoms as keys.
-	// The inner map consists of quote denoms as keys.
-	// The result of the inner map is prices of the outer base and inner quote.
-	GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error)
+	domain.TokensPriceFetcher
 
 	// GetPoolDenomMetadata returns the pool denom metadata of a pool denom.
 	// This metadata is accumulated from all pools.

--- a/domain/mvc/tokens.go
+++ b/domain/mvc/tokens.go
@@ -50,6 +50,11 @@ type TokensUsecase interface {
 	// GetSpotPriceScalingFactorByDenomMut returns the scaling factor for spot price.
 	GetSpotPriceScalingFactorByDenom(baseDenom, quoteDenom string) (osmomath.Dec, error)
 
+	// CalcSpotPrice calculates the spot price between two denoms.
+	// Price is derived from the chain prices across all pools between the two denoms.
+	// Returns error if any of the prices is not found or if the quote denom price is zero.
+	CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
+
 	// GetPrices returns prices for all given base and quote denoms given a pricing source type or, otherwise, error, if any.
 	// The options configure some customization with regards to how prices are computed.
 	// By default, the prices are computes by using cache and the default min liquidity parameter set via config.

--- a/domain/pools.go
+++ b/domain/pools.go
@@ -32,17 +32,9 @@ type ScalingFactorGetterCb func(denom string) (osmomath.Dec, error)
 type QuoteEstimatorCb func(ctx context.Context, tokenIn sdk.Coin, tokenOutDenom string) (sdk.Coin, error)
 
 // SpotPriceQuoteCalculator is an interface that defines a contract for computing spot price using
-// the quote method. Using this method, the calculator swaps 1 precision-scaled unit of the quote denom
-// For majority of the spot prices with USDC as a quote, this is a reliable method for computing spot price.
-// There are edge cases where this method might prove unreliable. For example, swaping 1 WBTC, might lead
-// to a severe price impact and an unreliable estimation method. On the other hand, swapping 1 PEPE might
-// be too small of an amount, leading to an output of zero.
-// To deal with these issues, we might introduce custom overwrites based on denom down the road.
-//
-// This method primarily exists to workaround a bug with Astroport PCL pools that fail to compute spot price
-// correctly due to downstream issues.
+// the quote method.
 type SpotPriceQuoteCalculator interface {
-	// Calculate returns spot price for base denom and quote denom.
+	// CalcSpotPrice returns spot price for base denom and quote denom.
 	// Returns error if:
 	// * Fails to retrieve scaling factor for the quote denom.
 	// * Quote fails to be computed.
@@ -50,7 +42,7 @@ type SpotPriceQuoteCalculator interface {
 	// * Quoute outputs coin with nil amount.
 	// * Quote outputs coin with zero amount
 	// * Truncation in intermediary calculations happens, leading to spot price of zero.
-	Calculate(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
+	CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
 }
 
 // UnsetScalingFactorGetterCb is a callback that is used to unset the scaling factor getter callback.

--- a/domain/route_test.go
+++ b/domain/route_test.go
@@ -132,7 +132,7 @@ func (s *RouterTestSuite) TestPrepareResultPools() {
 		s.Run(name, func() {
 
 			// Note: token in is chosen arbitrarily since it is irrelevant for this test
-			actualPools, _, _, err := tc.route.PrepareResultPoolsOutGivenIn(context.TODO(), sdk.NewCoin(DenomTwo, DefaultAmt0), &log.NoOpLogger{})
+			actualPools, _, _, err := tc.route.PrepareResultPoolsOutGivenIn(context.TODO(), sdk.NewCoin(DenomTwo, DefaultAmt0), nil, &log.NoOpLogger{})
 			s.Require().NoError(err)
 
 			s.ValidateRoutePools(tc.expectedPools, actualPools)

--- a/domain/router.go
+++ b/domain/router.go
@@ -50,13 +50,9 @@ type Route interface {
 	// Computes the spot price of the route.
 	// Returns the spot price before swap and effective spot price.
 	// The token in is the base token and the token out is the quote token.
-	PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk.Coin, spotPriceCalculator SpotPriceCalcultor, logger log.Logger) ([]RoutablePool, osmomath.Dec, osmomath.Dec, error)
+	PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk.Coin, spotPriceCalculator SpotPriceQuoteCalculator, logger log.Logger) ([]RoutablePool, osmomath.Dec, osmomath.Dec, error)
 
 	String() string
-}
-
-type SpotPriceCalcultor interface {
-	CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
 }
 
 type SplitRoute interface {
@@ -78,7 +74,7 @@ type Quote interface {
 	// scalingFactor is the spot price scaling factor according to chain precision.
 	// scalingFactor of zero is a valid value. It might occur if we do not have precision information
 	// for the tokens. In that case, we invalidate spot price by setting it to zero.
-	PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalculator SpotPriceCalcultor, logger log.Logger) ([]SplitRoute, osmomath.Dec, error)
+	PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalculator SpotPriceQuoteCalculator, logger log.Logger) ([]SplitRoute, osmomath.Dec, error)
 
 	// SetQuotePriceInfo sets the quote price info.
 	SetQuotePriceInfo(info *TxFeeInfo)

--- a/domain/router.go
+++ b/domain/router.go
@@ -50,9 +50,13 @@ type Route interface {
 	// Computes the spot price of the route.
 	// Returns the spot price before swap and effective spot price.
 	// The token in is the base token and the token out is the quote token.
-	PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk.Coin, logger log.Logger) ([]RoutablePool, osmomath.Dec, osmomath.Dec, error)
+	PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk.Coin, spotPriceCalculator SpotPriceCalcultor, logger log.Logger) ([]RoutablePool, osmomath.Dec, osmomath.Dec, error)
 
 	String() string
+}
+
+type SpotPriceCalcultor interface {
+	CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error)
 }
 
 type SplitRoute interface {
@@ -74,7 +78,7 @@ type Quote interface {
 	// scalingFactor is the spot price scaling factor according to chain precision.
 	// scalingFactor of zero is a valid value. It might occur if we do not have precision information
 	// for the tokens. In that case, we invalidate spot price by setting it to zero.
-	PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, logger log.Logger) ([]SplitRoute, osmomath.Dec, error)
+	PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalculator SpotPriceCalcultor, logger log.Logger) ([]SplitRoute, osmomath.Dec, error)
 
 	// SetQuotePriceInfo sets the quote price info.
 	SetQuotePriceInfo(info *TxFeeInfo)

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"context"
+
 	"github.com/osmosis-labs/osmosis/osmomath"
 )
 
@@ -71,3 +73,15 @@ const (
 	// Unknown swap method, used for error handling.
 	TokenSwapMethodInvalid
 )
+
+// TokensPriceFetcher is the contract for fetching prices of base and quote tokens from different sources.
+type TokensPriceFetcher interface {
+	// GetPrices returns prices for all given base and quote denoms given a pricing source type or, otherwise, error, if any.
+	// The options configure some customization with regards to how prices are computed.
+	// By default, the prices are computes by using cache and the default min liquidity parameter set via config.
+	// The options are capable of overriding the defaults.
+	// The outer map consists of base denoms as keys.
+	// The inner map consists of quote denoms as keys.
+	// The result of the inner map is prices of the outer base and inner quote.
+	GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType PricingSourceType, opts ...PricingOption) (PricesResult, error)
+}

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -256,9 +256,9 @@ func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
 				// helper method for validation.
 				// Note token in is chosen arbitrarily since it is irrelevant for this test
 				tokenIn := sdk.NewCoin(tc.tokenInDenom, osmomath.NewInt(100))
-				actualPools, _, _, err := actualRoute.PrepareResultPoolsOutGivenIn(context.TODO(), tokenIn, logger)
+				actualPools, _, _, err := actualRoute.PrepareResultPoolsOutGivenIn(context.TODO(), tokenIn, nil, logger)
 				s.Require().NoError(err)
-				expectedPools, _, _, err := expectedRoute.PrepareResultPoolsOutGivenIn(context.TODO(), tokenIn, logger)
+				expectedPools, _, _, err := expectedRoute.PrepareResultPoolsOutGivenIn(context.TODO(), tokenIn, nil, logger)
 				s.Require().NoError(err)
 
 				// Validates:

--- a/router/delivery/http/router_handler.go
+++ b/router/delivery/http/router_handler.go
@@ -142,7 +142,7 @@ func (a *RouterHandler) GetOptimalQuote(c echo.Context) (err error) {
 		scalingFactor = a.getSpotPriceScalingFactor(tokenIn.Denom, tokenOutDenom)
 	}
 
-	_, _, err = quote.PrepareResult(ctx, scalingFactor, a.logger)
+	_, _, err = quote.PrepareResult(ctx, scalingFactor, a.TUsecase, a.logger)
 	if err != nil {
 		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
 	}
@@ -245,7 +245,7 @@ func (a *RouterHandler) GetDirectCustomQuote(c echo.Context) (err error) {
 		scalingFactor = a.getSpotPriceScalingFactor(tokenIn.Denom, tokenOutDenom[len(tokenOutDenom)-1])
 	}
 
-	_, _, err = quote.PrepareResult(ctx, scalingFactor, a.logger)
+	_, _, err = quote.PrepareResult(ctx, scalingFactor, a.TUsecase, a.logger)
 	if err != nil {
 		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
 	}

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -137,7 +137,8 @@ func (s *RouterTestSuite) TestGetBestSplitRoutesQuote() {
 			routes: []route.RouteImpl{
 				WithRoutePools(route.RouteImpl{}, []domain.RoutablePool{
 					mocks.WithChainPoolModel(mocks.WithTokenOutDenom(DefaultMockPool, DenomOne), defaultBalancerPool),
-				})},
+				}),
+			},
 			tokenIn: sdk.NewCoin(DenomTwo, osmomath.NewInt(100)),
 
 			expectedTokenOutDenom: DenomOne,
@@ -270,7 +271,6 @@ func (s *RouterTestSuite) TestGetBestSplitRoutesQuote() {
 // This test ensures strict route validation.
 // See individual test cases for details.
 func (s *RouterTestSuite) TestValidateAndFilterOutGivenInRoutes() {
-
 	defaultDenomOneTwoOutTwoPool := usecase.CandidatePoolWrapper{
 		CandidatePool: ingesttypes.CandidatePool{
 			ID:            defaultPoolID,
@@ -565,7 +565,6 @@ func (s *RouterTestSuite) TestValidateAndFilterOutGivenInRoutes() {
 	for name, tc := range tests {
 		tc := tc
 		s.Run(name, func() {
-
 			filteredCandidateRoutes, err := routerusecase.ValidateAndFilterRoutesOutGivenIn(tc.routes, tc.tokenInDenom, noOpLogger)
 
 			if tc.expectError != nil {
@@ -753,7 +752,7 @@ func (s *RouterTestSuite) TestGetOptimalQuoteExactAmounOut_Mainnet() {
 			s.Require().NoError(err)
 
 			// TODO: update mainnet state and validate the quote for each test stricter.
-			routes, _, err := quote.PrepareResult(context.Background(), osmomath.NewDec(0), &log.NoOpLogger{}) //  we are not checking the scaling factor
+			routes, _, err := quote.PrepareResult(context.Background(), osmomath.NewDec(0), nil, &log.NoOpLogger{}) //  we are not checking the scaling factor
 			s.Require().NoError(err)
 
 			s.Require().Len(routes, tc.expectedRoutesCountExactAmountOut)
@@ -795,9 +794,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuote_Mainnet_UOSMOU
 	config.MaxPoolsPerRoute = 5
 	config.MaxRoutes = 10
 
-	var (
-		amountIn = osmomath.NewInt(5000000)
-	)
+	amountIn := osmomath.NewInt(5000000)
 
 	mainnetState := s.SetupMainnetState()
 
@@ -978,7 +975,6 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteOutGivenIn() {
 	for _, tc := range testCases {
 		tc := tc
 		s.Run(tc.name, func() {
-
 			// Pre-set cache
 			routerUseCase.SetCandidateRouteCacheToMock(domain.TokenSwapMethodExactIn, defaultTokenIn.Denom, tokenOutDenom)
 			routerUseCase.SetRankedRouteCacheToMock(domain.TokenSwapMethodExactIn, defaultTokenIn.Denom, tokenOutDenom, tokenInOrderOfMagnitude)
@@ -1023,7 +1019,6 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteOutGivenIn() {
 			// Validate cache did not get invalidated
 			s.Require().True(foundcandidateRoutes)
 			s.Require().NotEmpty(cachedRankedRoutes)
-
 		})
 	}
 }
@@ -1180,7 +1175,6 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteInGivenOut() {
 	for _, tc := range testCases {
 		tc := tc
 		s.Run(tc.name, func() {
-
 			// Pre-set cache
 			routerUseCase.SetCandidateRouteCacheToMock(domain.TokenSwapMethodExactOut, defaultTokenOut.Denom, tokenOutDenom)
 			routerUseCase.SetRankedRouteCacheToMock(domain.TokenSwapMethodExactOut, defaultTokenOut.Denom, tokenOutDenom, tokenOutOrderOfMagnitude)
@@ -1225,7 +1219,6 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteInGivenOut() {
 			// Validate cache did not get invalidated
 			s.Require().True(foundcandidateRoutes)
 			s.Require().NotEmpty(cachedRankedRoutes)
-
 		})
 	}
 }

--- a/router/usecase/pools/routable_cw_pool.go
+++ b/router/usecase/pools/routable_cw_pool.go
@@ -211,7 +211,7 @@ func (r *routableCosmWasmPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom 
 	codeID := r.ChainPool.CodeId
 	if codeID == astroportCodeID {
 		// Attempt to Calculate the spot price using quote
-		spotPriceFromQuote, err := r.spotPriceQuoteCalculator.Calculate(ctx, baseDenom, quoteDenom)
+		spotPriceFromQuote, err := r.spotPriceQuoteCalculator.CalcSpotPrice(ctx, baseDenom, quoteDenom)
 		// If no error return immediately
 		if err == nil {
 			return spotPriceFromQuote, nil

--- a/router/usecase/pools/spot_price_quote_calculator.go
+++ b/router/usecase/pools/spot_price_quote_calculator.go
@@ -8,6 +8,16 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 )
 
+// spotPriceQuoteCalculator implements domain.SpotPriceQuoteCalculator to compute spot price using the quote method.
+// Using this method, the calculator swaps 1 precision-scaled unit of the quote denom
+// For majority of the spot prices with USDC as a quote, this is a reliable method for computing spot price.
+// There are edge cases where this method might prove unreliable. For example, swaping 1 WBTC, might lead
+// to a severe price impact and an unreliable estimation method. On the other hand, swapping 1 PEPE might
+// be too small of an amount, leading to an output of zero.
+// To deal with these issues, we might introduce custom overwrites based on denom down the road.
+//
+// This method primarily exists to workaround a bug with Astroport PCL pools that fail to compute spot price
+// correctly due to downstream issues.
 type spotPriceQuoteCalculator struct {
 	scalingFactorGetterCb domain.ScalingFactorGetterCb
 	quoteEstimatorCb      domain.QuoteEstimatorCb
@@ -23,8 +33,8 @@ func NewSpotPriceQuoteComputer(scalingFactorGetterCb domain.ScalingFactorGetterC
 	}
 }
 
-// Calculate implements domain.SpotPriceQuoteCalculator
-func (s *spotPriceQuoteCalculator) Calculate(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+// CalcSpotPrice implements domain.SpotPriceQuoteCalculator
+func (s *spotPriceQuoteCalculator) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	quoteScalingFactor, err := s.scalingFactorGetterCb(quoteDenom)
 	if err != nil {
 		return osmomath.BigDec{}, err

--- a/router/usecase/pools/spot_price_quote_calculator_test.go
+++ b/router/usecase/pools/spot_price_quote_calculator_test.go
@@ -201,7 +201,7 @@ func (s *RoutablePoolTestSuite) TestSpotPriceQuoteCalculator_Calculate() {
 			spotPriceQuoteCalculator := pools.NewSpotPriceQuoteComputer(mockScalingFactorGetter, mockQuoteEstimator)
 
 			// System under test
-			actualSpotPrice, err := spotPriceQuoteCalculator.Calculate(context.TODO(), tc.baseDenom, tc.quoteDenom)
+			actualSpotPrice, err := spotPriceQuoteCalculator.CalcSpotPrice(context.TODO(), tc.baseDenom, tc.quoteDenom)
 
 			if tc.expectedError != nil {
 				s.Require().Error(err)

--- a/router/usecase/quote_in_given_out.go
+++ b/router/usecase/quote_in_given_out.go
@@ -14,9 +14,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var (
-	_ domain.Quote = &quoteExactAmountOut{}
-)
+var _ domain.Quote = &quoteExactAmountOut{}
 
 // quoteExactAmountOut is a quote wrapper for exact out quotes.
 // Note that only the PrepareResult method is different from the quoteExactAmountIn.
@@ -136,9 +134,9 @@ func (q *quoteExactAmountOut) SetQuotePriceInfo(info *domain.TxFeeInfo) {
 // Computes an effective spread factor from all routes.
 //
 // Returns the updated route and the effective spread factor.
-func (q *quoteExactAmountOut) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
+func (q *quoteExactAmountOut) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalculator domain.SpotPriceCalcultor, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
 	// Prepare exact out in the quote for inputs inversion
-	if _, _, err := q.quoteExactAmountIn.PrepareResult(ctx, scalingFactor, logger); err != nil {
+	if _, _, err := q.quoteExactAmountIn.PrepareResult(ctx, scalingFactor, spotPriceCalculator, logger); err != nil {
 		return nil, osmomath.Dec{}, err
 	}
 

--- a/router/usecase/quote_in_given_out.go
+++ b/router/usecase/quote_in_given_out.go
@@ -134,7 +134,7 @@ func (q *quoteExactAmountOut) SetQuotePriceInfo(info *domain.TxFeeInfo) {
 // Computes an effective spread factor from all routes.
 //
 // Returns the updated route and the effective spread factor.
-func (q *quoteExactAmountOut) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalculator domain.SpotPriceCalcultor, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
+func (q *quoteExactAmountOut) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalculator domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
 	// Prepare exact out in the quote for inputs inversion
 	if _, _, err := q.quoteExactAmountIn.PrepareResult(ctx, scalingFactor, spotPriceCalculator, logger); err != nil {
 		return nil, osmomath.Dec{}, err

--- a/router/usecase/quote_out_given_in.go
+++ b/router/usecase/quote_out_given_in.go
@@ -49,7 +49,7 @@ type quoteExactAmountIn struct {
 // Computes an effective spread factor from all routes.
 //
 // Returns the updated route and the effective spread factor.
-func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
+func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
 	totalAmountIn := q.AmountIn.Amount.ToLegacyDec()
 	totalFeeAcrossRoutes := osmomath.ZeroDec()
 

--- a/router/usecase/quote_out_given_in.go
+++ b/router/usecase/quote_out_given_in.go
@@ -14,13 +14,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var (
-	one = osmomath.OneDec()
-)
+var one = osmomath.OneDec()
 
-var (
-	_ domain.Quote = &quoteExactAmountIn{}
-)
+var _ domain.Quote = &quoteExactAmountIn{}
 
 // NOTE: This is because structs in alias declaration are not exported
 type (
@@ -53,7 +49,7 @@ type quoteExactAmountIn struct {
 // Computes an effective spread factor from all routes.
 //
 // Returns the updated route and the effective spread factor.
-func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
+func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalcultor domain.SpotPriceCalcultor, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
 	totalAmountIn := q.AmountIn.Amount.ToLegacyDec()
 	totalFeeAcrossRoutes := osmomath.ZeroDec()
 
@@ -80,7 +76,7 @@ func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor os
 		totalFeeAcrossRoutes.AddMut(routeTotalFee.MulMut(routeAmountInFraction))
 
 		amountInFraction := q.AmountIn.Amount.ToLegacyDec().MulMut(routeAmountInFraction).TruncateInt()
-		newPools, routeSpotPriceInBaseOutQuote, effectiveSpotPriceInBaseOutQuote, err := curRoute.PrepareResultPoolsOutGivenIn(ctx, sdk.NewCoin(q.AmountIn.Denom, amountInFraction), logger)
+		newPools, routeSpotPriceInBaseOutQuote, effectiveSpotPriceInBaseOutQuote, err := curRoute.PrepareResultPoolsOutGivenIn(ctx, sdk.NewCoin(q.AmountIn.Denom, amountInFraction), spotPriceCalcultor, logger)
 		if err != nil {
 			return nil, osmomath.Dec{}, err
 		}

--- a/router/usecase/quote_out_given_in.go
+++ b/router/usecase/quote_out_given_in.go
@@ -49,7 +49,7 @@ type quoteExactAmountIn struct {
 // Computes an effective spread factor from all routes.
 //
 // Returns the updated route and the effective spread factor.
-func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalcultor domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
+func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor osmomath.Dec, spotPriceCalculator domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.SplitRoute, osmomath.Dec, error) {
 	totalAmountIn := q.AmountIn.Amount.ToLegacyDec()
 	totalFeeAcrossRoutes := osmomath.ZeroDec()
 
@@ -76,7 +76,7 @@ func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor os
 		totalFeeAcrossRoutes.AddMut(routeTotalFee.MulMut(routeAmountInFraction))
 
 		amountInFraction := q.AmountIn.Amount.ToLegacyDec().MulMut(routeAmountInFraction).TruncateInt()
-		newPools, routeSpotPriceInBaseOutQuote, effectiveSpotPriceInBaseOutQuote, err := curRoute.PrepareResultPoolsOutGivenIn(ctx, sdk.NewCoin(q.AmountIn.Denom, amountInFraction), spotPriceCalcultor, logger)
+		newPools, routeSpotPriceInBaseOutQuote, effectiveSpotPriceInBaseOutQuote, err := curRoute.PrepareResultPoolsOutGivenIn(ctx, sdk.NewCoin(q.AmountIn.Denom, amountInFraction), spotPriceCalculator, logger)
 		if err != nil {
 			return nil, osmomath.Dec{}, err
 		}

--- a/router/usecase/quote_test.go
+++ b/router/usecase/quote_test.go
@@ -182,7 +182,7 @@ func (s *RouterTestSuite) TestPrepareResult() {
 	for _, tc := range testcases {
 		s.Run(tc.name, func() {
 			// System under test
-			routes, effectiveFee, err := tc.quote.PrepareResult(context.TODO(), defaultSpotPriceScalingFactor, &log.NoOpLogger{})
+			routes, effectiveFee, err := tc.quote.PrepareResult(context.TODO(), defaultSpotPriceScalingFactor, nil, &log.NoOpLogger{})
 			s.Require().NoError(err)
 
 			// Validate JSON representation, which is used for output to the client
@@ -265,7 +265,7 @@ func (s *RouterTestSuite) TestPrepareResult_PriceImpact() {
 	}
 
 	// System under test.
-	testQuote.PrepareResult(context.TODO(), defaultSpotPriceScalingFactor, &log.NoOpLogger{})
+	testQuote.PrepareResult(context.TODO(), defaultSpotPriceScalingFactor, nil, &log.NoOpLogger{})
 
 	// Validate price impact.
 	s.Require().Equal(expectedPriceImpact.String(), testQuote.GetPriceImpact().String())

--- a/router/usecase/route/route.go
+++ b/router/usecase/route/route.go
@@ -52,7 +52,7 @@ var spotPriceErrorResultCounter = prometheus.NewCounterVec(
 // Note that it mutates the route.
 // Returns spot price before swap and the effective spot price
 // with token in as base and token out as quote.
-func (r RouteImpl) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk.Coin, spotPriceCalculator domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, osmomath.Dec, osmomath.Dec, error) {
+func (r RouteImpl) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk.Coin, spotPriceCalculator domain.SpotPriceQuoteCalculator, logger log.Logger) ([]domain.RoutablePool, osmomath.Dec, osmomath.Dec, error) {
 	var (
 		routeSpotPriceInBaseOutQuote     = osmomath.OneDec()
 		effectiveSpotPriceInBaseOutQuote = osmomath.OneDec()

--- a/router/usecase/route/route.go
+++ b/router/usecase/route/route.go
@@ -31,14 +31,12 @@ type RouteImpl struct {
 	HasCanonicalOrderbookPool bool "json:\"-\""
 }
 
-var (
-	spotPriceErrorResultCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "sqs_routes_spot_price_error_total",
-			Help: "Spot price error when preparing result pools",
-		},
-		[]string{"token_in", "cur_token_out_denom", "route_token_out_denom"},
-	)
+var spotPriceErrorResultCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "sqs_routes_spot_price_error_total",
+		Help: "Spot price error when preparing result pools",
+	},
+	[]string{"token_in", "cur_token_out_denom", "route_token_out_denom"},
 )
 
 // PrepareResultPoolsOutGivenIn implements domain.Route.
@@ -54,7 +52,7 @@ var (
 // Note that it mutates the route.
 // Returns spot price before swap and the effective spot price
 // with token in as base and token out as quote.
-func (r RouteImpl) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk.Coin, logger log.Logger) ([]domain.RoutablePool, osmomath.Dec, osmomath.Dec, error) {
+func (r RouteImpl) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk.Coin, spotPriceCalculator domain.SpotPriceCalcultor, logger log.Logger) ([]domain.RoutablePool, osmomath.Dec, osmomath.Dec, error) {
 	var (
 		routeSpotPriceInBaseOutQuote     = osmomath.OneDec()
 		effectiveSpotPriceInBaseOutQuote = osmomath.OneDec()
@@ -64,7 +62,15 @@ func (r RouteImpl) PrepareResultPoolsOutGivenIn(ctx context.Context, tokenIn sdk
 
 	for _, pool := range r.Pools {
 		// Compute spot price before swap.
-		spotPriceInBaseOutQuote, err := pool.CalcSpotPrice(ctx, tokenIn.Denom, pool.GetTokenOutDenom())
+		var (
+			spotPriceInBaseOutQuote osmomath.BigDec
+			err                     error
+		)
+		if pool.GetSQSType() == domain.Orderbook {
+			spotPriceInBaseOutQuote, err = spotPriceCalculator.CalcSpotPrice(ctx, tokenIn.Denom, pool.GetTokenOutDenom())
+		} else {
+			spotPriceInBaseOutQuote, err = pool.CalcSpotPrice(ctx, tokenIn.Denom, pool.GetTokenOutDenom())
+		}
 		if err != nil {
 			logger.Error("failed to calculate spot price for pool", zap.Error(err))
 

--- a/router/usecase/route/route_test.go
+++ b/router/usecase/route/route_test.go
@@ -207,7 +207,7 @@ func (s *RouterTestSuite) TestPrepareResultPoolsOutGivenIn() {
 		s.Run(name, func() {
 
 			// Note: token in is chosen arbitrarily since it is irrelevant for this test
-			actualPools, spotPriceBeforeInBaseOutQuote, _, err := tc.route.PrepareResultPoolsOutGivenIn(context.TODO(), tc.tokenIn, &log.NoOpLogger{})
+			actualPools, spotPriceBeforeInBaseOutQuote, _, err := tc.route.PrepareResultPoolsOutGivenIn(context.TODO(), tc.tokenIn, nil, &log.NoOpLogger{})
 			s.Require().NoError(err)
 
 			s.Require().Equal(tc.expectedSpotPriceInBaseOutQuote, spotPriceBeforeInBaseOutQuote)

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -984,7 +984,7 @@ func (s *RouterTestSuite) TestPriceImpactRoute_Fractions() {
 	s.Require().NoError(err)
 
 	// Prepare quote result.
-	_, _, err = quote.PrepareResult(context.Background(), osmomath.NewDec(int64(wbtcMetadata.Precision)), &log.NoOpLogger{})
+	_, _, err = quote.PrepareResult(context.Background(), osmomath.NewDec(int64(wbtcMetadata.Precision)), nil, &log.NoOpLogger{})
 
 	priceImpact := quote.GetPriceImpact()
 

--- a/tokens/usecase/export_test.go
+++ b/tokens/usecase/export_test.go
@@ -1,23 +1,30 @@
 package usecase
 
+import "github.com/osmosis-labs/sqs/domain"
+
 // PutArbitraryTypeTokenMetadata is a test helper to put arbitrary types to token metadata
-func (t *tokensUseCase) SetTokenMetadataByChainDenom(key string, value any) {
+func (t *TokensUseCase) SetTokenMetadataByChainDenom(key string, value any) {
 	t.tokenMetadataByChainDenom.Store(key, value)
 }
 
 // PutArbitraryTypeHumanToChainDenomMap is a test helper to put arbitrary types to human to chain denom map
-func (t *tokensUseCase) SetTypeHumanToChainDenomMap(key string, value any) {
+func (t *TokensUseCase) SetTypeHumanToChainDenomMap(key string, value any) {
 	t.humanToChainDenomMap.Store(key, value)
 }
 
 // SetChainDenoms is a test helper to put arbitrary types to chain denoms
-func (t *tokensUseCase) SetChainDenoms(key any, value any) {
+func (t *TokensUseCase) SetChainDenoms(key any, value any) {
 	t.chainDenoms.Store(key, value)
 }
 
 // SetCoingeckoIDs is a test helper to put arbitrary types to coingecko ids
-func (t *tokensUseCase) SetCoingeckoIDs(key string, value any) {
+func (t *TokensUseCase) SetCoingeckoIDs(key string, value any) {
 	t.coingeckoIds.Store(key, value)
+}
+
+// SetTokensPriceFetcher is a test helper to set tokens price fetcher.
+func (t *TokensUseCase) SetTokensPriceFetcher(fetcher domain.TokensPriceFetcher) {
+	t.tokenPriceFetcher = fetcher
 }
 
 // SetLastFetchHash is a test helper to set last fetch hash.

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -21,7 +21,7 @@ const (
 	maxNumWorkes = 10
 )
 
-type tokensUseCase struct {
+type TokensUseCase struct {
 	// Can be considered for merge with humanToChainDenomMap in the future.
 	tokenMetadataByChainDenom sync.Map // domain.Token
 	humanToChainDenomMap      sync.Map // string
@@ -47,6 +47,9 @@ type tokensUseCase struct {
 	// Default quote denom to use for pricing
 	defaultQuoteDenom string
 
+	// TokenPriceFetcher is used for fetching token prices.
+	tokenPriceFetcher domain.TokensPriceFetcher
+
 	// Logger instance
 	logger log.Logger
 }
@@ -71,11 +74,11 @@ type priceResults struct {
 	err       error
 }
 
-var _ mvc.TokensUsecase = &tokensUseCase{}
+var _ mvc.TokensUsecase = &TokensUseCase{}
 
 // NewTokensUsecase will create a new tokens use case object
-func NewTokensUsecase(tokenMetadataByChainDenom map[string]domain.Token, updateAssetsHeightInterval int, logger log.Logger) *tokensUseCase {
-	us := tokensUseCase{
+func NewTokensUsecase(tokenMetadataByChainDenom map[string]domain.Token, updateAssetsHeightInterval int, logger log.Logger) *TokensUseCase {
+	us := &TokensUseCase{
 		pricingStrategyMap:         map[domain.PricingSourceType]domain.PricingSource{},
 		poolDenomMetaData:          sync.Map{},
 		updateAssetsHeightInterval: updateAssetsHeightInterval,
@@ -84,16 +87,18 @@ func NewTokensUsecase(tokenMetadataByChainDenom map[string]domain.Token, updateA
 
 	us.LoadTokens(tokenMetadataByChainDenom)
 
-	return &us
+	us.tokenPriceFetcher = us
+
+	return us
 }
 
 // SetTokenRegistryLoader sets the token registry loader for the tokens use case
-func (t *tokensUseCase) SetTokenRegistryLoader(loader domain.TokenRegistryLoader) {
+func (t *TokensUseCase) SetTokenRegistryLoader(loader domain.TokenRegistryLoader) {
 	t.tokenLoader = loader
 }
 
 // SetDefaultQuoteDenom sets the default quote denom for the tokens use case
-func (t *tokensUseCase) SetDefaultQuoteDenom(denom string) {
+func (t *TokensUseCase) SetDefaultQuoteDenom(denom string) {
 	t.defaultQuoteDenom = denom
 }
 
@@ -101,7 +106,7 @@ func (t *tokensUseCase) SetDefaultQuoteDenom(denom string) {
 type LoadTokensFunc func(tokenMetadataByChainDenom map[string]domain.Token)
 
 // LoadTokens implements mvc.TokensUsecase.
-func (t *tokensUseCase) LoadTokens(tokenMetadataByChainDenom map[string]domain.Token) {
+func (t *TokensUseCase) LoadTokens(tokenMetadataByChainDenom map[string]domain.Token) {
 	// Create human denom to chain denom map
 	for chainDenom, tokenMetadata := range tokenMetadataByChainDenom {
 		// lower case human denom
@@ -117,7 +122,7 @@ func (t *tokensUseCase) LoadTokens(tokenMetadataByChainDenom map[string]domain.T
 }
 
 // UpdatePoolDenomMetadata implements mvc.TokensUsecase.
-func (t *tokensUseCase) UpdatePoolDenomMetadata(poolDenomMetadata domain.PoolDenomMetaDataMap) {
+func (t *TokensUseCase) UpdatePoolDenomMetadata(poolDenomMetadata domain.PoolDenomMetaDataMap) {
 	for chainDenom, tokenMetadata := range poolDenomMetadata {
 		t.poolDenomMetaData.Store(chainDenom, tokenMetadata)
 	}
@@ -125,12 +130,12 @@ func (t *tokensUseCase) UpdatePoolDenomMetadata(poolDenomMetadata domain.PoolDen
 
 // ClearPoolDenomMetadata implements mvc.TokensUsecase.
 // WARNING: use with caution, this will clear all pool denom metadata
-func (t *tokensUseCase) ClearPoolDenomMetadata() {
+func (t *TokensUseCase) ClearPoolDenomMetadata() {
 	t.poolDenomMetaData = sync.Map{}
 }
 
 // GetPoolLiquidityCap implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetPoolLiquidityCap(chainDenom string) (osmomath.Int, error) {
+func (t *TokensUseCase) GetPoolLiquidityCap(chainDenom string) (osmomath.Int, error) {
 	poolDenomMetadata, err := t.GetPoolDenomMetadata(chainDenom)
 	if err != nil {
 		return osmomath.Int{}, err
@@ -139,7 +144,7 @@ func (t *tokensUseCase) GetPoolLiquidityCap(chainDenom string) (osmomath.Int, er
 }
 
 // GetPoolDenomMetadata implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetPoolDenomMetadata(chainDenom string) (domain.PoolDenomMetaData, error) {
+func (t *TokensUseCase) GetPoolDenomMetadata(chainDenom string) (domain.PoolDenomMetaData, error) {
 	poolDenomMetadataObj, ok := t.poolDenomMetaData.Load(chainDenom)
 	if !ok {
 		return domain.PoolDenomMetaData{}, domain.PoolDenomMetaDataNotPresentError{
@@ -156,7 +161,7 @@ func (t *tokensUseCase) GetPoolDenomMetadata(chainDenom string) (domain.PoolDeno
 }
 
 // GetPoolDenomsMetadata implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetPoolDenomsMetadata(chainDenoms []string) domain.PoolDenomMetaDataMap {
+func (t *TokensUseCase) GetPoolDenomsMetadata(chainDenoms []string) domain.PoolDenomMetaDataMap {
 	result := make(domain.PoolDenomMetaDataMap, len(chainDenoms))
 
 	for _, chainDenom := range chainDenoms {
@@ -179,7 +184,7 @@ func (t *tokensUseCase) GetPoolDenomsMetadata(chainDenoms []string) domain.PoolD
 }
 
 // GetFullPoolDenomMetadata implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetFullPoolDenomMetadata() domain.PoolDenomMetaDataMap {
+func (t *TokensUseCase) GetFullPoolDenomMetadata() domain.PoolDenomMetaDataMap {
 	var chainDenoms []string
 	t.chainDenoms.Range(func(chainDenom, _ any) bool {
 		v, ok := chainDenom.(string)
@@ -192,7 +197,7 @@ func (t *tokensUseCase) GetFullPoolDenomMetadata() domain.PoolDenomMetaDataMap {
 }
 
 // GetChainDenom implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetChainDenom(humanDenom string) (string, error) {
+func (t *TokensUseCase) GetChainDenom(humanDenom string) (string, error) {
 	humanDenomLowerCase := strings.ToLower(humanDenom)
 
 	chainDenom, ok := t.humanToChainDenomMap.Load(humanDenomLowerCase)
@@ -209,7 +214,7 @@ func (t *tokensUseCase) GetChainDenom(humanDenom string) (string, error) {
 }
 
 // GetMetadataByChainDenom implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetMetadataByChainDenom(denom string) (domain.Token, error) {
+func (t *TokensUseCase) GetMetadataByChainDenom(denom string) (domain.Token, error) {
 	token, ok := t.tokenMetadataByChainDenom.Load(denom)
 	if !ok {
 		return domain.Token{}, MetadataForChainDenomNotFoundError{ChainDenom: denom}
@@ -224,7 +229,7 @@ func (t *tokensUseCase) GetMetadataByChainDenom(denom string) (domain.Token, err
 }
 
 // GetFullTokenMetadata implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetFullTokenMetadata() (map[string]domain.Token, error) {
+func (t *TokensUseCase) GetFullTokenMetadata() (map[string]domain.Token, error) {
 	// Do a copy of the cached metadata
 	var err error
 	result := make(map[string]domain.Token)
@@ -249,7 +254,7 @@ func (t *tokensUseCase) GetFullTokenMetadata() (map[string]domain.Token, error) 
 }
 
 // GetChainScalingFactorByDenomMut implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetChainScalingFactorByDenomMut(denom string) (osmomath.Dec, error) {
+func (t *TokensUseCase) GetChainScalingFactorByDenomMut(denom string) (osmomath.Dec, error) {
 	denomMetadata, err := t.GetMetadataByChainDenom(denom)
 	if err != nil {
 		return osmomath.Dec{}, err
@@ -267,7 +272,7 @@ func (t *tokensUseCase) GetChainScalingFactorByDenomMut(denom string) (osmomath.
 }
 
 // GetPrices implements pricing.PricingStrategy.
-func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error) {
+func (t *TokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error) {
 	byBaseDenomResult := make(map[string]map[string]osmomath.BigDec, len(baseDenoms))
 
 	numWorkers := len(baseDenoms)
@@ -326,7 +331,7 @@ func (t *tokensUseCase) GetPrices(ctx context.Context, baseDenoms []string, quot
 // Returns a map with keys as quotes and values as prices or error, if any.
 // Returns error if base denom is not found in the token metadata.
 // Sets the price to zero in case of failing to compute the price between base and quote but these being valid tokens.
-func (t *tokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, pricingOptions ...domain.PricingOption) (map[string]osmomath.BigDec, error) {
+func (t *TokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, pricingOptions ...domain.PricingOption) (map[string]osmomath.BigDec, error) {
 	byQuoteDenomForGivenBaseResult := make(map[string]osmomath.BigDec, len(quoteDenoms))
 	// Validate base denom is a valid denom
 	// Return zeroes for all quotes if base denom is not found
@@ -383,15 +388,15 @@ func (t *tokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom str
 // normalized by the scaling factor derived from CalcScalingFactor.
 // Formula is: spotPrice = (base denom price / quote denom price) * scaling factor
 // Returns error if any of the prices is not found or if the quote denom price is zero.
-func (t *tokensUseCase) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+func (t *TokensUseCase) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	// Get the price of base denom in the default quote denom
-	basePrices, err := t.GetPrices(ctx, []string{baseDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
+	basePrices, err := t.tokenPriceFetcher.GetPrices(ctx, []string{baseDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}
 
 	// Get the price of base denom in the default quote denom
-	quotePrices, err := t.GetPrices(ctx, []string{quoteDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
+	quotePrices, err := t.tokenPriceFetcher.GetPrices(ctx, []string{quoteDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}
@@ -427,7 +432,7 @@ func (t *tokensUseCase) CalcSpotPrice(ctx context.Context, baseDenom string, quo
 // CalcScalingFactor calculates the scaling factor between two denoms.
 // Formula is: scaleFactor = (10^quote_decimals) / (10^base_decimals)
 // Returns error if any of the denoms is not found in the token metadata.
-func (t *tokensUseCase) CalcScalingFactor(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+func (t *TokensUseCase) CalcScalingFactor(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
 	// Retrieve metadata for base denom
 	baseDenomMetadata, err := t.GetMetadataByChainDenom(baseDenom)
 	if err != nil {
@@ -451,7 +456,7 @@ func (t *tokensUseCase) CalcScalingFactor(baseDenom string, quoteDenom string) (
 }
 
 // UpdateAssetsAtHeightIntervalSync updates assets at configured height interval.
-func (t *tokensUseCase) UpdateAssetsAtHeightIntervalSync(height uint64) error {
+func (t *TokensUseCase) UpdateAssetsAtHeightIntervalSync(height uint64) error {
 	if height%uint64(t.updateAssetsHeightInterval) == 0 {
 		if err := t.tokenLoader.FetchAndUpdateTokens(); err != nil {
 			return err
@@ -461,7 +466,7 @@ func (t *tokensUseCase) UpdateAssetsAtHeightIntervalSync(height uint64) error {
 }
 
 // GetSpotPriceScalingFactorByDenomMut implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetSpotPriceScalingFactorByDenom(baseDenom string, quoteDenom string) (osmomath.Dec, error) {
+func (t *TokensUseCase) GetSpotPriceScalingFactorByDenom(baseDenom string, quoteDenom string) (osmomath.Dec, error) {
 	baseScalingFactor, err := t.GetChainScalingFactorByDenomMut(baseDenom)
 	if err != nil {
 		return osmomath.Dec{}, err
@@ -480,12 +485,12 @@ func (t *tokensUseCase) GetSpotPriceScalingFactorByDenom(baseDenom string, quote
 }
 
 // RegisterPricingStrategy implements mvc.TokensUsecase.
-func (t *tokensUseCase) RegisterPricingStrategy(source domain.PricingSourceType, strategy domain.PricingSource) {
+func (t *TokensUseCase) RegisterPricingStrategy(source domain.PricingSourceType, strategy domain.PricingSource) {
 	t.pricingStrategyMap[source] = strategy
 }
 
 // IsValidChainDenom implements mvc.TokensUsecase.
-func (t *tokensUseCase) IsValidChainDenom(chainDenom string) bool {
+func (t *TokensUseCase) IsValidChainDenom(chainDenom string) bool {
 	metaData, ok := t.tokenMetadataByChainDenom.Load(chainDenom)
 	if !ok {
 		return false
@@ -501,7 +506,7 @@ func (t *tokensUseCase) IsValidChainDenom(chainDenom string) bool {
 }
 
 // GetMinPoolLiquidityCap implements mvc.TokensUsecase.
-func (t *tokensUseCase) GetMinPoolLiquidityCap(denomA, denomB string) (uint64, error) {
+func (t *TokensUseCase) GetMinPoolLiquidityCap(denomA, denomB string) (uint64, error) {
 	// Get the pool denoms metadata
 	poolDenomMetadataA, err := t.GetPoolDenomMetadata(denomA)
 	if err != nil {
@@ -524,13 +529,13 @@ func (t *tokensUseCase) GetMinPoolLiquidityCap(denomA, denomB string) (uint64, e
 }
 
 // IsValidPricingSource implements mvc.TokensUsecase.
-func (t *tokensUseCase) IsValidPricingSource(pricingSource int) bool {
+func (t *TokensUseCase) IsValidPricingSource(pricingSource int) bool {
 	ps := domain.PricingSourceType(pricingSource)
 	return ps == domain.ChainPricingSourceType || ps == domain.CoinGeckoPricingSourceType
 }
 
 // GetCoingeckoIdByChainDenom implements mvc.TokensUsecase
-func (t *tokensUseCase) GetCoingeckoIdByChainDenom(chainDenom string) (string, error) {
+func (t *TokensUseCase) GetCoingeckoIdByChainDenom(chainDenom string) (string, error) {
 	coingeckoId, found := t.coingeckoIds.Load(chainDenom)
 	if !found {
 		return "", ChainDenomNotFoundInChainRegistryError{}

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -44,6 +44,9 @@ type tokensUseCase struct {
 	// TokenRegistryLoader fetches tokens from the chain registry into the tokens use case
 	tokenLoader domain.TokenRegistryLoader
 
+	// Default quote denom to use for pricing
+	defaultQuoteDenom string
+
 	// Logger instance
 	logger log.Logger
 }
@@ -87,6 +90,11 @@ func NewTokensUsecase(tokenMetadataByChainDenom map[string]domain.Token, updateA
 // SetTokenRegistryLoader sets the token registry loader for the tokens use case
 func (t *tokensUseCase) SetTokenRegistryLoader(loader domain.TokenRegistryLoader) {
 	t.tokenLoader = loader
+}
+
+// SetDefaultQuoteDenom sets the default quote denom for the tokens use case
+func (t *tokensUseCase) SetDefaultQuoteDenom(denom string) {
+	t.defaultQuoteDenom = denom
 }
 
 // LoadTokensFunc is a function signature for LoadTokens.
@@ -368,6 +376,37 @@ func (t *tokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom str
 	}
 
 	return byQuoteDenomForGivenBaseResult, nil
+}
+
+// CalcSpotPrice calculates the spot price between two denoms.
+// Price is derived from the chain prices across all pools between the two denoms.
+// Returns error if any of the prices is not found or if the quote denom price is zero.
+func (t *tokensUseCase) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+	baseDenomPrice, err := t.GetPrices(ctx, []string{baseDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	quoteDenomPrice, err := t.GetPrices(ctx, []string{quoteDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	baseDenomPriceDec := baseDenomPrice[baseDenom][t.defaultQuoteDenom]
+	if baseDenomPriceDec.IsNil() {
+		return osmomath.BigDec{}, fmt.Errorf("base denom price is nil")
+	}
+
+	quoteDenomPriceDec := quoteDenomPrice[quoteDenom][t.defaultQuoteDenom]
+	if quoteDenomPriceDec.IsNil() {
+		return osmomath.BigDec{}, fmt.Errorf("quote denom price is nil")
+	}
+
+	if quoteDenomPriceDec.IsZero() {
+		return osmomath.BigDec{}, fmt.Errorf("quote denom price is zero")
+	}
+
+	return baseDenomPriceDec.Quo(quoteDenomPriceDec), nil
 }
 
 // UpdateAssetsAtHeightIntervalSync updates assets at configured height interval.

--- a/tokens/usecase/tokens_usecase.go
+++ b/tokens/usecase/tokens_usecase.go
@@ -379,34 +379,75 @@ func (t *tokensUseCase) getPricesForBaseDenom(ctx context.Context, baseDenom str
 }
 
 // CalcSpotPrice calculates the spot price between two denoms.
-// Price is derived from the chain prices across all pools between the two denoms.
+// Spot price is derived from the chain prices across all pools between the two denoms and
+// normalized by the scaling factor derived from CalcScalingFactor.
+// Formula is: spotPrice = (base denom price / quote denom price) * scaling factor
 // Returns error if any of the prices is not found or if the quote denom price is zero.
 func (t *tokensUseCase) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
-	baseDenomPrice, err := t.GetPrices(ctx, []string{baseDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
+	// Get the price of base denom in the default quote denom
+	basePrices, err := t.GetPrices(ctx, []string{baseDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}
 
-	quoteDenomPrice, err := t.GetPrices(ctx, []string{quoteDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
+	// Get the price of base denom in the default quote denom
+	quotePrices, err := t.GetPrices(ctx, []string{quoteDenom}, []string{t.defaultQuoteDenom}, domain.ChainPricingSourceType)
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}
 
-	baseDenomPriceDec := baseDenomPrice[baseDenom][t.defaultQuoteDenom]
-	if baseDenomPriceDec.IsNil() {
+	basePrice := basePrices[baseDenom][t.defaultQuoteDenom]
+	if basePrice.IsNil() {
 		return osmomath.BigDec{}, fmt.Errorf("base denom price is nil")
 	}
 
-	quoteDenomPriceDec := quoteDenomPrice[quoteDenom][t.defaultQuoteDenom]
-	if quoteDenomPriceDec.IsNil() {
+	quotePrice := quotePrices[quoteDenom][t.defaultQuoteDenom]
+	if quotePrice.IsNil() {
 		return osmomath.BigDec{}, fmt.Errorf("quote denom price is nil")
 	}
 
-	if quoteDenomPriceDec.IsZero() {
+	if quotePrice.IsZero() {
 		return osmomath.BigDec{}, fmt.Errorf("quote denom price is zero")
 	}
 
-	return baseDenomPriceDec.Quo(quoteDenomPriceDec), nil
+	// Calculate raw spot price
+	p := basePrice.Quo(quotePrice)
+
+	scaleFactor, err := t.CalcScalingFactor(baseDenom, quoteDenom)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	// Normalize using scaling factor
+	p = p.MulMut(scaleFactor)
+
+	return p, nil
+}
+
+// CalcScalingFactor calculates the scaling factor between two denoms.
+// Formula is: scaleFactor = (10^quote_decimals) / (10^base_decimals)
+// Returns error if any of the denoms is not found in the token metadata.
+func (t *tokensUseCase) CalcScalingFactor(baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+	// Retrieve metadata for base denom
+	baseDenomMetadata, err := t.GetMetadataByChainDenom(baseDenom)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	// Retrieve metadata for quote denom
+	quoteDenomMetadata, err := t.GetMetadataByChainDenom(quoteDenom)
+	if err != nil {
+		return osmomath.BigDec{}, err
+	}
+
+	tenDec := osmomath.NewBigDec(10)
+
+	// Calculate scaling factors based on token precision
+	baseScale := tenDec.Power(osmomath.NewBigDec(int64(baseDenomMetadata.Precision)))
+	quoteScale := tenDec.Power(osmomath.NewBigDec(int64(quoteDenomMetadata.Precision)))
+
+	// Calculate scale factor between quote and base
+	return quoteScale.Quo(baseScale), nil
 }
 
 // UpdateAssetsAtHeightIntervalSync updates assets at configured height interval.

--- a/tokens/usecase/tokens_usecase_test.go
+++ b/tokens/usecase/tokens_usecase_test.go
@@ -187,7 +187,6 @@ func (s *TokensUseCaseTestSuite) TestGetPrices_Coingecko() {
 // Additionally, for sanity check it confirms that for WBTC / USDC the price is within 15% of 50K
 // (approximately the real price at the time of writing)
 func (s *TokensUseCaseTestSuite) TestGetPrices_Chain() {
-
 	// Set up mainnet mock state.
 	mainnetUsecase := s.SetupDefaultRouterAndPoolsUsecase()
 
@@ -254,7 +253,6 @@ func (s *TokensUseCaseTestSuite) TestGetPrices_Chain_Specific() {
 // Currently, only tests recompute pricing options. In the future, we also add pricing options for the source,
 // once more sources are supported.
 func (s *TokensUseCaseTestSuite) TestGetPrices_Chain_PricingOptions() {
-
 	var (
 		defaultBase  = ATOM
 		defaultQuote = USDC
@@ -329,7 +327,6 @@ func (s *TokensUseCaseTestSuite) TestGetPrices_Chain_PricingOptions() {
 	for _, tt := range tests {
 		tt := tt
 		s.Run(tt.name, func() {
-
 			// Initialize pricing cache.
 			pricingCache := cache.New()
 
@@ -369,7 +366,6 @@ func (s *TokensUseCaseTestSuite) TestGetPrices_Chain_PricingOptions() {
 // Additionally, it valides that for the getter with multiple chain denoms, if the requested chain denom metadata is not present, it is nullified without erroring.
 // it will be nullified without error.
 func (s *TokensUseCaseTestSuite) TestPoolDenomMetadata() {
-
 	var (
 		xAmount       = osmomath.NewInt(1000)
 		doubleXAmount = xAmount.Add(xAmount)
@@ -927,6 +923,128 @@ func (s *TokensUseCaseTestSuite) TestUpdateAssetsAtHeightIntervalSync() {
 				callCount = tt.loader.CallCount() // panics for nil loader  test
 			}
 			s.Assert().Equal(tt.expectedCallCount, callCount)
+		})
+	}
+}
+
+func (s *TokensUseCaseTestSuite) TestCalcSpotPrice() {
+	tests := []struct {
+		name       string
+		baseDenom  string
+		quoteDenom string
+		setupMock  func(*tokensusecase.TokensUseCase, *mocks.TokensUsecaseMock)
+		expected   osmomath.BigDec
+		expectErr  bool
+	}{
+		{
+			name:       "Successful calculation",
+			baseDenom:  "uatom",
+			quoteDenom: "uosmo",
+			setupMock: func(uc *tokensusecase.TokensUseCase, m *mocks.TokensUsecaseMock) {
+				uc.SetTokenMetadataByChainDenom("uatom", domain.Token{Precision: 6})
+				uc.SetTokenMetadataByChainDenom("uosmo", domain.Token{Precision: 6})
+
+				m.GetPricesFunc = func(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error) {
+					result := make(domain.PricesResult)
+					if baseDenoms[0] == "uatom" {
+						result["uatom"] = map[string]osmomath.BigDec{"usd": osmomath.NewBigDec(10)}
+					} else if baseDenoms[0] == "uosmo" {
+						result["uosmo"] = map[string]osmomath.BigDec{"usd": osmomath.NewBigDec(2)}
+					}
+					return result, nil
+				}
+				m.CalcScalingFactorFunc = func(baseDenom, quoteDenom string) (osmomath.BigDec, error) {
+					return osmomath.NewBigDec(1), nil
+				}
+			},
+			expected:  osmomath.NewBigDec(5), // 10 / 2 = 5
+			expectErr: false,
+		},
+		{
+			name:       "Error getting base price",
+			baseDenom:  "uatom",
+			quoteDenom: "uosmo",
+			setupMock: func(uc *tokensusecase.TokensUseCase, m *mocks.TokensUsecaseMock) {
+				m.GetPricesFunc = func(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error) {
+					if baseDenoms[0] == "uatom" {
+						return nil, fmt.Errorf("error getting base price")
+					}
+					return make(domain.PricesResult), nil
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name:       "Error getting quote price",
+			baseDenom:  "uatom",
+			quoteDenom: "uosmo",
+			setupMock: func(uc *tokensusecase.TokensUseCase, m *mocks.TokensUsecaseMock) {
+				m.GetPricesFunc = func(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error) {
+					if baseDenoms[0] == "uosmo" {
+						return nil, fmt.Errorf("error getting quote price")
+					}
+					result := make(domain.PricesResult)
+					result["uatom"] = map[string]osmomath.BigDec{"usd": osmomath.NewBigDec(10)}
+					return result, nil
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name:       "Zero quote price",
+			baseDenom:  "uatom",
+			quoteDenom: "uosmo",
+			setupMock: func(uc *tokensusecase.TokensUseCase, m *mocks.TokensUsecaseMock) {
+				m.GetPricesFunc = func(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error) {
+					result := make(domain.PricesResult)
+					if baseDenoms[0] == "uatom" {
+						result["uatom"] = map[string]osmomath.BigDec{"usd": osmomath.NewBigDec(10)}
+					} else if baseDenoms[0] == "uosmo" {
+						result["uosmo"] = map[string]osmomath.BigDec{"usd": osmomath.NewBigDec(0)}
+					}
+					return result, nil
+				}
+			},
+			expectErr: true,
+		},
+		{
+			name:       "Error calculating scaling factor",
+			baseDenom:  "uatom",
+			quoteDenom: "uosmo",
+			setupMock: func(uc *tokensusecase.TokensUseCase, m *mocks.TokensUsecaseMock) {
+				m.GetPricesFunc = func(ctx context.Context, baseDenoms []string, quoteDenoms []string, pricingSourceType domain.PricingSourceType, opts ...domain.PricingOption) (domain.PricesResult, error) {
+					result := make(domain.PricesResult)
+					if baseDenoms[0] == "uatom" {
+						result["uatom"] = map[string]osmomath.BigDec{"usd": osmomath.NewBigDec(10)}
+					} else if baseDenoms[0] == "uosmo" {
+						result["uosmo"] = map[string]osmomath.BigDec{"usd": osmomath.NewBigDec(2)}
+					}
+					return result, nil
+				}
+				m.CalcScalingFactorFunc = func(baseDenom, quoteDenom string) (osmomath.BigDec, error) {
+					return osmomath.BigDec{}, fmt.Errorf("error calculating scaling factor")
+				}
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			mock := &mocks.TokensUsecaseMock{}
+			uc := &tokensusecase.TokensUseCase{}
+			tt.setupMock(uc, mock)
+
+			uc.SetDefaultQuoteDenom("usd")
+			uc.SetTokensPriceFetcher(mock)
+
+			result, err := uc.CalcSpotPrice(context.Background(), tt.baseDenom, tt.quoteDenom)
+			if tt.expectErr {
+				s.Assert().Error(err)
+			} else {
+				s.Assert().NoError(err)
+				s.Assert().True(result.Equal(tt.expected), "Expected %s, got %s", tt.expected.String(), result.String())
+			}
 		})
 	}
 }


### PR DESCRIPTION
Shallow orderbooks may compute spot price incorrectly leading to not accurate price impact.

This change introduces a fall back of spot price calculation for orderbooks based on on-chain pricing that would better reflect actual spot price across all on-chain orderbooks.

--

Most relevant parts in this PR are:

- [CalcSpotPrice](https://github.com/osmosis-labs/sqs/pull/646/files#diff-51d5472061b431279903d0c15b438868616e311e8971426185378b5e7d53dd60R384) in the tokens usecase implementing spot price calculation based on global on-chain pricing
- Actual fallback to above `CalcSpotPrice` in [PrepareResultPoolsOutGivenIn](https://github.com/osmosis-labs/sqs/pull/646/files#diff-abc7b7210fc55db67d247135049783d3a5c9ae353589484ae05dda6eff73ce79R69) of `RouteImpl`.

All other changes are ripple effect. :/ 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced spot price calculation between token denominations, enabling more accurate pricing across pools.
  - Added support for setting and using a default quote denomination in pricing calculations.
  - Added a standardized interface for fetching token prices from various sources.

- **Bug Fixes**
  - Improved error handling for missing or zero-value prices during spot price computation.

- **Refactor**
  - Updated interfaces and method signatures to include spot price calculator parameters, enhancing flexibility.
  - Adjusted internal logic to delegate spot price calculations based on pool type.
  - Simplified interface embedding and method naming for clarity and consistency.

- **Tests**
  - Enhanced mock implementations to support new spot price calculation features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->