### PR TITLE
BE-729 | Disable route cache by default

### DIFF
--- a/domain/config.go
+++ b/domain/config.go
@@ -111,7 +111,7 @@ var DefaultConfig = Config{
 		MaxRoutes:                        20,
 		MaxSplitRoutes:                   3,
 		MinPoolLiquidityCap:              0,
-		RouteCacheEnabled:                true,
+		RouteCacheEnabled:                false,
 		CandidateRouteCacheExpirySeconds: 1200,
 		RankedRouteCacheExpirySeconds:    45,
 		DynamicMinLiquidityCapFiltersDesc: []DynamicMinLiquidityCapFilterEntry{


### PR DESCRIPTION
Disable route cache by default as it is now disabled on production environment. Leaving it enabled causes some confusion as it produces different computations comparing with production and might lead frustration and additional spent time figuring out why is that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default setting for route caching to be disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->