### PR TITLE
BE-719 | Fix race conditions for PoolWrapper

### DIFF
--- a/domain/candidate_routes.go
+++ b/domain/candidate_routes.go
@@ -2,8 +2,10 @@ package domain
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/osmosis-labs/sqs/domain/osmomath"
+	sqsatomic "github.com/osmosis-labs/sqs/domain/sync/atomic"
 	ingesttypes "github.com/osmosis-labs/sqs/ingest/types"
 
 	osmoingesttypes "github.com/osmosis-labs/osmosis/v28/ingest/types"
@@ -86,7 +88,7 @@ type CandidateRouteSearcher interface {
 type CandidatePoolWrapper struct {
 	ID                uint64
 	PoolDenoms        []string
-	PoolLiquidityCap  uint64 // Note: the value is truncated if it is larger than uint64
+	PoolLiquidityCap  *atomic.Uint64 // Note: the value is truncated if it is larger than uint64
 	Balances          sdk.Coins
 	IsAlloyTransmuter bool
 	IsOrderbook       bool
@@ -96,11 +98,19 @@ func NewCandidatePoolWrapper(id uint64, p osmoingesttypes.SQSPool) CandidatePool
 	return CandidatePoolWrapper{
 		ID:                id,
 		PoolDenoms:        p.PoolDenoms,
-		PoolLiquidityCap:  osmomath.SafeUint64(p.PoolLiquidityCap),
+		PoolLiquidityCap:  sqsatomic.NewUint64(osmomath.SafeUint64(p.PoolLiquidityCap)),
 		Balances:          p.Balances,
 		IsAlloyTransmuter: p.CosmWasmPoolModel != nil && p.CosmWasmPoolModel.IsAlloyTransmuter(),
 		IsOrderbook:       p.CosmWasmPoolModel != nil && p.CosmWasmPoolModel.IsOrderbook(),
 	}
+}
+
+func (c CandidatePoolWrapper) SetPoolLiquidityCap(liquidityCap uint64) {
+	c.PoolLiquidityCap.Store(liquidityCap)
+}
+
+func (c CandidatePoolWrapper) GetPoolLiquidityCap() uint64 {
+	return c.PoolLiquidityCap.Load()
 }
 
 type CandidateRouteDenomData struct {

--- a/domain/candidate_routes_test.go
+++ b/domain/candidate_routes_test.go
@@ -22,16 +22,16 @@ func TestCandidateRouteSearchOptions_ShouldSkipPool(t *testing.T) {
 		defaultPoolID = uint64(1)
 	)
 
+	defaultNonOrderBookPool := ingesttypes.PoolWrapper{}
+	defaultNonOrderBookPool.SetUnderlyingPool(&mocks.ChainPoolMock{
+		ID: defaultPoolID,
+	})
+
 	var (
-		defaultNonOrderBookPool = ingesttypes.PoolWrapper{
-			ChainModel: &mocks.ChainPoolMock{
-				ID: defaultPoolID,
-			},
-		}
 
 		// instruments the given pool with orderbook data, returning new copy.
 		withOrderBookPool = func(pool ingesttypes.PoolWrapper) ingesttypes.PoolWrapper {
-			pool.SQSModel = ingesttypes.SQSPool{
+			pool.SetSQSPoolModel(ingesttypes.SQSPool{
 				CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
 					ContractInfo: cosmwasmpool.ContractInfo{
 						Contract: cosmwasmpool.ORDERBOOK_CONTRACT_NAME,
@@ -41,15 +41,15 @@ func TestCandidateRouteSearchOptions_ShouldSkipPool(t *testing.T) {
 						Orderbook: &cosmwasmpool.OrderbookData{},
 					},
 				},
-			}
+			})
 			return pool
 		}
 
 		// instruments the given pool with a new id returning new copy
 		withPoolID = func(pool ingesttypes.PoolWrapper, newPoolID uint64) ingesttypes.PoolWrapper {
-			pool.ChainModel = &mocks.ChainPoolMock{
+			pool.SetUnderlyingPool(&mocks.ChainPoolMock{
 				ID: newPoolID,
-			}
+			})
 			return pool
 		}
 

--- a/domain/sync/atomic/cow.go
+++ b/domain/sync/atomic/cow.go
@@ -6,26 +6,26 @@ import (
 	"sync/atomic"
 )
 
-// AtomicCopyOnWrite is a concurrency-safe utility that allows
+// CopyOnWrite is a concurrency-safe utility that allows
 // atomic reads and synchronized writes. Reads are lock-free
 // and fast, while writes are protected by a mutex to ensure
 // copy-on-write safety.
-type AtomicCopyOnWrite[T any] struct {
+type CopyOnWrite[T any] struct {
 	v  atomic.Value
 	mu sync.Mutex
 }
 
 // NewAtomicCopyOnWrite returns a new instance of AtomicCopyOnWrite.
 // Writes are serialized via a mutex, while reads are atomic and lock-free.
-func NewAtomicCopyOnWrite[T any]() *AtomicCopyOnWrite[T] {
-	return &AtomicCopyOnWrite[T]{
+func NewAtomicCopyOnWrite[T any]() *CopyOnWrite[T] {
+	return &CopyOnWrite[T]{
 		mu: sync.Mutex{},
 	}
 }
 
 // Store sets the value atomically. It acquires a lock to ensure
 // write consistency, making this safe for concurrent use with Load.
-func (c *AtomicCopyOnWrite[T]) Store(v T) {
+func (c *CopyOnWrite[T]) Store(v T) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.v.Store(v)
@@ -33,7 +33,7 @@ func (c *AtomicCopyOnWrite[T]) Store(v T) {
 
 // Load returns the most recent value atomically. If no value
 // has been stored yet, it returns the zero value of T.
-func (c *AtomicCopyOnWrite[T]) Load() T {
+func (c *CopyOnWrite[T]) Load() T {
 	v, ok := c.v.Load().(T)
 	if !ok {
 		return *new(T)

--- a/domain/sync/atomic/cow.go
+++ b/domain/sync/atomic/cow.go
@@ -1,0 +1,43 @@
+// Package atomic provides concurrency-safe types and utilities.
+package atomic
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// AtomicCopyOnWrite is a concurrency-safe utility that allows
+// atomic reads and synchronized writes. Reads are lock-free
+// and fast, while writes are protected by a mutex to ensure
+// copy-on-write safety.
+type AtomicCopyOnWrite[T any] struct {
+	v  atomic.Value
+	mu sync.Mutex
+}
+
+// NewAtomicCopyOnWrite returns a new instance of AtomicCopyOnWrite.
+// Writes are serialized via a mutex, while reads are atomic and lock-free.
+func NewAtomicCopyOnWrite[T any]() *AtomicCopyOnWrite[T] {
+	return &AtomicCopyOnWrite[T]{
+		mu: sync.Mutex{},
+	}
+}
+
+// Store sets the value atomically. It acquires a lock to ensure
+// write consistency, making this safe for concurrent use with Load.
+func (c *AtomicCopyOnWrite[T]) Store(v T) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.v.Store(v)
+}
+
+// Load returns the most recent value atomically. If no value
+// has been stored yet, it returns the zero value of T.
+func (c *AtomicCopyOnWrite[T]) Load() T {
+	v, ok := c.v.Load().(T)
+	if !ok {
+		return *new(T)
+	}
+
+	return v
+}

--- a/domain/sync/atomic/cow_test.go
+++ b/domain/sync/atomic/cow_test.go
@@ -1,0 +1,100 @@
+package atomic
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestAtomicCopyOnWrite(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       func(*AtomicCopyOnWrite[int])
+		expected int
+	}{
+		{
+			name: "Store and Load single value",
+			op: func(cow *AtomicCopyOnWrite[int]) {
+				cow.Store(42)
+			},
+			expected: 42,
+		},
+		{
+			name: "Store and Load multiple values",
+			op: func(cow *AtomicCopyOnWrite[int]) {
+				cow.Store(1)
+				cow.Store(2)
+				cow.Store(3)
+			},
+			expected: 3,
+		},
+		{
+			name:     "Load without Store",
+			op:       func(cow *AtomicCopyOnWrite[int]) {},
+			expected: 0,
+		},
+		{
+			name: "Concurrent Store and Load",
+			op: func(cow *AtomicCopyOnWrite[int]) {
+				var wg sync.WaitGroup
+				for i := range 100 {
+					wg.Add(2)
+					go func(v int) {
+						defer wg.Done()
+						cow.Store(v)
+					}(i)
+
+					go func() {
+						defer wg.Done()
+						_ = cow.Load()
+					}()
+				}
+
+				wg.Wait()
+			},
+			expected: -1, // final value is indeterminate due to concurrent writes
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cow := NewAtomicCopyOnWrite[int]()
+			tt.op(cow)
+			result := cow.Load()
+			if result != tt.expected && tt.expected != -1 {
+				t.Errorf("Expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestConcurrentOperations(t *testing.T) {
+	cow := NewAtomicCopyOnWrite[int]()
+	var wg sync.WaitGroup
+	iterations := 1000
+
+	// Concurrent writes
+	for i := range iterations {
+		wg.Add(1)
+		go func(v int) {
+			defer wg.Done()
+			cow.Store(v)
+		}(i)
+	}
+
+	// Concurrent reads
+	for range iterations {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = cow.Load()
+		}()
+	}
+
+	wg.Wait()
+
+	// Final value should be in the range [0, iterations-1]
+	finalValue := cow.Load()
+	if finalValue < 0 || finalValue >= iterations {
+		t.Errorf("Unexpected final value: %d", finalValue)
+	}
+}

--- a/domain/sync/atomic/cow_test.go
+++ b/domain/sync/atomic/cow_test.go
@@ -8,19 +8,19 @@ import (
 func TestAtomicCopyOnWrite(t *testing.T) {
 	tests := []struct {
 		name     string
-		op       func(*AtomicCopyOnWrite[int])
+		op       func(*CopyOnWrite[int])
 		expected int
 	}{
 		{
 			name: "Store and Load single value",
-			op: func(cow *AtomicCopyOnWrite[int]) {
+			op: func(cow *CopyOnWrite[int]) {
 				cow.Store(42)
 			},
 			expected: 42,
 		},
 		{
 			name: "Store and Load multiple values",
-			op: func(cow *AtomicCopyOnWrite[int]) {
+			op: func(cow *CopyOnWrite[int]) {
 				cow.Store(1)
 				cow.Store(2)
 				cow.Store(3)
@@ -29,12 +29,12 @@ func TestAtomicCopyOnWrite(t *testing.T) {
 		},
 		{
 			name:     "Load without Store",
-			op:       func(cow *AtomicCopyOnWrite[int]) {},
+			op:       func(cow *CopyOnWrite[int]) {},
 			expected: 0,
 		},
 		{
 			name: "Concurrent Store and Load",
-			op: func(cow *AtomicCopyOnWrite[int]) {
+			op: func(cow *CopyOnWrite[int]) {
 				var wg sync.WaitGroup
 				for i := range 100 {
 					wg.Add(2)

--- a/domain/sync/atomic/int.go
+++ b/domain/sync/atomic/int.go
@@ -1,0 +1,18 @@
+package atomic
+
+import "sync/atomic"
+
+// Uint64 returns a pointer to an atomic.Uint64 initialized with the given value.
+//
+// This is a convenience function that simplifies the creation and initialization
+// of atomic.Uint64 values. It uses Store to set the value.
+//
+// Example:
+//
+//	counter := Uint64(42)
+//	fmt.Println(counter.Load()) // Output: 42
+func NewUint64(i uint64) *atomic.Uint64 {
+	v := &atomic.Uint64{}
+	v.Store(i)
+	return v
+}

--- a/domain/sync/atomic/int_test.go
+++ b/domain/sync/atomic/int_test.go
@@ -1,0 +1,67 @@
+package atomic
+
+import (
+	"math"
+	"sync"
+	"testing"
+)
+
+func TestNewUint64(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    uint64
+		expected uint64
+	}{
+		{
+			name:     "Zero value",
+			input:    0,
+			expected: 0,
+		},
+		{
+			name:     "Positive value",
+			input:    42,
+			expected: 42,
+		},
+		{
+			name:     "Large value",
+			input:    math.MaxUint64,
+			expected: math.MaxUint64,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewUint64(tt.input)
+			if result.Load() != tt.expected {
+				t.Errorf("NewUint64(%d) = %d; want %d", tt.input, result.Load(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewUint64Concurrent(t *testing.T) {
+	const (
+		goroutines = 100
+		iterations = 1000
+	)
+
+	var wg sync.WaitGroup
+	counter := NewUint64(0)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				counter.Add(1)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	expected := uint64(goroutines * iterations)
+	if counter.Load() != expected {
+		t.Errorf("Concurrent increments: got %d, want %d", counter.Load(), expected)
+	}
+}

--- a/ingest/types/pools_test.go
+++ b/ingest/types/pools_test.go
@@ -82,9 +82,8 @@ func TestPoolWrapper_Incentive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pool := &PoolWrapper{
-				APRData: tt.aprData,
-			}
+			pool := &PoolWrapper{}
+			pool.SetAPRData(tt.aprData)
 			assert.Equal(t, tt.expected, pool.Incentive())
 		})
 	}

--- a/ingest/types/types.go
+++ b/ingest/types/types.go
@@ -72,12 +72,14 @@ type PoolI interface {
 var _ PoolI = &PoolWrapper{}
 
 type PoolWrapper struct {
-	ChainModel  poolmanagertypes.PoolI                   `json:"underlying_pool"`
-	SQSModel    ingesttypes.SQSPool                      `json:"sqs_model"`
-	APRData     passthroughdomain.PoolAPRDataStatusWrap  `json:"apr_data,omitempty"`
-	FeesData    passthroughdomain.PoolFeesDataStatusWrap `json:"fees_data,omitempty"`
-	TickModel   atomic.Value                             `json:"tick_model,omitempty"` // TODO: json
-	tickModelMu sync.Mutex                               `json:"-"`
+	ChainModel  poolmanagertypes.PoolI
+	SQSModel    ingesttypes.SQSPool
+	aprData     atomic.Value
+	aprDataMu   sync.Mutex
+	feesData    atomic.Value
+	feesDataMu  sync.Mutex
+	tickModel   atomic.Value
+	tickModelMu sync.Mutex
 }
 
 func NewPool(model poolmanagertypes.PoolI, spreadFactor osmomath.Dec, balances sdk.Coins) *PoolWrapper {
@@ -128,12 +130,12 @@ func (p *PoolWrapper) GetTickModel() (*TickModel, error) {
 		return nil, fmt.Errorf("pool (%d) is not a concentrated pool, type (%d)", p.GetId(), p.GetType())
 	}
 
-	m, ok := p.TickModel.Load().(*TickModel)
-	if m == nil || !ok {
+	tickModel, ok := p.tickModel.Load().(*TickModel)
+	if tickModel == nil || !ok {
 		return nil, ingesttypes.ConcentratedPoolNoTickModelError{PoolId: p.GetId()}
 	}
 
-	return m, nil
+	return tickModel, nil
 }
 
 // Incentive implements PoolI.
@@ -163,7 +165,7 @@ func (p *PoolWrapper) SetTickModel(tickModel *TickModel) error {
 	p.tickModelMu.Lock() // sync with the writers
 	defer p.tickModelMu.Unlock()
 
-	p.TickModel.Store(tickModel)
+	p.tickModel.Store(tickModel)
 
 	return nil
 }
@@ -211,20 +213,36 @@ func (p *PoolWrapper) SetLiquidityCapError(liquidityCapError string) {
 
 // SetAPRData implements PoolI.
 func (p *PoolWrapper) SetAPRData(aprData passthroughdomain.PoolAPRDataStatusWrap) {
-	p.APRData = aprData
+	p.aprDataMu.Lock() // sync with the writers
+	defer p.aprDataMu.Unlock()
+
+	p.aprData.Store(aprData)
 }
 
 // SetFeesData implements PoolI.
 func (p *PoolWrapper) SetFeesData(feesData passthroughdomain.PoolFeesDataStatusWrap) {
-	p.FeesData = feesData
+	p.feesDataMu.Lock() // sync with the writers
+	defer p.feesDataMu.Unlock()
+
+	p.feesData.Store(feesData)
 }
 
 // GetAPRData implements PoolI.
 func (p *PoolWrapper) GetAPRData() passthroughdomain.PoolAPRDataStatusWrap {
-	return p.APRData
+	aprData, ok := p.aprData.Load().(passthroughdomain.PoolAPRDataStatusWrap)
+	if !ok {
+		return passthroughdomain.PoolAPRDataStatusWrap{}
+	}
+
+	return aprData
 }
 
 // GetFeesData implements PoolI.
 func (p *PoolWrapper) GetFeesData() passthroughdomain.PoolFeesDataStatusWrap {
-	return p.FeesData
+	feesData, ok := p.feesData.Load().(passthroughdomain.PoolFeesDataStatusWrap)
+	if !ok {
+		return passthroughdomain.PoolFeesDataStatusWrap{}
+	}
+
+	return feesData
 }

--- a/ingest/types/types.go
+++ b/ingest/types/types.go
@@ -4,10 +4,9 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
-	"sync/atomic"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/osmosis-labs/sqs/domain/sync/atomic"
 	api "github.com/osmosis-labs/sqs/pkg/api/v1beta1/pools"
 
 	ingesttypes "github.com/osmosis-labs/osmosis/v28/ingest/types"
@@ -15,7 +14,6 @@ import (
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v28/x/poolmanager/types"
 
 	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 type (
@@ -72,25 +70,18 @@ type PoolI interface {
 var _ PoolI = &PoolWrapper{}
 
 type PoolWrapper struct {
-	chainModel   atomic.Value
-	chainModelMu sync.Mutex
-	sqsModel     atomic.Value
-	sqsModelMu   sync.Mutex
-	aprData      atomic.Value
-	aprDataMu    sync.Mutex
-	feesData     atomic.Value
-	feesDataMu   sync.Mutex
-	tickModel    atomic.Value
-	tickModelMu  sync.Mutex
+	chainModel atomic.AtomicCopyOnWrite[poolmanagertypes.PoolI]
+	sqsModel   atomic.AtomicCopyOnWrite[SQSPool]
+	aprData    atomic.AtomicCopyOnWrite[passthroughdomain.PoolAPRDataStatusWrap]
+	feesData   atomic.AtomicCopyOnWrite[passthroughdomain.PoolFeesDataStatusWrap]
+	tickModel  atomic.AtomicCopyOnWrite[*TickModel]
 }
 
-func NewPool(model poolmanagertypes.PoolI, spreadFactor osmomath.Dec, balances sdk.Coins) *PoolWrapper {
+func NewPool(chainModel poolmanagertypes.PoolI, sqsModel SQSPool) *PoolWrapper {
 	pool := &PoolWrapper{}
-	pool.SetUnderlyingPool(model)
-	pool.SetSQSPoolModel(SQSPool{
-		SpreadFactor: spreadFactor,
-		Balances:     balances,
-	})
+
+	pool.SetUnderlyingPool(chainModel)
+	pool.SetSQSPoolModel(sqsModel)
 
 	return pool
 }
@@ -119,28 +110,22 @@ func (p *PoolWrapper) GetPoolDenoms() []string {
 
 // GetUnderlyingPool implements PoolI.
 func (p *PoolWrapper) SetUnderlyingPool(model poolmanagertypes.PoolI) {
-	p.chainModelMu.Lock() // sync with the writers
-	defer p.chainModelMu.Unlock()
-
 	p.chainModel.Store(model)
 }
 
 // GetUnderlyingPool implements PoolI.
 func (p *PoolWrapper) GetUnderlyingPool() poolmanagertypes.PoolI {
-	return p.chainModel.Load().(poolmanagertypes.PoolI)
+	return p.chainModel.Load()
 }
 
 // GetSQSPoolModel implements PoolI.
 func (p *PoolWrapper) SetSQSPoolModel(model SQSPool) {
-	p.sqsModelMu.Lock() // sync with the writers
-	defer p.sqsModelMu.Unlock()
-
 	p.sqsModel.Store(model)
 }
 
 // GetSQSPoolModel implements PoolI.
 func (p *PoolWrapper) GetSQSPoolModel() SQSPool {
-	return p.sqsModel.Load().(SQSPool)
+	return p.sqsModel.Load()
 }
 
 // GetTickModel implements PoolI.
@@ -149,8 +134,8 @@ func (p *PoolWrapper) GetTickModel() (*TickModel, error) {
 		return nil, fmt.Errorf("pool (%d) is not a concentrated pool, type (%d)", p.GetId(), p.GetType())
 	}
 
-	tickModel, ok := p.tickModel.Load().(*TickModel)
-	if tickModel == nil || !ok {
+	tickModel := p.tickModel.Load()
+	if tickModel == nil {
 		return nil, ingesttypes.ConcentratedPoolNoTickModelError{PoolId: p.GetId()}
 	}
 
@@ -181,9 +166,6 @@ func (p *PoolWrapper) Incentive() api.IncentiveType {
 
 // SetTickModel implements PoolI.
 func (p *PoolWrapper) SetTickModel(tickModel *TickModel) error {
-	p.tickModelMu.Lock() // sync with the writers
-	defer p.tickModelMu.Unlock()
-
 	p.tickModel.Store(tickModel)
 
 	return nil
@@ -217,9 +199,6 @@ func (p *PoolWrapper) GetLiquidityCap() osmomath.Int {
 
 // SetLiquidityCap implements PoolI.
 func (p *PoolWrapper) SetLiquidityCap(liquidityCap math.Int) {
-	p.sqsModelMu.Lock() // sync with the writers
-	defer p.sqsModelMu.Unlock()
-
 	sqsModel := p.GetSQSPoolModel()
 	sqsModel.PoolLiquidityCap = liquidityCap
 
@@ -236,44 +215,25 @@ func (p *PoolWrapper) SetLiquidityCapError(liquidityCapError string) {
 	sqsModel := p.GetSQSPoolModel()
 	sqsModel.PoolLiquidityCapError = liquidityCapError
 
-	p.sqsModelMu.Lock() // sync with the writers
-	defer p.sqsModelMu.Unlock()
-
 	p.sqsModel.Store(sqsModel)
 }
 
 // SetAPRData implements PoolI.
 func (p *PoolWrapper) SetAPRData(aprData passthroughdomain.PoolAPRDataStatusWrap) {
-	p.aprDataMu.Lock() // sync with the writers
-	defer p.aprDataMu.Unlock()
-
 	p.aprData.Store(aprData)
-}
-
-// SetFeesData implements PoolI.
-func (p *PoolWrapper) SetFeesData(feesData passthroughdomain.PoolFeesDataStatusWrap) {
-	p.feesDataMu.Lock() // sync with the writers
-	defer p.feesDataMu.Unlock()
-
-	p.feesData.Store(feesData)
 }
 
 // GetAPRData implements PoolI.
 func (p *PoolWrapper) GetAPRData() passthroughdomain.PoolAPRDataStatusWrap {
-	aprData, ok := p.aprData.Load().(passthroughdomain.PoolAPRDataStatusWrap)
-	if !ok {
-		return passthroughdomain.PoolAPRDataStatusWrap{}
-	}
+	return p.aprData.Load()
+}
 
-	return aprData
+// SetFeesData implements PoolI.
+func (p *PoolWrapper) SetFeesData(feesData passthroughdomain.PoolFeesDataStatusWrap) {
+	p.feesData.Store(feesData)
 }
 
 // GetFeesData implements PoolI.
 func (p *PoolWrapper) GetFeesData() passthroughdomain.PoolFeesDataStatusWrap {
-	feesData, ok := p.feesData.Load().(passthroughdomain.PoolFeesDataStatusWrap)
-	if !ok {
-		return passthroughdomain.PoolFeesDataStatusWrap{}
-	}
-
-	return feesData
+	return p.feesData.Load()
 }

--- a/ingest/types/types.go
+++ b/ingest/types/types.go
@@ -70,11 +70,11 @@ type PoolI interface {
 var _ PoolI = &PoolWrapper{}
 
 type PoolWrapper struct {
-	chainModel atomic.AtomicCopyOnWrite[poolmanagertypes.PoolI]
-	sqsModel   atomic.AtomicCopyOnWrite[SQSPool]
-	aprData    atomic.AtomicCopyOnWrite[passthroughdomain.PoolAPRDataStatusWrap]
-	feesData   atomic.AtomicCopyOnWrite[passthroughdomain.PoolFeesDataStatusWrap]
-	tickModel  atomic.AtomicCopyOnWrite[*TickModel]
+	chainModel atomic.CopyOnWrite[poolmanagertypes.PoolI]
+	sqsModel   atomic.CopyOnWrite[SQSPool]
+	aprData    atomic.CopyOnWrite[passthroughdomain.PoolAPRDataStatusWrap]
+	feesData   atomic.CopyOnWrite[passthroughdomain.PoolFeesDataStatusWrap]
+	tickModel  atomic.CopyOnWrite[*TickModel]
 }
 
 func NewPool(chainModel poolmanagertypes.PoolI, sqsModel SQSPool) *PoolWrapper {

--- a/ingest/types/types.go
+++ b/ingest/types/types.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	api "github.com/osmosis-labs/sqs/pkg/api/v1beta1/pools"
@@ -70,11 +72,12 @@ type PoolI interface {
 var _ PoolI = &PoolWrapper{}
 
 type PoolWrapper struct {
-	ChainModel poolmanagertypes.PoolI                   `json:"underlying_pool"`
-	SQSModel   ingesttypes.SQSPool                      `json:"sqs_model"`
-	APRData    passthroughdomain.PoolAPRDataStatusWrap  `json:"apr_data,omitempty"`
-	FeesData   passthroughdomain.PoolFeesDataStatusWrap `json:"fees_data,omitempty"`
-	TickModel  *ingesttypes.TickModel                   `json:"tick_model,omitempty"`
+	ChainModel  poolmanagertypes.PoolI                   `json:"underlying_pool"`
+	SQSModel    ingesttypes.SQSPool                      `json:"sqs_model"`
+	APRData     passthroughdomain.PoolAPRDataStatusWrap  `json:"apr_data,omitempty"`
+	FeesData    passthroughdomain.PoolFeesDataStatusWrap `json:"fees_data,omitempty"`
+	TickModel   atomic.Value                             `json:"tick_model,omitempty"` // TODO: json
+	tickModelMu sync.Mutex                               `json:"-"`
 }
 
 func NewPool(model poolmanagertypes.PoolI, spreadFactor osmomath.Dec, balances sdk.Coins) *PoolWrapper {
@@ -125,11 +128,12 @@ func (p *PoolWrapper) GetTickModel() (*TickModel, error) {
 		return nil, fmt.Errorf("pool (%d) is not a concentrated pool, type (%d)", p.GetId(), p.GetType())
 	}
 
-	if p.TickModel == nil {
+	m, ok := p.TickModel.Load().(*TickModel)
+	if m == nil || !ok {
 		return nil, ingesttypes.ConcentratedPoolNoTickModelError{PoolId: p.GetId()}
 	}
 
-	return p.TickModel, nil
+	return m, nil
 }
 
 // Incentive implements PoolI.
@@ -156,11 +160,10 @@ func (p *PoolWrapper) Incentive() api.IncentiveType {
 
 // SetTickModel implements PoolI.
 func (p *PoolWrapper) SetTickModel(tickModel *TickModel) error {
-	if p.GetType() != poolmanagertypes.Concentrated {
-		return fmt.Errorf("pool (%d) is not a concentrated pool, type (%d)", p.GetId(), p.GetType())
-	}
+	p.tickModelMu.Lock() // sync with the writers
+	defer p.tickModelMu.Unlock()
 
-	p.TickModel = tickModel
+	p.TickModel.Store(tickModel)
 
 	return nil
 }

--- a/ingest/types/types.go
+++ b/ingest/types/types.go
@@ -72,56 +72,75 @@ type PoolI interface {
 var _ PoolI = &PoolWrapper{}
 
 type PoolWrapper struct {
-	ChainModel  poolmanagertypes.PoolI
-	SQSModel    ingesttypes.SQSPool
-	aprData     atomic.Value
-	aprDataMu   sync.Mutex
-	feesData    atomic.Value
-	feesDataMu  sync.Mutex
-	tickModel   atomic.Value
-	tickModelMu sync.Mutex
+	chainModel   atomic.Value
+	chainModelMu sync.Mutex
+	sqsModel     atomic.Value
+	sqsModelMu   sync.Mutex
+	aprData      atomic.Value
+	aprDataMu    sync.Mutex
+	feesData     atomic.Value
+	feesDataMu   sync.Mutex
+	tickModel    atomic.Value
+	tickModelMu  sync.Mutex
 }
 
 func NewPool(model poolmanagertypes.PoolI, spreadFactor osmomath.Dec, balances sdk.Coins) *PoolWrapper {
-	return &PoolWrapper{
-		ChainModel: model,
-		SQSModel: SQSPool{
-			SpreadFactor: spreadFactor,
-			Balances:     balances,
-		},
-	}
+	pool := &PoolWrapper{}
+	pool.SetUnderlyingPool(model)
+	pool.SetSQSPoolModel(SQSPool{
+		SpreadFactor: spreadFactor,
+		Balances:     balances,
+	})
+
+	return pool
 }
 
 // GetId implements PoolI.
 func (p *PoolWrapper) GetId() uint64 {
-	return p.ChainModel.GetId()
+	return p.GetUnderlyingPool().GetId()
 }
 
 // GetType implements PoolI.
 func (p *PoolWrapper) GetType() poolmanagertypes.PoolType {
-	return p.ChainModel.GetType()
+	return p.GetUnderlyingPool().GetType()
 }
 
 // GetPoolLiquidityCap implements PoolI.
 func (p *PoolWrapper) GetPoolLiquidityCap() osmomath.Int {
-	return p.SQSModel.PoolLiquidityCap
+	return p.GetSQSPoolModel().PoolLiquidityCap
 }
 
 // GetPoolDenoms implements PoolI.
 func (p *PoolWrapper) GetPoolDenoms() []string {
-	// sort pool denoms
-	sort.Strings(p.SQSModel.PoolDenoms)
-	return p.SQSModel.PoolDenoms
+	denoms := p.GetSQSPoolModel().PoolDenoms
+	sort.Strings(denoms)
+	return denoms
+}
+
+// GetUnderlyingPool implements PoolI.
+func (p *PoolWrapper) SetUnderlyingPool(model poolmanagertypes.PoolI) {
+	p.chainModelMu.Lock() // sync with the writers
+	defer p.chainModelMu.Unlock()
+
+	p.chainModel.Store(model)
 }
 
 // GetUnderlyingPool implements PoolI.
 func (p *PoolWrapper) GetUnderlyingPool() poolmanagertypes.PoolI {
-	return p.ChainModel
+	return p.chainModel.Load().(poolmanagertypes.PoolI)
+}
+
+// GetSQSPoolModel implements PoolI.
+func (p *PoolWrapper) SetSQSPoolModel(model SQSPool) {
+	p.sqsModelMu.Lock() // sync with the writers
+	defer p.sqsModelMu.Unlock()
+
+	p.sqsModel.Store(model)
 }
 
 // GetSQSPoolModel implements PoolI.
 func (p *PoolWrapper) GetSQSPoolModel() SQSPool {
-	return p.SQSModel
+	return p.sqsModel.Load().(SQSPool)
 }
 
 // GetTickModel implements PoolI.
@@ -183,7 +202,7 @@ func (p *PoolWrapper) Validate(minPoolLiquidityCapitalization osmomath.Int) erro
 	// Validate pool liquidity capitalization.
 	// If there is no pool liquidity capitalization error set and the pool liquidity capitalization is nil or zero, return an error. This implies
 	// That pool has no liquidity.
-	poolLiquidityCapError := strings.TrimSpace(p.SQSModel.PoolLiquidityCapError)
+	poolLiquidityCapError := strings.TrimSpace(p.GetSQSPoolModel().PoolLiquidityCapError)
 	if poolLiquidityCapError == "" && (sqsModel.PoolLiquidityCap.IsNil() || sqsModel.PoolLiquidityCap.IsZero()) {
 		return fmt.Errorf("pool (%d) has no liquidity, minimum pool liquidity capitalization (%s)", p.GetId(), minPoolLiquidityCapitalization)
 	}
@@ -193,22 +212,34 @@ func (p *PoolWrapper) Validate(minPoolLiquidityCapitalization osmomath.Int) erro
 
 // GetLiquidityCap implements PoolI.
 func (p *PoolWrapper) GetLiquidityCap() osmomath.Int {
-	return p.SQSModel.PoolLiquidityCap
+	return p.GetSQSPoolModel().PoolLiquidityCap
 }
 
 // SetLiquidityCap implements PoolI.
 func (p *PoolWrapper) SetLiquidityCap(liquidityCap math.Int) {
-	p.SQSModel.PoolLiquidityCap = liquidityCap
+	p.sqsModelMu.Lock() // sync with the writers
+	defer p.sqsModelMu.Unlock()
+
+	sqsModel := p.GetSQSPoolModel()
+	sqsModel.PoolLiquidityCap = liquidityCap
+
+	p.sqsModel.Store(sqsModel)
 }
 
 // GetLiquidityCapError implements PoolI.
 func (p *PoolWrapper) GetLiquidityCapError() string {
-	return p.SQSModel.PoolLiquidityCapError
+	return p.GetSQSPoolModel().PoolLiquidityCapError
 }
 
 // SetLiquidityCapError implements PoolI.
 func (p *PoolWrapper) SetLiquidityCapError(liquidityCapError string) {
-	p.SQSModel.PoolLiquidityCapError = liquidityCapError
+	sqsModel := p.GetSQSPoolModel()
+	sqsModel.PoolLiquidityCapError = liquidityCapError
+
+	p.sqsModelMu.Lock() // sync with the writers
+	defer p.sqsModelMu.Unlock()
+
+	p.sqsModel.Store(sqsModel)
 }
 
 // SetAPRData implements PoolI.

--- a/ingest/types/types.go
+++ b/ingest/types/types.go
@@ -103,7 +103,9 @@ func (p *PoolWrapper) GetPoolLiquidityCap() osmomath.Int {
 
 // GetPoolDenoms implements PoolI.
 func (p *PoolWrapper) GetPoolDenoms() []string {
-	denoms := p.GetSQSPoolModel().PoolDenoms
+	denoms := make([]string, len(p.GetSQSPoolModel().PoolDenoms))
+	copy(denoms, p.GetSQSPoolModel().PoolDenoms)
+
 	sort.Strings(denoms)
 	return denoms
 }

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -452,14 +452,11 @@ func transferDenomLiquidityMap(transferTo, transferFrom domain.DenomPoolLiquidit
 // For concentrated pools, it also processes the tick model
 func (p *ingestUseCase) parsePool(pool *types.PoolData) (sqsingesttypes.PoolI, error) {
 	poolWrapper := sqsingesttypes.PoolWrapper{}
-
-	if err := p.codec.UnmarshalInterfaceJSON(pool.ChainModel, &poolWrapper.ChainModel); err != nil {
+	var chainModel poolmanagertypes.PoolI
+	if err := p.codec.UnmarshalInterfaceJSON(pool.ChainModel, &chainModel); err != nil {
 		return nil, err
 	}
-
-	if err := json.Unmarshal(pool.SqsModel, &poolWrapper.SQSModel); err != nil {
-		return nil, err
-	}
+	poolWrapper.SetUnderlyingPool(chainModel)
 
 	if poolWrapper.GetType() == poolmanagertypes.Concentrated {
 		var tickModel ingesttypes.TickModel
@@ -471,10 +468,17 @@ func (p *ingestUseCase) parsePool(pool *types.PoolData) (sqsingesttypes.PoolI, e
 		}
 	}
 
+	var sqsModel ingesttypes.SQSPool
+	if err := json.Unmarshal(pool.SqsModel, &sqsModel); err != nil {
+		return nil, err
+	}
+
 	// Process the SQS model
-	if err := processSQSModelMut(&poolWrapper.SQSModel); err != nil {
+	if err := processSQSModelMut(&sqsModel); err != nil {
 		p.logger.Error("error processing SQS model", zap.Error(err))
 	}
+
+	poolWrapper.SetSQSPoolModel(sqsModel)
 
 	return &poolWrapper, nil
 }

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -451,21 +451,9 @@ func transferDenomLiquidityMap(transferTo, transferFrom domain.DenomPoolLiquidit
 // parsePool parses the pool data and returns the pool object
 // For concentrated pools, it also processes the tick model
 func (p *ingestUseCase) parsePool(pool *types.PoolData) (sqsingesttypes.PoolI, error) {
-	poolWrapper := sqsingesttypes.PoolWrapper{}
 	var chainModel poolmanagertypes.PoolI
 	if err := p.codec.UnmarshalInterfaceJSON(pool.ChainModel, &chainModel); err != nil {
 		return nil, err
-	}
-	poolWrapper.SetUnderlyingPool(chainModel)
-
-	if poolWrapper.GetType() == poolmanagertypes.Concentrated {
-		var tickModel ingesttypes.TickModel
-		if err := json.Unmarshal(pool.TickModel, &tickModel); err != nil {
-			return nil, err
-		}
-		if err := poolWrapper.SetTickModel(&tickModel); err != nil {
-			return nil, err
-		}
 	}
 
 	var sqsModel ingesttypes.SQSPool
@@ -478,9 +466,18 @@ func (p *ingestUseCase) parsePool(pool *types.PoolData) (sqsingesttypes.PoolI, e
 		p.logger.Error("error processing SQS model", zap.Error(err))
 	}
 
-	poolWrapper.SetSQSPoolModel(sqsModel)
+	poolWrapper := sqsingesttypes.NewPool(chainModel, sqsModel)
+	if poolWrapper.GetType() == poolmanagertypes.Concentrated {
+		var tickModel ingesttypes.TickModel
+		if err := json.Unmarshal(pool.TickModel, &tickModel); err != nil {
+			return nil, err
+		}
+		if err := poolWrapper.SetTickModel(&tickModel); err != nil {
+			return nil, err
+		}
+	}
 
-	return &poolWrapper, nil
+	return poolWrapper, nil
 }
 
 // executeEndBlockProcessPlugins executes the end block process plugins.

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -79,13 +79,9 @@ const (
 	tracerName = "sqs-ingest-usecase"
 )
 
-var (
-	tracer = otel.Tracer(tracerName)
-)
+var tracer = otel.Tracer(tracerName)
 
-var (
-	_ mvc.IngestUsecase = &ingestUseCase{}
-)
+var _ mvc.IngestUsecase = &ingestUseCase{}
 
 // NewIngestUsecase will create a new pools use case object
 func NewIngestUsecase(poolsUseCase mvc.PoolsUsecase, routerUseCase mvc.RouterUsecase, pricingRouterUsecase mvc.RouterUsecase, tokensUseCase mvc.TokensUsecase, chainInfoUseCase mvc.ChainInfoUsecase, codec codec.Codec, quotePriceUpdateWorker domain.PricingWorker, candidateRouteSearchWorker domain.CandidateRouteSearchDataWorker, orderBookUseCase mvc.OrderBookUsecase, logger log.Logger) (mvc.IngestUsecase, error) {
@@ -466,8 +462,11 @@ func (p *ingestUseCase) parsePool(pool *types.PoolData) (sqsingesttypes.PoolI, e
 	}
 
 	if poolWrapper.GetType() == poolmanagertypes.Concentrated {
-		poolWrapper.TickModel = &ingesttypes.TickModel{}
-		if err := json.Unmarshal(pool.TickModel, poolWrapper.TickModel); err != nil {
+		var tickModel ingesttypes.TickModel
+		if err := json.Unmarshal(pool.TickModel, &tickModel); err != nil {
+			return nil, err
+		}
+		if err := poolWrapper.SetTickModel(&tickModel); err != nil {
 			return nil, err
 		}
 	}

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -230,7 +230,12 @@ func (p *poolsUseCase) GetTickModelMap(poolIDs []uint64) (map[uint64]*ingesttype
 			}
 		}
 
-		tickModelMap[poolID] = poolWrapper.TickModel
+		tickModel, err := poolWrapper.GetTickModel()
+		if err != nil {
+			tickModel = nil
+		}
+
+		tickModelMap[poolID] = tickModel
 	}
 
 	return tickModelMap, nil

--- a/pools/usecase/pools_usecase_test.go
+++ b/pools/usecase/pools_usecase_test.go
@@ -82,7 +82,6 @@ func TestPoolsUsecaseTestSuite(t *testing.T) {
 // - taker fee is correctly set.
 // - token out denom is correctly set.
 func (s *PoolsUsecaseTestSuite) TestGetRoutesFromCandidates() {
-
 	s.Setup()
 
 	// Setup default chain pool
@@ -350,7 +349,6 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 	for _, tc := range testCases {
 		tc := tc
 		s.Run(tc.name, func() {
-
 			poolsUsecase := s.newDefaultPoolsUseCase()
 
 			// Pre-set invalid data for the base/quote
@@ -393,7 +391,6 @@ func (s *PoolsUsecaseTestSuite) TestProcessOrderbookPoolIDForBaseQuote() {
 // for orderbook pools, we also update the canonical orderbook pool ID.
 // We also validate that any errors stemming from orderbook handling logic are silently skipped
 func (s *PoolsUsecaseTestSuite) TestStorePools() {
-
 	const (
 		validOrderBookPoolID   = defaultPoolID + 1
 		invalidOrderBookPoolID = defaultPoolID + 2
@@ -499,7 +496,6 @@ func (s *PoolsUsecaseTestSuite) TestStorePools() {
 // if they are correctly set. The correctness of setting them is ensured
 // by the StorePools and ProcessOrderbookPoolIDForBaseQuote tests.
 func (s *PoolsUsecaseTestSuite) TestGetAllCanonicalOrderbooks_HappyPath() {
-
 	poolsUseCase := s.newDefaultPoolsUseCase()
 
 	// Denom one and denom two
@@ -532,14 +528,12 @@ func (s *PoolsUsecaseTestSuite) TestGetAllCanonicalOrderbooks_HappyPath() {
 
 	// Validate that the correct canonical orderbook pool IDs are returned
 	s.Require().Equal(expectedCanonicalOrderbookPoolIDs, canonicalOrderbooks)
-
 }
 
 // Happy path test to vaidate that no panics/errors occur and coins are returned
 // as intended.
 // The correctness of math is ensured at a different layer of abstraction.
 func (s *PoolsUsecaseTestSuite) TestCalcExitCFMMPool_HappyPath() {
-
 	s.Setup()
 
 	// Create pool
@@ -552,7 +546,10 @@ func (s *PoolsUsecaseTestSuite) TestCalcExitCFMMPool_HappyPath() {
 	s.Require().NoError(err)
 
 	// Create sqs pool
-	sqsPool := ingesttypes.NewPool(cfmmPool, cfmmPool.GetSpreadFactor(s.Ctx), poolBalances)
+	sqsPool := ingesttypes.NewPool(cfmmPool, ingesttypes.SQSPool{
+		SpreadFactor: cfmmPool.GetSpreadFactor(s.Ctx),
+		Balances:     poolBalances,
+	})
 
 	// Create default use case
 	poolsUseCase := s.newDefaultPoolsUseCase()
@@ -1025,7 +1022,6 @@ func (s *PoolsUsecaseTestSuite) newRoutablePool(pool ingesttypes.PoolI, tokenInD
 }
 
 func (s *PoolsUsecaseTestSuite) TestetPoolAPRAndFeeDataIfConfigured() {
-
 }
 
 func (s *PoolsUsecaseTestSuite) newDefaultPoolsUseCase() *usecase.PoolsUsecase {

--- a/router/repository/memory_router_repository.go
+++ b/router/repository/memory_router_repository.go
@@ -188,14 +188,14 @@ func (r *routerRepo) SetCandidateRouteSearchData(data map[string]*domain.Candida
 	// that we can still route over such pools.
 	for denom, value := range newData {
 		for i := range value.SortedPools {
-			if value.SortedPools[i].PoolLiquidityCap == 0 {
+			if value.SortedPools[i].GetPoolLiquidityCap() == 0 {
 				p, _, err := r.poolHandler.GetPools(domain.WithPoolIDFilter([]uint64{value.SortedPools[i].ID}))
 				if len(p) == 0 || err != nil {
 					continue // no pool found
 				}
 
 				if p[0].GetLiquidityCap().GT(osmomath.ZeroInt()) {
-					newData[denom].SortedPools[i].PoolLiquidityCap = sqsosmomath.SafeUint64(p[0].GetLiquidityCap())
+					newData[denom].SortedPools[i].SetPoolLiquidityCap(sqsosmomath.SafeUint64(p[0].GetLiquidityCap()))
 				}
 			}
 		}

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -125,7 +125,7 @@ func (c candidateRouteFinder) FindCandidateRoutesOutGivenIn(ctx context.Context,
 				continue
 			}
 
-			if pool.PoolLiquidityCap < options.MinPoolLiquidityCap {
+			if pool.GetPoolLiquidityCap() < options.MinPoolLiquidityCap {
 				visited[pool.ID] = true
 				// Skip pools that have less liquidity than the minimum required.
 				continue

--- a/router/usecase/pools/routable_concentrated_pool_test.go
+++ b/router/usecase/pools/routable_concentrated_pool_test.go
@@ -75,14 +75,13 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 			ticks, currentTickIndex, err := s.App.ConcentratedLiquidityKeeper.GetTickLiquidityForFullRange(s.Ctx, concentratedPool.GetId())
 			s.Require().NoError(err)
 
-			poolWrapper := &ingesttypes.PoolWrapper{}
-			poolWrapper.SetUnderlyingPool(concentratedPool)
-			poolWrapper.SetSQSPoolModel(ingesttypes.SQSPool{
+			poolWrapper := ingesttypes.NewPool(concentratedPool, ingesttypes.SQSPool{
 				PoolLiquidityCap:      osmomath.NewInt(100),
 				PoolLiquidityCapError: "",
 				Balances:              sdk.Coins{},
 				PoolDenoms:            []string{"foo", "bar"},
 			})
+
 			err = poolWrapper.SetTickModel(&ingesttypes.TickModel{
 				Ticks:            ticks,
 				CurrentTickIndex: currentTickIndex,
@@ -135,19 +134,19 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenInByTokenOut_Concentrated_Succ
 			ticks, currentTickIndex, err := s.App.ConcentratedLiquidityKeeper.GetTickLiquidityForFullRange(s.Ctx, concentratedPool.GetId())
 			s.Require().NoError(err)
 
-			poolWrapper := &ingesttypes.PoolWrapper{}
-			poolWrapper.SetUnderlyingPool(concentratedPool)
-			poolWrapper.SetSQSPoolModel(ingesttypes.SQSPool{
+			poolWrapper := ingesttypes.NewPool(concentratedPool, ingesttypes.SQSPool{
 				PoolLiquidityCap:      osmomath.NewInt(100),
 				PoolLiquidityCapError: "",
 				Balances:              sdk.Coins{},
 				PoolDenoms:            []string{"foo", "bar"},
 			})
-			poolWrapper.SetTickModel(&ingesttypes.TickModel{
+
+			err = poolWrapper.SetTickModel(&ingesttypes.TickModel{
 				Ticks:            ticks,
 				CurrentTickIndex: currentTickIndex,
 				HasNoLiquidity:   false,
 			})
+			s.Require().NoError(err)
 
 			cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,

--- a/router/usecase/pools/routable_concentrated_pool_test.go
+++ b/router/usecase/pools/routable_concentrated_pool_test.go
@@ -77,11 +77,6 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 
 			poolWrapper := &ingesttypes.PoolWrapper{
 				ChainModel: concentratedPool,
-				TickModel: &ingesttypes.TickModel{
-					Ticks:            ticks,
-					CurrentTickIndex: currentTickIndex,
-					HasNoLiquidity:   false,
-				},
 				SQSModel: ingesttypes.SQSPool{
 					PoolLiquidityCap:      osmomath.NewInt(100),
 					PoolLiquidityCapError: "",
@@ -89,6 +84,14 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 					PoolDenoms:            []string{"foo", "bar"},
 				},
 			}
+
+			err = poolWrapper.SetTickModel(&ingesttypes.TickModel{
+				Ticks:            ticks,
+				CurrentTickIndex: currentTickIndex,
+				HasNoLiquidity:   false,
+			})
+			s.Require().NoError(err)
+
 			cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 			}
@@ -136,11 +139,6 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenInByTokenOut_Concentrated_Succ
 
 			poolWrapper := &ingesttypes.PoolWrapper{
 				ChainModel: concentratedPool,
-				TickModel: &ingesttypes.TickModel{
-					Ticks:            ticks,
-					CurrentTickIndex: currentTickIndex,
-					HasNoLiquidity:   false,
-				},
 				SQSModel: ingesttypes.SQSPool{
 					PoolLiquidityCap:      osmomath.NewInt(100),
 					PoolLiquidityCapError: "",
@@ -148,6 +146,13 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenInByTokenOut_Concentrated_Succ
 					PoolDenoms:            []string{"foo", "bar"},
 				},
 			}
+
+			poolWrapper.SetTickModel(&ingesttypes.TickModel{
+				Ticks:            ticks,
+				CurrentTickIndex: currentTickIndex,
+				HasNoLiquidity:   false,
+			})
+
 			cosmWasmPoolsParams := cosmwasmdomain.CosmWasmPoolsParams{
 				ScalingFactorGetterCb: domain.UnsetScalingFactorGetterCb,
 			}
@@ -310,7 +315,6 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Erro
 
 			if tc.tickModelOverwrite != nil {
 				tickModel = tc.tickModelOverwrite
-
 			} else if tc.isTickModelNil {
 				// For clarity:
 				tickModel = nil
@@ -494,7 +498,6 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenInByTokenOut_Concentrated_Erro
 
 			if tc.tickModelOverwrite != nil {
 				tickModel = tc.tickModelOverwrite
-
 			} else if tc.isTickModelNil {
 				// For clarity:
 				tickModel = nil

--- a/router/usecase/pools/routable_concentrated_pool_test.go
+++ b/router/usecase/pools/routable_concentrated_pool_test.go
@@ -75,16 +75,14 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenOutByTokenIn_Concentrated_Succ
 			ticks, currentTickIndex, err := s.App.ConcentratedLiquidityKeeper.GetTickLiquidityForFullRange(s.Ctx, concentratedPool.GetId())
 			s.Require().NoError(err)
 
-			poolWrapper := &ingesttypes.PoolWrapper{
-				ChainModel: concentratedPool,
-				SQSModel: ingesttypes.SQSPool{
-					PoolLiquidityCap:      osmomath.NewInt(100),
-					PoolLiquidityCapError: "",
-					Balances:              sdk.Coins{},
-					PoolDenoms:            []string{"foo", "bar"},
-				},
-			}
-
+			poolWrapper := &ingesttypes.PoolWrapper{}
+			poolWrapper.SetUnderlyingPool(concentratedPool)
+			poolWrapper.SetSQSPoolModel(ingesttypes.SQSPool{
+				PoolLiquidityCap:      osmomath.NewInt(100),
+				PoolLiquidityCapError: "",
+				Balances:              sdk.Coins{},
+				PoolDenoms:            []string{"foo", "bar"},
+			})
 			err = poolWrapper.SetTickModel(&ingesttypes.TickModel{
 				Ticks:            ticks,
 				CurrentTickIndex: currentTickIndex,
@@ -137,16 +135,14 @@ func (s *RoutablePoolTestSuite) TestCalculateTokenInByTokenOut_Concentrated_Succ
 			ticks, currentTickIndex, err := s.App.ConcentratedLiquidityKeeper.GetTickLiquidityForFullRange(s.Ctx, concentratedPool.GetId())
 			s.Require().NoError(err)
 
-			poolWrapper := &ingesttypes.PoolWrapper{
-				ChainModel: concentratedPool,
-				SQSModel: ingesttypes.SQSPool{
-					PoolLiquidityCap:      osmomath.NewInt(100),
-					PoolLiquidityCapError: "",
-					Balances:              sdk.Coins{},
-					PoolDenoms:            []string{"foo", "bar"},
-				},
-			}
-
+			poolWrapper := &ingesttypes.PoolWrapper{}
+			poolWrapper.SetUnderlyingPool(concentratedPool)
+			poolWrapper.SetSQSPoolModel(ingesttypes.SQSPool{
+				PoolLiquidityCap:      osmomath.NewInt(100),
+				PoolLiquidityCapError: "",
+				Balances:              sdk.Coins{},
+				PoolDenoms:            []string{"foo", "bar"},
+			})
 			poolWrapper.SetTickModel(&ingesttypes.TickModel{
 				Ticks:            ticks,
 				CurrentTickIndex: currentTickIndex,

--- a/router/usecase/router_test.go
+++ b/router/usecase/router_test.go
@@ -106,6 +106,26 @@ func (s *RouterTestSuite) TestRouterSorting() {
 	thirdBalancerPool, err := s.App.PoolManagerKeeper.GetPool(s.Ctx, thirdBalancerPoolID)
 	s.Require().NoError(err)
 
+	poolWrapperWithTicks := &ingesttypes.PoolWrapper{
+		ChainModel: concentratedPool,
+		SQSModel: ingesttypes.SQSPool{
+			PoolLiquidityCap: osmomath.NewInt(4 * OsmoPrecisionMultiplier), // 4
+			PoolDenoms:       defaultDenoms,
+		},
+	}
+
+	poolWrapperWithTicks.SetTickModel(&ingesttypes.TickModel{
+		Ticks: []ingesttypes.LiquidityDepthsWithRange{
+			{
+				LowerTick:       0,
+				UpperTick:       100,
+				LiquidityAmount: osmomath.NewDec(100),
+			},
+		},
+		CurrentTickIndex: 0,
+		HasNoLiquidity:   false,
+	})
+
 	var (
 		// Inputs
 		minPoolLiquidityCap = 2
@@ -125,24 +145,7 @@ func (s *RouterTestSuite) TestRouterSorting() {
 					PoolDenoms:       defaultDenoms,
 				},
 			},
-			&ingesttypes.PoolWrapper{
-				ChainModel: concentratedPool,
-				SQSModel: ingesttypes.SQSPool{
-					PoolLiquidityCap: osmomath.NewInt(4 * OsmoPrecisionMultiplier), // 4
-					PoolDenoms:       defaultDenoms,
-				},
-				TickModel: &ingesttypes.TickModel{
-					Ticks: []ingesttypes.LiquidityDepthsWithRange{
-						{
-							LowerTick:       0,
-							UpperTick:       100,
-							LiquidityAmount: osmomath.NewDec(100),
-						},
-					},
-					CurrentTickIndex: 0,
-					HasNoLiquidity:   false,
-				},
-			},
+			poolWrapperWithTicks,
 			&ingesttypes.PoolWrapper{
 				ChainModel: cosmWasmPool,
 				SQSModel: ingesttypes.SQSPool{

--- a/router/usecase/router_test.go
+++ b/router/usecase/router_test.go
@@ -106,14 +106,14 @@ func (s *RouterTestSuite) TestRouterSorting() {
 	thirdBalancerPool, err := s.App.PoolManagerKeeper.GetPool(s.Ctx, thirdBalancerPoolID)
 	s.Require().NoError(err)
 
-	poolWrapperWithTicks := &ingesttypes.PoolWrapper{
-		ChainModel: concentratedPool,
-		SQSModel: ingesttypes.SQSPool{
-			PoolLiquidityCap: osmomath.NewInt(4 * OsmoPrecisionMultiplier), // 4
-			PoolDenoms:       defaultDenoms,
-		},
-	}
+	poolWrapperWithTicks := &ingesttypes.PoolWrapper{}
 
+	poolWrapperWithTicks.SetSQSPoolModel(ingesttypes.SQSPool{
+		PoolLiquidityCap: osmomath.NewInt(4 * OsmoPrecisionMultiplier), // 4
+		PoolDenoms:       defaultDenoms,
+	})
+
+	poolWrapperWithTicks.SetUnderlyingPool(concentratedPool)
 	poolWrapperWithTicks.SetTickModel(&ingesttypes.TickModel{
 		Ticks: []ingesttypes.LiquidityDepthsWithRange{
 			{
@@ -131,31 +131,31 @@ func (s *RouterTestSuite) TestRouterSorting() {
 		minPoolLiquidityCap = 2
 		logger, _           = log.NewLogger(false, "", "")
 		defaultAllPools     = []ingesttypes.PoolI{
-			&ingesttypes.PoolWrapper{
-				ChainModel: balancerPool,
-				SQSModel: ingesttypes.SQSPool{
+			ingesttypes.NewPool(
+				balancerPool,
+				ingesttypes.SQSPool{
 					PoolLiquidityCap: osmomath.NewInt(5 * OsmoPrecisionMultiplier), // 5
 					PoolDenoms:       defaultDenoms,
 				},
-			},
-			&ingesttypes.PoolWrapper{
-				ChainModel: stableswapPool,
-				SQSModel: ingesttypes.SQSPool{
+			),
+			ingesttypes.NewPool(
+				stableswapPool,
+				ingesttypes.SQSPool{
 					PoolLiquidityCap: osmomath.NewInt(int64(minPoolLiquidityCap) - 1), // 1
 					PoolDenoms:       defaultDenoms,
 				},
-			},
+			),
 			poolWrapperWithTicks,
-			&ingesttypes.PoolWrapper{
-				ChainModel: cosmWasmPool,
-				SQSModel: ingesttypes.SQSPool{
+			ingesttypes.NewPool(
+				cosmWasmPool,
+				ingesttypes.SQSPool{
 					PoolLiquidityCap: osmomath.NewInt(3 * OsmoPrecisionMultiplier), // 3
 					PoolDenoms:       defaultDenoms,
 				},
-			},
-			&ingesttypes.PoolWrapper{
-				ChainModel: &mocks.ChainPoolMock{ID: alloyedPoolID, Type: poolmanagertypes.CosmWasm},
-				SQSModel: ingesttypes.SQSPool{
+			),
+			ingesttypes.NewPool(
+				&mocks.ChainPoolMock{ID: alloyedPoolID, Type: poolmanagertypes.CosmWasm},
+				ingesttypes.SQSPool{
 					PoolLiquidityCap: osmomath.NewInt(3*OsmoPrecisionMultiplier - 1), // 3 * precision - 1
 					PoolDenoms:       defaultDenoms,
 					CosmWasmPoolModel: &cosmwasmpool.CosmWasmPoolModel{
@@ -165,27 +165,27 @@ func (s *RouterTestSuite) TestRouterSorting() {
 						},
 					},
 				},
-			},
+			),
 
 			// Note that the pools below have higher TVL.
 			// However, since they have TVL error flag set, they
 			// should be sorted after other pools, unless overriden by preferredPoolIDs.
-			&ingesttypes.PoolWrapper{
-				ChainModel: secondBalancerPool,
-				SQSModel: ingesttypes.SQSPool{
+			ingesttypes.NewPool(
+				secondBalancerPool,
+				ingesttypes.SQSPool{
 					PoolLiquidityCap:      osmomath.NewInt(10 * OsmoPrecisionMultiplier), // 10
 					PoolDenoms:            defaultDenoms,
 					PoolLiquidityCapError: dummyPoolLiquidityCapErrorStr,
 				},
-			},
-			&ingesttypes.PoolWrapper{
-				ChainModel: thirdBalancerPool,
-				SQSModel: ingesttypes.SQSPool{
+			),
+			ingesttypes.NewPool(
+				thirdBalancerPool,
+				ingesttypes.SQSPool{
 					PoolLiquidityCap:      osmomath.NewInt(11 * OsmoPrecisionMultiplier), // 11
 					PoolDenoms:            defaultDenoms,
 					PoolLiquidityCapError: dummyPoolLiquidityCapErrorStr,
 				},
-			},
+			),
 		}
 
 		// Expected

--- a/router/usecase/router_test.go
+++ b/router/usecase/router_test.go
@@ -106,14 +106,11 @@ func (s *RouterTestSuite) TestRouterSorting() {
 	thirdBalancerPool, err := s.App.PoolManagerKeeper.GetPool(s.Ctx, thirdBalancerPoolID)
 	s.Require().NoError(err)
 
-	poolWrapperWithTicks := &ingesttypes.PoolWrapper{}
-
-	poolWrapperWithTicks.SetSQSPoolModel(ingesttypes.SQSPool{
+	poolWrapperWithTicks := ingesttypes.NewPool(concentratedPool, ingesttypes.SQSPool{
 		PoolLiquidityCap: osmomath.NewInt(4 * OsmoPrecisionMultiplier), // 4
 		PoolDenoms:       defaultDenoms,
 	})
 
-	poolWrapperWithTicks.SetUnderlyingPool(concentratedPool)
 	poolWrapperWithTicks.SetTickModel(&ingesttypes.TickModel{
 		Ticks: []ingesttypes.LiquidityDepthsWithRange{
 			{

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -108,15 +108,15 @@ func (s *RouterTestSuite) TestHandleRoutes() {
 	balancerPool, err := s.App.PoolManagerKeeper.GetPool(s.Ctx, balancerPoolID)
 	s.Require().NoError(err)
 
-	defaultPool := &ingesttypes.PoolWrapper{
-		ChainModel: balancerPool,
-		SQSModel: ingesttypes.SQSPool{
+	defaultPool := ingesttypes.NewPool(
+		balancerPool,
+		ingesttypes.SQSPool{
 			PoolLiquidityCap: osmomath.NewInt(int64(minPoolLiquidityCap*OsmoPrecisionMultiplier + 1)),
 			PoolDenoms:       []string{tokenInDenom, tokenOutDenom},
 			Balances:         balancerCoins,
 			SpreadFactor:     DefaultSpreadFactor,
 		},
-	}
+	)
 
 	var (
 		defaultRoute = WithCandidateRoutePools(
@@ -277,7 +277,6 @@ func (s *RouterTestSuite) TestHandleRoutes() {
 	for _, tc := range testCases {
 		tc := tc
 		s.Run(tc.name, func() {
-
 			routerRepositoryMock := routerrepo.New(&log.NoOpLogger{})
 
 			candidateRouteCache := cache.New()
@@ -551,7 +550,6 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 	for name, tc := range tests {
 		tc := tc
 		s.Run(name, func() {
-
 			actualRoutes := usecase.FilterDuplicatePoolIDRoutes(tc.routes)
 
 			s.Require().Equal(len(tc.expectedRoutes), len(actualRoutes))
@@ -560,7 +558,6 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 }
 
 func (s *RouterTestSuite) TestConvertRankedToCandidateRoutes() {
-
 	tests := map[string]struct {
 		rankedRoutes []route.RouteImpl
 
@@ -636,7 +633,6 @@ func (s *RouterTestSuite) TestConvertRankedToCandidateRoutes() {
 	for name, tc := range tests {
 		tc := tc
 		s.Run(name, func() {
-
 			actualCandidateRoutes := usecase.ConvertRankedToCandidateRoutes(tc.rankedRoutes)
 
 			s.Require().Equal(tc.expectedCandidateRoutes, actualCandidateRoutes)
@@ -1152,9 +1148,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuotes_Mainnet_UOSMO
 	config.MaxPoolsPerRoute = 5
 	config.MaxRoutes = 10
 
-	var (
-		amountIn = osmomath.NewInt(5000000)
-	)
+	amountIn := osmomath.NewInt(5000000)
 
 	mainnetState := s.SetupMainnetState()
 
@@ -1298,9 +1292,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuotesInGivenOut_Mai
 	config.MaxPoolsPerRoute = 5
 	config.MaxRoutes = 10
 
-	var (
-		amountOut = osmomath.NewInt(5000000)
-	)
+	amountOut := osmomath.NewInt(5000000)
 
 	mainnetState := s.SetupMainnetState()
 
@@ -1442,9 +1434,7 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuotes_Mainnet_Order
 	config.MaxPoolsPerRoute = 5
 	config.MaxRoutes = 10
 
-	var (
-		orderbookCodeId = uint64(885)
-	)
+	orderbookCodeId := uint64(885)
 
 	mainnetState := s.SetupMainnetState()
 
@@ -1510,7 +1500,6 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuotes_Mainnet_Order
 	for _, tc := range testCases {
 		s.Run(tc.name, func() {
 			quote, err := routerUsecase.GetCustomDirectQuoteOutGivenIn(context.Background(), tc.tokenIn, tc.tokenOutDenom, tc.poolID)
-
 			if err != nil {
 				s.Require().EqualError(tc.err, err.Error())
 				return // nothing else to do
@@ -1524,7 +1513,6 @@ func (s *RouterTestSuite) TestGetCustomQuote_GetCustomDirectQuotes_Mainnet_Order
 }
 
 func (s *RouterTestSuite) TestCutRoutesForSplits() {
-
 	// Note: contents are irrelevant. Only count of routes matters for this test.
 	var (
 		defaultRoute = route.RouteImpl{}
@@ -1610,7 +1598,6 @@ func (s *RouterTestSuite) TestCutRoutesForSplits() {
 
 	for _, tc := range testcases {
 		s.Run(tc.name, func() {
-
 			routes := usecase.CutRoutesForSplits(tc.maxSplitRoutes, tc.routes)
 
 			s.Require().Len(routes, tc.expectedRoutesLen)
@@ -1619,7 +1606,6 @@ func (s *RouterTestSuite) TestCutRoutesForSplits() {
 }
 
 func (s *RouterTestSuite) TestGetMinPoolLiquidityCapFilter() {
-
 	const (
 		dynamicFilterValue = 10_000
 		defaultFilterValue = 100

--- a/router/usecase/routertesting/parsing/mainnet_pools.go
+++ b/router/usecase/routertesting/parsing/mainnet_pools.go
@@ -428,10 +428,7 @@ func UnmarshalPool(serializedPool SerializedPool) (ingesttypes.PoolI, error) {
 		return nil, domain.InvalidPoolTypeError{PoolType: int32(serializedPool.Type)}
 	}
 
-	poolWrapper := &ingesttypes.PoolWrapper{}
-	poolWrapper.SetUnderlyingPool(chainModel)
-	poolWrapper.SetSQSPoolModel(serializedPool.SQSModel)
-
+	poolWrapper := ingesttypes.NewPool(chainModel, serializedPool.SQSModel)
 	if err := poolWrapper.SetTickModel(serializedPool.TickModel); err != nil {
 		return nil, err
 	}

--- a/router/usecase/routertesting/parsing/mainnet_pools.go
+++ b/router/usecase/routertesting/parsing/mainnet_pools.go
@@ -428,14 +428,13 @@ func UnmarshalPool(serializedPool SerializedPool) (ingesttypes.PoolI, error) {
 		return nil, domain.InvalidPoolTypeError{PoolType: int32(serializedPool.Type)}
 	}
 
-	poolWrapper := ingesttypes.PoolWrapper{
-		ChainModel: chainModel,
-		SQSModel:   serializedPool.SQSModel,
-	}
+	poolWrapper := &ingesttypes.PoolWrapper{}
+	poolWrapper.SetUnderlyingPool(chainModel)
+	poolWrapper.SetSQSPoolModel(serializedPool.SQSModel)
 
 	if err := poolWrapper.SetTickModel(serializedPool.TickModel); err != nil {
 		return nil, err
 	}
 
-	return &poolWrapper, nil
+	return poolWrapper, nil
 }

--- a/router/usecase/routertesting/parsing/mainnet_pools.go
+++ b/router/usecase/routertesting/parsing/mainnet_pools.go
@@ -431,7 +431,10 @@ func UnmarshalPool(serializedPool SerializedPool) (ingesttypes.PoolI, error) {
 	poolWrapper := ingesttypes.PoolWrapper{
 		ChainModel: chainModel,
 		SQSModel:   serializedPool.SQSModel,
-		TickModel:  serializedPool.TickModel,
+	}
+
+	if err := poolWrapper.SetTickModel(serializedPool.TickModel); err != nil {
+		return nil, err
 	}
 
 	return &poolWrapper, nil

--- a/router/usecase/routertesting/quote.go
+++ b/router/usecase/routertesting/quote.go
@@ -59,19 +59,24 @@ func (s *RouterTestHelper) NewExactAmountInQuote(p1, p2, p3 poolmanagertypes.Poo
 
 		// 2 routes with 50-50 split, each single hop
 		Route: []domain.SplitRoute{
-
 			// Route 1
 			&usecase.RouteWithOutAmount{
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						s.newRoutablePool(
-							ingesttypes.NewPool(p1, p1.GetSpreadFactor(sdk.Context{}), poolOneBalances),
+							ingesttypes.NewPool(p1, ingesttypes.SQSPool{
+								SpreadFactor: p1.GetSpreadFactor(sdk.Context{}),
+								Balances:     poolOneBalances,
+							}),
 							ETH,
 							USDT,
 							takerFeeOne,
 						),
 						s.newRoutablePool(
-							ingesttypes.NewPool(p2, p2.GetSpreadFactor(sdk.Context{}), poolTwoBalances),
+							ingesttypes.NewPool(p2, ingesttypes.SQSPool{
+								SpreadFactor: p2.GetSpreadFactor(sdk.Context{}),
+								Balances:     poolTwoBalances,
+							}),
 							USDT,
 							USDC,
 							takerFeeTwo,
@@ -88,7 +93,10 @@ func (s *RouterTestHelper) NewExactAmountInQuote(p1, p2, p3 poolmanagertypes.Poo
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						s.newRoutablePool(
-							ingesttypes.NewPool(p3, p3.GetSpreadFactor(sdk.Context{}), poolThreeBalances),
+							ingesttypes.NewPool(p3, ingesttypes.SQSPool{
+								SpreadFactor: p3.GetSpreadFactor(sdk.Context{}),
+								Balances:     poolThreeBalances,
+							}),
 							ETH,
 							USDC,
 							takerFeeThree,
@@ -117,13 +125,19 @@ func (s *RouterTestHelper) NewExactAmountOutQuote(p1, p2, p3 poolmanagertypes.Po
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						s.newRoutablePool(
-							ingesttypes.NewPool(p1, p1.GetSpreadFactor(sdk.Context{}), poolOneBalances),
+							ingesttypes.NewPool(p1, ingesttypes.SQSPool{
+								SpreadFactor: p1.GetSpreadFactor(sdk.Context{}),
+								Balances:     poolOneBalances,
+							}),
 							ETH,
 							USDT,
 							takerFeeOne,
 						),
 						s.newRoutablePool(
-							ingesttypes.NewPool(p2, p2.GetSpreadFactor(sdk.Context{}), poolTwoBalances),
+							ingesttypes.NewPool(p2, ingesttypes.SQSPool{
+								SpreadFactor: p2.GetSpreadFactor(sdk.Context{}),
+								Balances:     poolTwoBalances,
+							}),
 							USDT,
 							USDC,
 							takerFeeTwo,
@@ -138,7 +152,10 @@ func (s *RouterTestHelper) NewExactAmountOutQuote(p1, p2, p3 poolmanagertypes.Po
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						s.newRoutablePool(
-							ingesttypes.NewPool(p3, p3.GetSpreadFactor(sdk.Context{}), poolThreeBalances),
+							ingesttypes.NewPool(p3, ingesttypes.SQSPool{
+								SpreadFactor: p3.GetSpreadFactor(sdk.Context{}),
+								Balances:     poolThreeBalances,
+							}),
 							ETH,
 							USDC,
 							takerFeeThree,


### PR DESCRIPTION
This PR fixes a several race conditions for `PoolWrapper` resulted by accessing this data sructure by multiple goroutines at the same time.

Main changes are for:

- [CandidatePoolWrapper](https://github.com/osmosis-labs/sqs/pull/651/files#diff-398954fa36fe1c18e8236c372135c00ecde7838df367c154b36d844b428707a6R88)
- [PoolWrapper](https://github.com/osmosis-labs/sqs/pull/651/files#diff-0a9dad9c062a31f51bf466e47e36513570429c745905d0480ce9d39624e249d2R72)

All other changes are side effect mainly or cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved thread safety and concurrent access for pool and candidate route data by introducing atomic operations and copy-on-write wrappers for key fields.
  - Updated various methods to use atomic getters and setters instead of direct field access, ensuring safer handling of mutable data.
  - Enhanced error handling in pool initialization and tick model assignment.

- **Chores**
  - Updated internal usage patterns to align with new atomic and setter/getter conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->