### PR TITLE
BE-741 | Parallelize calls to CalculateTokenOutByTokenIn for routes

### DIFF
--- a/router/usecase/dynamic_splits.go
+++ b/router/usecase/dynamic_splits.go
@@ -31,8 +31,8 @@ func getSplitQuote(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Co
 	}
 	// If only one route, return the best single route quote
 	if len(routes) == 1 {
-		route := routes[0]
-		coinOut, err := route.CalculateTokenOutByTokenIn(ctx, tokenIn)
+		r := routes[0]
+		coinOut, err := r.CalculateTokenOutByTokenIn(ctx, tokenIn)
 		if err != nil {
 			return nil, err
 		}
@@ -40,8 +40,8 @@ func getSplitQuote(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Co
 		quote := &quoteExactAmountIn{
 			AmountIn:  tokenIn,
 			AmountOut: coinOut.Amount,
-			Route: []domain.SplitRoute{&RouteWithOutAmount{
-				RouteImpl: route,
+			Route: []domain.SplitRoute{&route.RouteWithOutAmount{
+				RouteImpl: r,
 				OutAmount: coinOut.Amount,
 				InAmount:  tokenIn.Amount,
 			}},
@@ -150,7 +150,7 @@ func getSplitQuote(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Co
 			return nil, fmt.Errorf("out amount is zero when in is not (%s), route index (%d)", inAmount, i)
 		}
 
-		resultRoutes = append(resultRoutes, &RouteWithOutAmount{
+		resultRoutes = append(resultRoutes, &route.RouteWithOutAmount{
 			RouteImpl: currentRoute,
 			InAmount:  inAmount,
 			OutAmount: currentRouteAmtOut,

--- a/router/usecase/export_test.go
+++ b/router/usecase/export_test.go
@@ -33,15 +33,15 @@ func (r *routerUseCaseImpl) HandleRoutes(ctx context.Context, tokenIn sdk.Coin, 
 	return r.handleCandidateRoutes(ctx, tokenIn, tokenOutDenom, candidateRouteSearchOptions)
 }
 
-func (r *routerUseCaseImpl) EstimateAndRankSingleRouteQuoteOutGivenIn(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Coin, logger log.Logger) (domain.Quote, []RouteWithOutAmount, error) {
-	return r.estimateAndRankSingleRouteQuoteOutGivenIn(ctx, routes, tokenIn, logger)
+func (r *routerUseCaseImpl) EstimateAndRankSingleRouteQuoteOutGivenIn(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Coin) (domain.Quote, []route.RouteWithOutAmount, error) {
+	return r.estimateAndRankSingleRouteQuoteOutGivenIn(ctx, routes, tokenIn)
 }
 
-func (r *routerUseCaseImpl) EstimateAndRankSingleRouteQuoteInGivenOut(ctx context.Context, routes []route.RouteImpl, tokenOut sdk.Coin, logger log.Logger) (domain.Quote, []RouteWithOutAmount, error) {
+func (r *routerUseCaseImpl) EstimateAndRankSingleRouteQuoteInGivenOut(ctx context.Context, routes []route.RouteImpl, tokenOut sdk.Coin, logger log.Logger) (domain.Quote, []route.RouteWithOutAmount, error) {
 	return r.estimateAndRankSingleRouteQuoteInGivenOut(ctx, routes, tokenOut, logger)
 }
 
-func FilterDuplicatePoolIDRoutes(rankedRoutes []RouteWithOutAmount) []route.RouteImpl {
+func FilterDuplicatePoolIDRoutes(rankedRoutes []route.RouteWithOutAmount) []route.RouteImpl {
 	return filterAndConvertDuplicatePoolIDRankedRoutes(rankedRoutes)
 }
 

--- a/router/usecase/optimized_routes.go
+++ b/router/usecase/optimized_routes.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"sync"
 
-	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"go.uber.org/zap"
 
@@ -21,60 +19,13 @@ import (
 // Returns best quote as well as all routes sorted by amount out and error if any.
 // CONTRACT: router repository must be set on the router.
 // CONTRACT: pools reporitory must be set on the router
-func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteOutGivenIn(ctx context.Context, routes []route.RouteImpl, tokenIn sdk.Coin, logger log.Logger) (quote domain.Quote, sortedRoutesByAmtOut []RouteWithOutAmount, err error) {
+func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteOutGivenIn(ctx context.Context, routes route.RouteImpls, tokenIn sdk.Coin) (quote domain.Quote, sortedRoutesByAmtOut []route.RouteWithOutAmount, err error) {
 	if len(routes) == 0 {
 		return nil, nil, fmt.Errorf("no routes were provided for token in (%s)", tokenIn.Denom)
 	}
 
-	type result struct {
-		index int
-		data  RouteWithOutAmount
-		err   error
-	}
-
-	routesWithAmountOut := make([]RouteWithOutAmount, 0, len(routes))
-	results := make(chan result, len(routes))
-
-	var wg sync.WaitGroup
-	for i, r := range routes {
-		wg.Add(1)
-		go func(i int, r route.RouteImpl) {
-			defer wg.Done()
-
-			directRouteTokenOut, err := r.CalculateTokenOutByTokenIn(ctx, tokenIn)
-			if err != nil {
-				results <- result{index: i, err: err}
-				return
-			}
-
-			if directRouteTokenOut.Amount.IsNil() {
-				directRouteTokenOut.Amount = osmomath.ZeroInt()
-			}
-
-			results <- result{
-				index: i,
-				data: RouteWithOutAmount{
-					RouteImpl: r,
-					InAmount:  tokenIn.Amount,
-					OutAmount: directRouteTokenOut.Amount,
-				},
-			}
-		}(i, r)
-	}
-
-	wg.Wait() // wait for all goroutines to finish
-	close(results)
-
-	var errors []error
-	for range len(routes) {
-		res := <-results
-		if res.err != nil {
-			errors = append(errors, res.err)
-			logger.Debug("skipping single route due to error in estimate", zap.Error(err))
-			continue
-		}
-		routesWithAmountOut = append(routesWithAmountOut, res.data)
-	}
+	// Compute token out for each route
+	routesWithAmountOut, errors := routes.CalculateTokenOutByTokenIn(ctx, tokenIn)
 
 	// If we skipped all routes due to errors, return the first error
 	if len(routesWithAmountOut) == 0 && len(errors) > 0 {
@@ -113,17 +64,17 @@ func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteOutGivenIn(ctx contex
 // Returns best quote as well as all routes sorted by amount in and error if any.
 // CONTRACT: router repository must be set on the router.
 // CONTRACT: pools reporitory must be set on the router
-func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteInGivenOut(ctx context.Context, routes []route.RouteImpl, tokenOut sdk.Coin, logger log.Logger) (quote domain.Quote, sortedRoutesByAmtOut []RouteWithOutAmount, err error) { //nolint:unused
+func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteInGivenOut(ctx context.Context, routes []route.RouteImpl, tokenOut sdk.Coin, logger log.Logger) (quote domain.Quote, sortedRoutesByAmtOut []route.RouteWithOutAmount, err error) { //nolint:unused
 	if len(routes) == 0 {
 		return nil, nil, fmt.Errorf("no routes were provided for token in (%s)", tokenOut.Denom)
 	}
 
-	routesWithAmountIn := make([]RouteWithOutAmount, 0, len(routes))
+	routesWithAmountIn := make([]route.RouteWithOutAmount, 0, len(routes))
 
 	errors := []error{}
 
-	for _, route := range routes {
-		directRouteTokenIn, err := route.CalculateTokenInByTokenOut(ctx, tokenOut)
+	for _, r := range routes {
+		directRouteTokenIn, err := r.CalculateTokenInByTokenOut(ctx, tokenOut)
 		if err != nil {
 			logger.Debug("skipping single route due to error in estimate", zap.Error(err))
 			errors = append(errors, err)
@@ -134,8 +85,8 @@ func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteInGivenOut(ctx contex
 			directRouteTokenIn.Amount = osmomath.ZeroInt()
 		}
 
-		routesWithAmountIn = append(routesWithAmountIn, RouteWithOutAmount{
-			RouteImpl: route,
+		routesWithAmountIn = append(routesWithAmountIn, route.RouteWithOutAmount{
+			RouteImpl: r,
 			InAmount:  directRouteTokenIn.Amount,
 			OutAmount: tokenOut.Amount,
 		})
@@ -303,27 +254,4 @@ ROUTE_LOOP:
 		UniquePoolIDs:              uniquePoolIDs,
 		ContainsCanonicalOrderbook: containsCanonicalOrderbook,
 	}, nil
-}
-
-type RouteWithOutAmount struct {
-	route.RouteImpl
-	OutAmount osmomath.Int "json:\"out_amount\""
-	InAmount  osmomath.Int "json:\"in_amount\""
-}
-
-var _ domain.SplitRoute = &RouteWithOutAmount{}
-
-// GetAmountIn implements domain.SplitRoute.
-func (r RouteWithOutAmount) GetAmountIn() osmomath.Int {
-	return r.InAmount
-}
-
-// GetAmountOut implements domain.SplitRoute.
-func (r RouteWithOutAmount) GetAmountOut() math.Int {
-	return r.OutAmount
-}
-
-type Split struct {
-	Routes          []domain.SplitRoute
-	CurrentTotalOut osmomath.Int
 }

--- a/router/usecase/optimized_routes.go
+++ b/router/usecase/optimized_routes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 
 	"cosmossdk.io/math"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -25,27 +26,54 @@ func (r *routerUseCaseImpl) estimateAndRankSingleRouteQuoteOutGivenIn(ctx contex
 		return nil, nil, fmt.Errorf("no routes were provided for token in (%s)", tokenIn.Denom)
 	}
 
+	type result struct {
+		index int
+		data  RouteWithOutAmount
+		err   error
+	}
+
 	routesWithAmountOut := make([]RouteWithOutAmount, 0, len(routes))
+	results := make(chan result, len(routes))
 
-	errors := []error{}
+	var wg sync.WaitGroup
+	for i, r := range routes {
+		wg.Add(1)
+		go func(i int, r route.RouteImpl) {
+			defer wg.Done()
 
-	for _, route := range routes {
-		directRouteTokenOut, err := route.CalculateTokenOutByTokenIn(ctx, tokenIn)
-		if err != nil {
+			directRouteTokenOut, err := r.CalculateTokenOutByTokenIn(ctx, tokenIn)
+			if err != nil {
+				results <- result{index: i, err: err}
+				return
+			}
+
+			if directRouteTokenOut.Amount.IsNil() {
+				directRouteTokenOut.Amount = osmomath.ZeroInt()
+			}
+
+			results <- result{
+				index: i,
+				data: RouteWithOutAmount{
+					RouteImpl: r,
+					InAmount:  tokenIn.Amount,
+					OutAmount: directRouteTokenOut.Amount,
+				},
+			}
+		}(i, r)
+	}
+
+	wg.Wait() // wait for all goroutines to finish
+	close(results)
+
+	var errors []error
+	for range len(routes) {
+		res := <-results
+		if res.err != nil {
+			errors = append(errors, res.err)
 			logger.Debug("skipping single route due to error in estimate", zap.Error(err))
-			errors = append(errors, err)
 			continue
 		}
-
-		if directRouteTokenOut.Amount.IsNil() {
-			directRouteTokenOut.Amount = osmomath.ZeroInt()
-		}
-
-		routesWithAmountOut = append(routesWithAmountOut, RouteWithOutAmount{
-			RouteImpl: route,
-			InAmount:  tokenIn.Amount,
-			OutAmount: directRouteTokenOut.Amount,
-		})
+		routesWithAmountOut = append(routesWithAmountOut, res.data)
 	}
 
 	// If we skipped all routes due to errors, return the first error

--- a/router/usecase/optimized_routes_test.go
+++ b/router/usecase/optimized_routes_test.go
@@ -986,7 +986,7 @@ func (s *RouterTestSuite) TestEstimateAndRankSingleRouteQuoteOutGivenIn() {
 			}
 
 			// System under test
-			quote, rankedRoutes, sytErr := routerUseCase.EstimateAndRankSingleRouteQuoteOutGivenIn(context.Background(), routes, defaultTokenIn, &log.NoOpLogger{})
+			quote, rankedRoutes, sytErr := routerUseCase.EstimateAndRankSingleRouteQuoteOutGivenIn(context.Background(), routes, defaultTokenIn)
 
 			// Get cache results
 			_, foundcandidateRoutes, err := routerUseCase.GetCachedCandidateRoutes(context.Background(), domain.TokenSwapMethodExactIn, defaultTokenIn.Denom, tokenOutDenom)

--- a/router/usecase/quote_in_given_out.go
+++ b/router/usecase/quote_in_given_out.go
@@ -8,6 +8,7 @@ import (
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/router/types"
+	"github.com/osmosis-labs/sqs/router/usecase/route"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 
@@ -148,8 +149,8 @@ func (q *quoteExactAmountOut) PrepareResult(ctx context.Context, scalingFactor o
 	q.PriceImpact = q.quoteExactAmountIn.PriceImpact
 	q.InBaseOutQuoteSpotPrice = q.quoteExactAmountIn.InBaseOutQuoteSpotPrice
 
-	for i, route := range q.Route {
-		route, ok := route.(*RouteWithOutAmount)
+	for i, r := range q.Route {
+		route, ok := r.(*route.RouteWithOutAmount)
 		if !ok {
 			return nil, osmomath.Dec{}, types.ErrInvalidRouteType
 		}

--- a/router/usecase/quote_out_given_in.go
+++ b/router/usecase/quote_out_given_in.go
@@ -84,7 +84,7 @@ func (q *quoteExactAmountIn) PrepareResult(ctx context.Context, scalingFactor os
 		totalSpotPriceInBaseOutQuote = totalSpotPriceInBaseOutQuote.AddMut(routeSpotPriceInBaseOutQuote.MulMut(routeAmountInFraction))
 		totalEffectiveSpotPriceInBaseOutQuote = totalEffectiveSpotPriceInBaseOutQuote.AddMut(effectiveSpotPriceInBaseOutQuote.MulMut(routeAmountInFraction))
 
-		resultRoutes = append(resultRoutes, &RouteWithOutAmount{
+		resultRoutes = append(resultRoutes, &route.RouteWithOutAmount{
 			RouteImpl: route.RouteImpl{
 				Pools:                      newPools,
 				HasGeneralizedCosmWasmPool: curRoute.ContainsGeneralizedCosmWasmPool(),

--- a/router/usecase/quote_test.go
+++ b/router/usecase/quote_test.go
@@ -78,7 +78,7 @@ func (s *RouterTestSuite) TestPrepareResult() {
 			quote: s.NewExactAmountInQuote(poolOne, poolTwo, poolThree),
 			expectedRoutes: []domain.SplitRoute{
 				// Route 1
-				&usecase.RouteWithOutAmount{
+				&route.RouteWithOutAmount{
 					RouteImpl: route.RouteImpl{
 						Pools: []domain.RoutablePool{
 							pools.NewRoutableResultPool(
@@ -105,7 +105,7 @@ func (s *RouterTestSuite) TestPrepareResult() {
 				},
 
 				// Route 2
-				&usecase.RouteWithOutAmount{
+				&route.RouteWithOutAmount{
 					RouteImpl: route.RouteImpl{
 						Pools: []domain.RoutablePool{
 							pools.NewRoutableResultPool(
@@ -131,7 +131,7 @@ func (s *RouterTestSuite) TestPrepareResult() {
 			name:  "exact amount out",
 			quote: s.NewExactAmountOutQuote(poolOne, poolTwo, poolThree),
 			expectedRoutes: []domain.SplitRoute{
-				&usecase.RouteWithOutAmount{
+				&route.RouteWithOutAmount{
 					RouteImpl: route.RouteImpl{
 						Pools: []domain.RoutablePool{
 							pools.NewExactAmountOutRoutableResultPool(
@@ -156,7 +156,7 @@ func (s *RouterTestSuite) TestPrepareResult() {
 					InAmount:  totalOutAmount.QuoRaw(3),
 					OutAmount: totalInAmount.QuoRaw(2),
 				},
-				&usecase.RouteWithOutAmount{
+				&route.RouteWithOutAmount{
 					RouteImpl: route.RouteImpl{
 						Pools: []domain.RoutablePool{
 							pools.NewExactAmountOutRoutableResultPool(
@@ -244,9 +244,8 @@ func (s *RouterTestSuite) TestPrepareResult_PriceImpact() {
 
 		// 2 routes with 50-50 split, each single hop
 		Route: []domain.SplitRoute{
-
 			// Route 1
-			&usecase.RouteWithOutAmount{
+			&route.RouteWithOutAmount{
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						mocks.WithMockedTokenOut(

--- a/router/usecase/route/route.go
+++ b/router/usecase/route/route.go
@@ -20,23 +20,23 @@ import (
 var _ domain.Route = &RouteImpl{}
 
 type RouteImpl struct {
-	Pools []domain.RoutablePool "json:\"pools\""
+	Pools []domain.RoutablePool `json:"pools"`
 	// HasGeneralizedCosmWasmPool is true if the route contains a generalized cosmwasm pool.
 	// We track whether a route contains a generalized cosmwasm pool
 	// so that we can exclude it from split quote logic.
 	// The reason for this is that making network requests to chain is expensive.
 	// As a result, we want to minimize the number of requests we make.
-	HasGeneralizedCosmWasmPool bool "json:\"has-cw-pool\""
+	HasGeneralizedCosmWasmPool bool `json:"has-cw-pool"`
 	// HasCanonicalOrderbookPool is true if the route contains a canonical orderbook pool.
-	HasCanonicalOrderbookPool bool "json:\"-\""
+	HasCanonicalOrderbookPool bool `json:"-"`
 }
 
 type RouteImpls []RouteImpl
 
 type RouteWithOutAmount struct {
 	RouteImpl
-	OutAmount osmomath.Int "json:\"out_amount\""
-	InAmount  osmomath.Int "json:\"in_amount\""
+	OutAmount osmomath.Int `json:"out_amount"`
+	InAmount  osmomath.Int `json:"in_amount"`
 }
 
 var _ domain.SplitRoute = &RouteWithOutAmount{}
@@ -51,6 +51,8 @@ func (r RouteWithOutAmount) GetAmountOut() osmomath.Int {
 	return r.OutAmount
 }
 
+// CalculateTokenOutByTokenIn calculates the token out amount given the token in amount for each route in r.
+// Returns slice errors for each route than failed to calculate token out.
 func (r RouteImpls) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) ([]RouteWithOutAmount, []error) {
 	type result struct {
 		index int
@@ -61,6 +63,7 @@ func (r RouteImpls) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.
 	routesWithAmountOut := make([]RouteWithOutAmount, 0, len(r))
 	results := make(chan result, len(r))
 
+	// spin up goroutines to calculate token out for each route
 	var wg sync.WaitGroup
 	for i, route := range r {
 		wg.Add(1)
@@ -91,6 +94,7 @@ func (r RouteImpls) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.
 	wg.Wait()      // wait for all goroutines to finish
 	close(results) // close the channel so we can range over it
 
+	// collect results
 	var errors []error
 	for range len(r) {
 		res := <-results

--- a/router/usecase/route/route.go
+++ b/router/usecase/route/route.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
-
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/prometheus/client_golang/prometheus"
+	"sync"
 
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/log"
@@ -14,6 +12,8 @@ import (
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
 
@@ -29,6 +29,79 @@ type RouteImpl struct {
 	HasGeneralizedCosmWasmPool bool "json:\"has-cw-pool\""
 	// HasCanonicalOrderbookPool is true if the route contains a canonical orderbook pool.
 	HasCanonicalOrderbookPool bool "json:\"-\""
+}
+
+type RouteImpls []RouteImpl
+
+type RouteWithOutAmount struct {
+	RouteImpl
+	OutAmount osmomath.Int "json:\"out_amount\""
+	InAmount  osmomath.Int "json:\"in_amount\""
+}
+
+var _ domain.SplitRoute = &RouteWithOutAmount{}
+
+// GetAmountIn implements domain.SplitRoute.
+func (r RouteWithOutAmount) GetAmountIn() osmomath.Int {
+	return r.InAmount
+}
+
+// GetAmountOut implements domain.SplitRoute.
+func (r RouteWithOutAmount) GetAmountOut() osmomath.Int {
+	return r.OutAmount
+}
+
+func (r RouteImpls) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) ([]RouteWithOutAmount, []error) {
+	type result struct {
+		index int
+		data  RouteWithOutAmount
+		err   error
+	}
+
+	routesWithAmountOut := make([]RouteWithOutAmount, 0, len(r))
+	results := make(chan result, len(r))
+
+	var wg sync.WaitGroup
+	for i, route := range r {
+		wg.Add(1)
+		go func(i int, r RouteImpl) {
+			defer wg.Done()
+
+			directRouteTokenOut, err := r.CalculateTokenOutByTokenIn(ctx, tokenIn)
+			if err != nil {
+				results <- result{index: i, err: err}
+				return
+			}
+
+			if directRouteTokenOut.Amount.IsNil() {
+				directRouteTokenOut.Amount = osmomath.ZeroInt()
+			}
+
+			results <- result{
+				index: i,
+				data: RouteWithOutAmount{
+					RouteImpl: r,
+					InAmount:  tokenIn.Amount,
+					OutAmount: directRouteTokenOut.Amount,
+				},
+			}
+		}(i, route)
+	}
+
+	wg.Wait()      // wait for all goroutines to finish
+	close(results) // close the channel so we can range over it
+
+	var errors []error
+	for range len(r) {
+		res := <-results
+		if res.err != nil {
+			errors = append(errors, res.err)
+			continue
+		}
+		routesWithAmountOut = append(routesWithAmountOut, res.data)
+	}
+
+	return routesWithAmountOut, errors
 }
 
 var spotPriceErrorResultCounter = prometheus.NewCounterVec(

--- a/router/usecase/router_usecase.go
+++ b/router/usecase/router_usecase.go
@@ -257,7 +257,7 @@ func (r *routerUseCaseImpl) GetSimpleQuote(ctx context.Context, tokenIn sdk.Coin
 		return nil, err
 	}
 
-	topQuote, _, err := r.estimateAndRankSingleRouteQuoteOutGivenIn(ctx, routes, tokenIn, r.logger)
+	topQuote, _, err := r.estimateAndRankSingleRouteQuoteOutGivenIn(ctx, routes, tokenIn)
 	if err != nil {
 		return nil, fmt.Errorf("%s, tokenOutDenom (%s)", err, tokenOutDenom)
 	}
@@ -270,7 +270,7 @@ func (r *routerUseCaseImpl) GetSimpleQuote(ctx context.Context, tokenIn sdk.Coin
 // Additionally, the routes are converted into route.Route.Impl type.
 // CONTRACT: rankedRoutes are sorted in decreasing order by amount out
 // from first to last.
-func filterAndConvertDuplicatePoolIDRankedRoutes(rankedRoutes []RouteWithOutAmount) []route.RouteImpl {
+func filterAndConvertDuplicatePoolIDRankedRoutes(rankedRoutes []route.RouteWithOutAmount) []route.RouteImpl {
 	// We use two maps for all routes and for the current route.
 	// This is so that if a route ends up getting filtered, its pool IDs are not added to the combined map.
 	combinedPoolIDsMap := make(map[uint64]struct{})
@@ -334,7 +334,7 @@ func (r *routerUseCaseImpl) rankRoutesByDirectQuote(ctx context.Context, candida
 		return nil, nil, err
 	}
 
-	topQuote, routesWithAmtOut, err := r.estimateAndRankSingleRouteQuoteOutGivenIn(ctx, routes, tokenIn, r.logger)
+	topQuote, routesWithAmtOut, err := r.estimateAndRankSingleRouteQuoteOutGivenIn(ctx, routes, tokenIn)
 	if err != nil {
 		return nil, nil, fmt.Errorf("%s, tokenOutDenom (%s)", err, tokenOutDenom)
 	}
@@ -455,7 +455,7 @@ func (r *routerUseCaseImpl) GetCustomDirectQuoteOutGivenIn(ctx context.Context, 
 	}
 
 	// Compute direct quote
-	bestSingleRouteQuote, _, err := r.estimateAndRankSingleRouteQuoteOutGivenIn(ctx, routes, tokenIn, r.logger)
+	bestSingleRouteQuote, _, err := r.estimateAndRankSingleRouteQuoteOutGivenIn(ctx, routes, tokenIn)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ func (r *routerUseCaseImpl) GetCustomDirectQuoteMultiPoolOutGivenIn(ctx context.
 
 	// Construct the final multi-hop custom direct quote route.
 	result.Route = []domain.SplitRoute{
-		&RouteWithOutAmount{
+		&route.RouteWithOutAmount{
 			RouteImpl: route.RouteImpl{
 				Pools: pools,
 			},

--- a/router/usecase/router_usecase_test.go
+++ b/router/usecase/router_usecase_test.go
@@ -391,25 +391,25 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		})
 	)
 
-	wrapRoute := func(r route.RouteImpl) usecase.RouteWithOutAmount {
-		return usecase.RouteWithOutAmount{
+	wrapRoute := func(r route.RouteImpl) route.RouteWithOutAmount {
+		return route.RouteWithOutAmount{
 			RouteImpl: r,
 			// Note: amount is not relevant for this test
 		}
 	}
 
 	tests := map[string]struct {
-		routes []usecase.RouteWithOutAmount
+		routes []route.RouteWithOutAmount
 
 		expectedRoutes []route.RouteImpl
 	}{
 		"empty routes": {
-			routes:         []usecase.RouteWithOutAmount{},
+			routes:         []route.RouteWithOutAmount{},
 			expectedRoutes: []route.RouteImpl{},
 		},
 
 		"single route single pool": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(defaultSingleRoute),
 			},
 
@@ -419,7 +419,7 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		},
 
 		"single route two different pools": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(WithRoutePools(route.RouteImpl{}, []domain.RoutablePool{
 					deafaultPool,
 					otherPool,
@@ -438,7 +438,7 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		// Duplicate pool IDs within the same route are filtered out at a different step
 		// in the router logic.
 		"single route two same pools (have no effect on filtering)": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(WithRoutePools(route.RouteImpl{}, []domain.RoutablePool{
 					deafaultPool,
 					deafaultPool,
@@ -454,7 +454,7 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		},
 
 		"two single hop routes and no duplicates": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(defaultSingleRoute),
 
 				wrapRoute(WithRoutePools(route.RouteImpl{}, []domain.RoutablePool{
@@ -472,7 +472,7 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		},
 
 		"two single hop routes with duplicates (second filtered)": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(defaultSingleRoute),
 
 				wrapRoute(defaultSingleRoute),
@@ -484,7 +484,7 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		},
 
 		"three route. first and second overlap. second and third overlap. second is filtered out but not third": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(defaultSingleRoute),
 
 				wrapRoute(WithRoutePools(route.RouteImpl{}, []domain.RoutablePool{
@@ -507,7 +507,7 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		},
 
 		"two routes with duplicate alloy -> not filtered": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(alloyRouteOne),
 
 				wrapRoute(alloyRouteTwo),
@@ -521,7 +521,7 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		},
 
 		"two routes with duplicate transmuter -> not filtered": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(transmuterRouteOne),
 
 				wrapRoute(transmuterRouteTwo),
@@ -535,7 +535,7 @@ func (s *RouterTestSuite) TestFilterDuplicatePoolIDRoutes() {
 		},
 
 		"two exact routes with alloy and transmuter -> filtered": {
-			routes: []usecase.RouteWithOutAmount{
+			routes: []route.RouteWithOutAmount{
 				wrapRoute(alloyTransmuterV1Route),
 				wrapRoute(alloyTransmuterV1Route),
 			},

--- a/router/usecase/routertesting/quote.go
+++ b/router/usecase/routertesting/quote.go
@@ -60,7 +60,7 @@ func (s *RouterTestHelper) NewExactAmountInQuote(p1, p2, p3 poolmanagertypes.Poo
 		// 2 routes with 50-50 split, each single hop
 		Route: []domain.SplitRoute{
 			// Route 1
-			&usecase.RouteWithOutAmount{
+			&route.RouteWithOutAmount{
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						s.newRoutablePool(
@@ -89,7 +89,7 @@ func (s *RouterTestHelper) NewExactAmountInQuote(p1, p2, p3 poolmanagertypes.Poo
 			},
 
 			// Route 2
-			&usecase.RouteWithOutAmount{
+			&route.RouteWithOutAmount{
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						s.newRoutablePool(
@@ -121,7 +121,7 @@ func (s *RouterTestHelper) NewExactAmountOutQuote(p1, p2, p3 poolmanagertypes.Po
 
 		// 2 routes with 50-50 split, each single hop
 		Route: []domain.SplitRoute{
-			&usecase.RouteWithOutAmount{
+			&route.RouteWithOutAmount{
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						s.newRoutablePool(
@@ -148,7 +148,7 @@ func (s *RouterTestHelper) NewExactAmountOutQuote(p1, p2, p3 poolmanagertypes.Po
 				InAmount:  totalInAmount.QuoRaw(2),
 				OutAmount: totalOutAmount.QuoRaw(3),
 			},
-			&usecase.RouteWithOutAmount{
+			&route.RouteWithOutAmount{
 				RouteImpl: route.RouteImpl{
 					Pools: []domain.RoutablePool{
 						s.newRoutablePool(


### PR DESCRIPTION
This PR introduces parallelization `CalculateTokenOutByTokenIn` calls when computing `tokenOut` for  the routes.

Key part is [CalculateTokenOutByTokenIn](https://github.com/osmosis-labs/sqs/pull/654/files#diff-abc7b7210fc55db67d247135049783d3a5c9ae353589484ae05dda6eff73ce79R54) method while other changes are noise of cleanup. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Centralized route calculation logic for input/output amounts into a dedicated package for improved clarity.
  - Updated type references throughout the app to use fully qualified route types.
  - Simplified function signatures and removed redundant local type declarations.

- **Style**
  - Improved variable naming for better code readability.

No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->