### PR TITLE
BE-742 | Optimize CalculateTokenOutByTokenIn for balancer pool

### DIFF
--- a/router/usecase/pools/amm.go
+++ b/router/usecase/pools/amm.go
@@ -31,7 +31,12 @@ func solveConstantFunctionInvariant(
 	y := tokenBalanceFixedBefore.Quo(tokenBalanceFixedAfter)
 
 	// amountY = balanceY * (1 - (y ^ weightRatio))
-	yToWeightRatio := osmomath.MustNewDecFromStr(fmt.Sprintf("%v", math.Pow(y.MustFloat64(), weightRatio.MustFloat64())))
+	yWeightRatio := math.Pow(y.MustFloat64(), weightRatio.MustFloat64())
+	if math.IsInf(yWeightRatio, 0) || math.IsNaN(yWeightRatio) {
+		panic("constant-function invariant: overflow while exponentiating y ^ weightRatio")
+	}
+
+	yToWeightRatio := osmomath.MustNewDecFromStr(fmt.Sprintf("%v", yWeightRatio))
 	paranthetical := oneDec.Sub(yToWeightRatio)
 
 	amountY := paranthetical.MulMut(tokenBalanceUnknownBefore)

--- a/router/usecase/pools/amm.go
+++ b/router/usecase/pools/amm.go
@@ -1,0 +1,39 @@
+package pools
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+)
+
+// solveConstantFunctionInvariant solves the constant function of an AMM
+// that determines the relationship between the differences of two sides
+// of assets inside the pool.
+// For fixed balanceXBefore, balanceXAfter, weightX, balanceY, weightY,
+// we could deduce the balanceYDelta, calculated by:
+// balanceYDelta = balanceY * (1 - (balanceXBefore/balanceXAfter)^(weightX/weightY))
+// balanceYDelta is positive when the balance liquidity decreases.
+// balanceYDelta is negative when the balance liquidity increases.
+//
+// panics if tokenWeightUnknown is 0.
+func solveConstantFunctionInvariant(
+	tokenBalanceFixedBefore,
+	tokenBalanceFixedAfter,
+	tokenWeightFixed,
+	tokenBalanceUnknownBefore,
+	tokenWeightUnknown osmomath.Dec,
+) osmomath.Dec {
+	// weightRatio = (weightX/weightY)
+	weightRatio := tokenWeightFixed.Quo(tokenWeightUnknown)
+
+	// y = balanceXBefore/balanceXAfter
+	y := tokenBalanceFixedBefore.Quo(tokenBalanceFixedAfter)
+
+	// amountY = balanceY * (1 - (y ^ weightRatio))
+	yToWeightRatio := osmomath.MustNewDecFromStr(fmt.Sprintf("%v", math.Pow(y.MustFloat64(), weightRatio.MustFloat64())))
+	paranthetical := oneDec.Sub(yToWeightRatio)
+
+	amountY := paranthetical.MulMut(tokenBalanceUnknownBefore)
+	return amountY
+}

--- a/router/usecase/pools/amm_test.go
+++ b/router/usecase/pools/amm_test.go
@@ -74,3 +74,14 @@ func TestSolveConstantFunctionInvariant(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSolveConstantFunctionInvariant(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		solveConstantFunctionInvariant(osmomath.NewDec(386971117259),
+			osmomath.NewDec(386971331294),
+			osmomath.NewDec(536870912000000),
+			osmomath.NewDec(7773284087995),
+			osmomath.NewDec(536870912000000),
+		)
+	}
+}

--- a/router/usecase/pools/amm_test.go
+++ b/router/usecase/pools/amm_test.go
@@ -1,0 +1,76 @@
+package pools
+
+import (
+	"testing"
+
+	"github.com/osmosis-labs/osmosis/osmomath"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSolveConstantFunctionInvariant(t *testing.T) {
+	tests := []struct {
+		name                    string
+		tokenBalanceFixedBefore osmomath.Dec
+		tokenBalanceFixedAfter  osmomath.Dec
+		tokenWeightFixed        osmomath.Dec
+		tokenBalanceUnknown     osmomath.Dec
+		tokenWeightUnknown      osmomath.Dec
+		expectedResult          osmomath.Dec
+		expectPanic             bool
+	}{
+		{
+			name:                    "change",
+			tokenBalanceFixedBefore: osmomath.NewDec(386971117259),
+			tokenBalanceFixedAfter:  osmomath.NewDec(386971331294),
+			tokenWeightFixed:        osmomath.NewDec(536870912000000),
+			tokenBalanceUnknown:     osmomath.NewDec(7773284087995),
+			tokenWeightUnknown:      osmomath.NewDec(536870912000000),
+			expectedResult:          osmomath.MustNewDecFromStr("4299426.663416173517055000"),
+			expectPanic:             false,
+		},
+		{
+			name:                    "no change",
+			tokenBalanceFixedBefore: osmomath.NewDec(100),
+			tokenBalanceFixedAfter:  osmomath.NewDec(100),
+			tokenWeightFixed:        osmomath.NewDec(1),
+			tokenBalanceUnknown:     osmomath.NewDec(100),
+			tokenWeightUnknown:      osmomath.NewDec(1),
+			expectedResult:          osmomath.NewDec(0),
+			expectPanic:             false,
+		},
+		{
+			name:                    "panic on zero weight",
+			tokenBalanceFixedBefore: osmomath.NewDec(100),
+			tokenBalanceFixedAfter:  osmomath.NewDec(90),
+			tokenWeightFixed:        osmomath.NewDecWithPrec(5, 1),
+			tokenBalanceUnknown:     osmomath.NewDec(200),
+			tokenWeightUnknown:      osmomath.NewDec(0), // Should panic
+			expectPanic:             true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc // capture range variable
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.expectPanic {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("expected panic but did not get one")
+					}
+				}()
+			}
+
+			result := solveConstantFunctionInvariant(
+				tc.tokenBalanceFixedBefore,
+				tc.tokenBalanceFixedAfter,
+				tc.tokenWeightFixed,
+				tc.tokenBalanceUnknown,
+				tc.tokenWeightUnknown,
+			)
+
+			if !tc.expectPanic {
+				require.Equal(t, tc.expectedResult.String(), result.String())
+			}
+		})
+	}
+}

--- a/router/usecase/pools/amm_test.go
+++ b/router/usecase/pools/amm_test.go
@@ -47,6 +47,25 @@ func TestSolveConstantFunctionInvariant(t *testing.T) {
 			tokenWeightUnknown:      osmomath.NewDec(0), // Should panic
 			expectPanic:             true,
 		},
+		{
+			name:                    "change",
+			tokenBalanceFixedBefore: osmomath.NewDec(386971117259),
+			tokenBalanceFixedAfter:  osmomath.NewDec(386971331294),
+			tokenWeightFixed:        osmomath.NewDec(536870912000000),
+			tokenBalanceUnknown:     osmomath.NewDec(7773284087995),
+			tokenWeightUnknown:      osmomath.NewDec(536870912000000),
+			expectedResult:          osmomath.MustNewDecFromStr("4299426.663416173517055000"),
+			expectPanic:             false,
+		},
+		{
+			name:                    "overflow handling",
+			tokenBalanceFixedBefore: osmomath.MustNewDecFromStr("1000000000000000000000000000000"),
+			tokenBalanceFixedAfter:  osmomath.NewDec(1),
+			tokenWeightFixed:        osmomath.MustNewDecFromStr("1000000000000000000000000000000"),
+			tokenBalanceUnknown:     osmomath.MustNewDecFromStr("1000000000000000000000000000000"),
+			tokenWeightUnknown:      osmomath.NewDec(1),
+			expectPanic:             true,
+		},
 	}
 
 	for _, tc := range tests {

--- a/router/usecase/pools/amm_test.go
+++ b/router/usecase/pools/amm_test.go
@@ -48,16 +48,6 @@ func TestSolveConstantFunctionInvariant(t *testing.T) {
 			expectPanic:             true,
 		},
 		{
-			name:                    "change",
-			tokenBalanceFixedBefore: osmomath.NewDec(386971117259),
-			tokenBalanceFixedAfter:  osmomath.NewDec(386971331294),
-			tokenWeightFixed:        osmomath.NewDec(536870912000000),
-			tokenBalanceUnknown:     osmomath.NewDec(7773284087995),
-			tokenWeightUnknown:      osmomath.NewDec(536870912000000),
-			expectedResult:          osmomath.MustNewDecFromStr("4299426.663416173517055000"),
-			expectPanic:             false,
-		},
-		{
 			name:                    "overflow handling",
 			tokenBalanceFixedBefore: osmomath.MustNewDecFromStr("1000000000000000000000000000000"),
 			tokenBalanceFixedAfter:  osmomath.NewDec(1),

--- a/router/usecase/pools/constants.go
+++ b/router/usecase/pools/constants.go
@@ -1,0 +1,7 @@
+package pools
+
+import (
+	"github.com/osmosis-labs/osmosis/osmomath"
+)
+
+var oneDec = osmomath.OneDec()

--- a/router/usecase/pools/routable_balancer_pool.go
+++ b/router/usecase/pools/routable_balancer_pool.go
@@ -30,8 +30,17 @@ type routableBalancerPoolImpl struct {
 type PoolAsset = balancer.PoolAsset
 
 // CalculateTokenOutByTokenIn implements RoutablePool.
-func (p *routableBalancerPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
-	tokenOut, err := p.CalcOutAmtGivenIn(sdk.Context{}.WithContext(ctx), sdk.Coins{tokenIn}, p.TokenOutDenom, p.GetSpreadFactor())
+func (p *routableBalancerPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (tokenOut sdk.Coin, err error) {
+	defer func() {
+		if perr := recover(); perr != nil {
+			// If the invariant calculation fails, we try to use the chain pool's implementation.
+			// That usually means that the invariant calculation panicked due to an overflow.
+			tokenOut, err = p.ChainPool.CalcOutAmtGivenIn(sdk.Context{}.WithContext(ctx), sdk.Coins{tokenIn}, p.TokenOutDenom, p.GetSpreadFactor())
+		}
+	}()
+
+	// Attempt to calculate the token out amount using local implementation.
+	tokenOut, err = p.CalcOutAmtGivenIn(sdk.Context{}.WithContext(ctx), sdk.Coins{tokenIn}, p.TokenOutDenom, p.GetSpreadFactor())
 	if err != nil {
 		return sdk.Coin{}, err
 	}

--- a/router/usecase/pools/routable_balancer_pool.go
+++ b/router/usecase/pools/routable_balancer_pool.go
@@ -2,18 +2,20 @@ package pools
 
 import (
 	"context"
+	"errors"
 	"fmt"
-
-	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
 
+	"github.com/osmosis-labs/osmosis/v28/x/gamm/pool-models/balancer"
+	"github.com/osmosis-labs/osmosis/v28/x/gamm/types"
 	"github.com/osmosis-labs/osmosis/v28/x/poolmanager"
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v28/x/poolmanager/types"
 
-	"github.com/osmosis-labs/osmosis/v28/x/gamm/pool-models/balancer"
+	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var _ domain.RoutablePool = &routableBalancerPoolImpl{}
@@ -25,9 +27,11 @@ type routableBalancerPoolImpl struct {
 	TakerFee      osmomath.Dec   `json:"taker_fee"`
 }
 
+type PoolAsset = balancer.PoolAsset
+
 // CalculateTokenOutByTokenIn implements RoutablePool.
-func (r *routableBalancerPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
-	tokenOut, err := r.ChainPool.CalcOutAmtGivenIn(sdk.Context{}.WithContext(ctx), sdk.Coins{tokenIn}, r.TokenOutDenom, r.GetSpreadFactor())
+func (p *routableBalancerPoolImpl) CalculateTokenOutByTokenIn(ctx context.Context, tokenIn sdk.Coin) (sdk.Coin, error) {
+	tokenOut, err := p.CalcOutAmtGivenIn(sdk.Context{}.WithContext(ctx), sdk.Coins{tokenIn}, p.TokenOutDenom, p.GetSpreadFactor())
 	if err != nil {
 		return sdk.Coin{}, err
 	}
@@ -35,9 +39,82 @@ func (r *routableBalancerPoolImpl) CalculateTokenOutByTokenIn(ctx context.Contex
 	return tokenOut, nil
 }
 
+// CalcOutAmtGivenIn calculates tokens to be swapped out given the provided
+// amount and fee deducted, using solveConstantFunctionInvariant.
+func (p *routableBalancerPoolImpl) CalcOutAmtGivenIn(
+	ctx sdk.Context,
+	tokensIn sdk.Coins,
+	tokenOutDenom string,
+	spreadFactor osmomath.Dec,
+) (sdk.Coin, error) {
+	tokenIn, poolAssetIn, poolAssetOut, err := p.parsePoolAssets(tokensIn, tokenOutDenom)
+	if err != nil {
+		return sdk.Coin{}, err
+	}
+
+	tokenAmountInAfterFee := tokenIn.Amount.ToLegacyDec().MulMut(oneDec.Sub(spreadFactor))
+	poolTokenInBalance := poolAssetIn.Token.Amount.ToLegacyDec()
+	poolPostSwapInBalance := tokenAmountInAfterFee.AddMut(poolTokenInBalance)
+
+	// deduct spread factor on the tokensIn
+	// delta balanceOut is positive(tokens inside the pool decreases)
+	tokenAmountOut := solveConstantFunctionInvariant(
+		poolTokenInBalance,
+		poolPostSwapInBalance,
+		poolAssetIn.Weight.ToLegacyDec(),
+		poolAssetOut.Token.Amount.ToLegacyDec(),
+		poolAssetOut.Weight.ToLegacyDec(),
+	)
+
+	// We ignore the decimal component, as we round down the token amount out.
+	tokenAmountOutInt := tokenAmountOut.TruncateInt()
+	if !tokenAmountOutInt.IsPositive() {
+		return sdk.Coin{}, errorsmod.Wrapf(types.ErrInvalidMathApprox, "token amount must be positive")
+	}
+
+	return sdk.NewCoin(tokenOutDenom, tokenAmountOutInt), nil
+}
+
+func (p *routableBalancerPoolImpl) parsePoolAssetsByDenoms(tokenADenom, tokenBDenom string) (
+	Aasset PoolAsset, Basset PoolAsset, err error,
+) {
+	Aasset, found1 := getPoolAssetByDenom(p.ChainPool.PoolAssets, tokenADenom)
+	Basset, found2 := getPoolAssetByDenom(p.ChainPool.PoolAssets, tokenBDenom)
+
+	if !found1 {
+		return PoolAsset{}, PoolAsset{}, fmt.Errorf("(%s) does not exist in the pool", tokenADenom)
+	}
+	if !found2 {
+		return PoolAsset{}, PoolAsset{}, fmt.Errorf("(%s) does not exist in the pool", tokenBDenom)
+	}
+	return Aasset, Basset, nil
+}
+
+func getPoolAssetByDenom(assets []PoolAsset, denom string) (PoolAsset, bool) {
+	for _, asset := range assets {
+		if asset.Token.Denom == denom {
+			return asset, true
+		}
+	}
+	return PoolAsset{}, false
+}
+
+func (p *routableBalancerPoolImpl) parsePoolAssets(tokensA sdk.Coins, tokenBDenom string) (
+	tokenA sdk.Coin, Aasset PoolAsset, Basset PoolAsset, err error,
+) {
+	if len(tokensA) != 1 {
+		return tokenA, Aasset, Basset, errors.New("expected tokensB to be of length one")
+	}
+	Aasset, Basset, err = p.parsePoolAssetsByDenoms(tokensA[0].Denom, tokenBDenom)
+	if err != nil {
+		return sdk.Coin{}, PoolAsset{}, PoolAsset{}, err
+	}
+	return tokensA[0], Aasset, Basset, nil
+}
+
 // CalculateTokenInByTokenOut implements RoutablePool.
-func (r *routableBalancerPoolImpl) CalculateTokenInByTokenOut(ctx context.Context, tokenOut sdk.Coin) (sdk.Coin, error) {
-	tokenIn, err := r.ChainPool.CalcInAmtGivenOut(sdk.Context{}.WithContext(ctx), sdk.Coins{tokenOut}, r.TokenInDenom, r.GetSpreadFactor())
+func (p *routableBalancerPoolImpl) CalculateTokenInByTokenOut(ctx context.Context, tokenOut sdk.Coin) (sdk.Coin, error) {
+	tokenIn, err := p.ChainPool.CalcInAmtGivenOut(sdk.Context{}.WithContext(ctx), sdk.Coins{tokenOut}, p.TokenInDenom, p.GetSpreadFactor())
 	if err != nil {
 		return sdk.Coin{}, err
 	}
@@ -46,62 +123,62 @@ func (r *routableBalancerPoolImpl) CalculateTokenInByTokenOut(ctx context.Contex
 }
 
 // GetTokenOutDenom implements RoutablePool.
-func (r *routableBalancerPoolImpl) GetTokenOutDenom() string {
-	return r.TokenOutDenom
+func (p *routableBalancerPoolImpl) GetTokenOutDenom() string {
+	return p.TokenOutDenom
 }
 
 // GetTokenInDenom implements RoutablePool.
-func (r *routableBalancerPoolImpl) GetTokenInDenom() string {
-	return r.TokenInDenom
+func (p *routableBalancerPoolImpl) GetTokenInDenom() string {
+	return p.TokenInDenom
 }
 
 // String implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) String() string {
-	return fmt.Sprintf("pool (%d), pool type (%d), pool denoms (%v), token out (%s)", r.ChainPool.Id, poolmanagertypes.Balancer, r.ChainPool.GetPoolDenoms(sdk.Context{}), r.TokenOutDenom)
+func (p *routableBalancerPoolImpl) String() string {
+	return fmt.Sprintf("pool (%d), pool type (%d), pool denoms (%v), token out (%s)", p.ChainPool.Id, poolmanagertypes.Balancer, p.ChainPool.GetPoolDenoms(sdk.Context{}), p.TokenOutDenom)
 }
 
 // ChargeTakerFee implements domain.RoutablePool.
 // Charges the taker fee for the given token in and returns the token in after the fee has been charged.
-func (r *routableBalancerPoolImpl) ChargeTakerFeeExactIn(tokenIn sdk.Coin) (tokenInAfterFee sdk.Coin) {
-	tokenInAfterTakerFee, _ := poolmanager.CalcTakerFeeExactIn(tokenIn, r.TakerFee)
+func (p *routableBalancerPoolImpl) ChargeTakerFeeExactIn(tokenIn sdk.Coin) (tokenInAfterFee sdk.Coin) {
+	tokenInAfterTakerFee, _ := poolmanager.CalcTakerFeeExactIn(tokenIn, p.TakerFee)
 	return tokenInAfterTakerFee
 }
 
 // ChargeTakerFee implements domain.RoutablePool.
 // Charges the taker fee for the given token out and returns the token out after the fee has been charged.
-func (r *routableBalancerPoolImpl) ChargeTakerFeeExactOut(tokenIn sdk.Coin) (tokenInAfterFee sdk.Coin) {
-	tokenInAfterTakerFee, _ := poolmanager.CalcTakerFeeExactOut(tokenIn, r.TakerFee)
+func (p *routableBalancerPoolImpl) ChargeTakerFeeExactOut(tokenIn sdk.Coin) (tokenInAfterFee sdk.Coin) {
+	tokenInAfterTakerFee, _ := poolmanager.CalcTakerFeeExactOut(tokenIn, p.TakerFee)
 	return tokenInAfterTakerFee
 }
 
 // GetTakerFee implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) GetTakerFee() math.LegacyDec {
-	return r.TakerFee
+func (p *routableBalancerPoolImpl) GetTakerFee() math.LegacyDec {
+	return p.TakerFee
 }
 
 // SetTokenInDenom implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) SetTokenInDenom(tokenInDenom string) {
-	r.TokenInDenom = tokenInDenom
+func (p *routableBalancerPoolImpl) SetTokenInDenom(tokenInDenom string) {
+	p.TokenInDenom = tokenInDenom
 }
 
 // SetTokenOutDenom implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) SetTokenOutDenom(tokenOutDenom string) {
-	r.TokenOutDenom = tokenOutDenom
+func (p *routableBalancerPoolImpl) SetTokenOutDenom(tokenOutDenom string) {
+	p.TokenOutDenom = tokenOutDenom
 }
 
 // GetSpreadFactor implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) GetSpreadFactor() math.LegacyDec {
-	return r.ChainPool.GetSpreadFactor(sdk.Context{})
+func (p *routableBalancerPoolImpl) GetSpreadFactor() math.LegacyDec {
+	return p.ChainPool.GetSpreadFactor(sdk.Context{})
 }
 
 // GetId implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) GetId() uint64 {
-	return r.ChainPool.Id
+func (p *routableBalancerPoolImpl) GetId() uint64 {
+	return p.ChainPool.Id
 }
 
 // GetPoolDenoms implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) GetPoolDenoms() []string {
-	return r.ChainPool.GetPoolDenoms(sdk.Context{})
+func (p *routableBalancerPoolImpl) GetPoolDenoms() []string {
+	return p.ChainPool.GetPoolDenoms(sdk.Context{})
 }
 
 // GetType implements domain.RoutablePool.
@@ -110,8 +187,8 @@ func (*routableBalancerPoolImpl) GetType() poolmanagertypes.PoolType {
 }
 
 // CalcSpotPrice implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
-	spotPrice, err := r.ChainPool.SpotPrice(sdk.Context{}.WithContext(ctx), quoteDenom, baseDenom)
+func (p *routableBalancerPoolImpl) CalcSpotPrice(ctx context.Context, baseDenom string, quoteDenom string) (osmomath.BigDec, error) {
+	spotPrice, err := p.ChainPool.SpotPrice(sdk.Context{}.WithContext(ctx), quoteDenom, baseDenom)
 	if err != nil {
 		return osmomath.BigDec{}, err
 	}
@@ -124,6 +201,6 @@ func (*routableBalancerPoolImpl) GetSQSType() domain.SQSPoolType {
 }
 
 // GetCodeID implements domain.RoutablePool.
-func (r *routableBalancerPoolImpl) GetCodeID() uint64 {
+func (p *routableBalancerPoolImpl) GetCodeID() uint64 {
 	return notCosmWasmPoolCodeID
 }


### PR DESCRIPTION
This PR optimizes expensive `osmomath.Pow` call in `CalculateTokenOutByTokenIn` method of the balancer pool by substitution of std math package.

Previous:

```
cpu: AMD Ryzen 7 5700X3D 8-Core Processor
BenchmarkSolveConstantFunctionInvariant
BenchmarkSolveConstantFunctionInvariant-16        659817              1543 ns/op
PASS
ok      github.com/osmosis-labs/sqs/router/usecase/pools        6.586s
````

New:

```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/router/usecase/pools
cpu: AMD Ryzen 7 5700X3D 8-Core Processor
BenchmarkSolveConstantFunctionInvariant
BenchmarkSolveConstantFunctionInvariant-16        450052              2645 ns/op
PASS
ok      github.com/osmosis-labs/sqs/router/usecase/pools        8.177s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added a precise calculation for token output amounts in Automated Market Maker (AMM) pools.
- **Refactor**
  - Enhanced internal handling of pool asset calculations with improved error recovery.
  - Standardized method naming for better code consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->