### PR TITLE
BE-730 | golangci-lint use toolchain of current go.mod version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ export OSTYPE := $(shell uname -s)
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 GO_VERSION := $(shell cat go.mod | grep -E 'go [0-9].[0-9]+' | cut -d ' ' -f 2)
+GOTOOLCHAIN := go$(GO_VERSION)
 PACKAGES_UNIT=$(shell go list ./...)
 DOCKER := $(shell which docker)
 BUILDDIR ?= $(CURDIR)/build
@@ -58,7 +59,7 @@ all-start: osmosis-start run
 
 lint:
 	@echo "--> Running linter"
-	golangci-lint run --timeout=10m
+	GOTOOLCHAIN=$(GOTOOLCHAIN) golangci-lint run --timeout=10m
 
 test-unit:
 	@VERSION=$(VERSION) go test -mod=readonly $(PACKAGES_UNIT)


### PR DESCRIPTION
Older versions of golangci-lint has some memory leaks when running with newer Go versions leading consuming all available RAM and crashing, [context](https://github.com/golangci/golangci-lint/pull/5695).

This PR forces to use same Go version for `golangci-lint` as in the module ( go.mod ).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal build process to use a specific Go toolchain version when running code linting tasks. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->