### PR TITLE
BE-748 | Migrate from big.Float to float64 for balancer pools

### DIFF
--- a/domain/types/coin.go
+++ b/domain/types/coin.go
@@ -1,17 +1,14 @@
 package types
 
-import (
-	"math/big"
-
-	"github.com/osmosis-labs/osmosis/osmomath"
-)
+import "github.com/osmosis-labs/osmosis/osmomath"
 
 // NewCoin returns a new coin with a denomination and amount.
 func NewCoin(denom string, amount osmomath.Int) Coin {
+	amountFloat, _ := amount.BigInt().Float64()
 	return Coin{
 		Denom:       denom,
 		AmountInt:   amount,
-		AmountFloat: *new(big.Float).SetInt(amount.BigInt()),
+		AmountFloat: amountFloat,
 	}
 }
 
@@ -22,5 +19,5 @@ type Coins []Coin
 type Coin struct {
 	Denom       string
 	AmountInt   osmomath.Int
-	AmountFloat big.Float
+	AmountFloat float64
 }

--- a/router/usecase/pools/balancer/amm.go
+++ b/router/usecase/pools/balancer/amm.go
@@ -1,9 +1,7 @@
 package balancer
 
 import (
-	"math/big"
-
-	"github.com/ALTree/bigfloat"
+	"math"
 )
 
 // solveConstantFunctionInvariant solves the constant function of an AMM
@@ -21,25 +19,24 @@ func solveConstantFunctionInvariant(
 	tokenBalanceFixedAfter,
 	tokenWeightFixed,
 	tokenBalanceUnknownBefore,
-	tokenWeightUnknown *big.Float,
-) *big.Float {
-	// weightRatio = (weightX/weightY)
-	weightRatio := new(big.Float).Quo(tokenWeightFixed, tokenWeightUnknown)
-	if weightRatio.IsInf() || weightRatio.Cmp(big.NewFloat(0)) == 0 {
+	tokenWeightUnknown float64,
+) float64 {
+	weightRatio := tokenWeightFixed / tokenWeightUnknown
+	if math.IsInf(weightRatio, 0) || weightRatio == 0 {
 		panic("weight ratio is zero or overflow")
 	}
 
 	// y = balanceXBefore/balanceXAfter
-	y := new(big.Float).Quo(tokenBalanceFixedBefore, tokenBalanceFixedAfter)
+	y := tokenBalanceFixedBefore / tokenBalanceFixedAfter
 
 	// amountY = balanceY * (1 - (y ^ weightRatio))
-	yWeightRatio := bigfloat.Pow(y, weightRatio)
-	if yWeightRatio.IsInf() {
+	yWeightRatio := math.Pow(y, weightRatio)
+	if math.IsInf(yWeightRatio, 0) {
 		panic("yWeightRatio overflow")
 	}
 
-	paranthetical := new(big.Float).Sub(oneDec, yWeightRatio)
-	amountY := new(big.Float).Mul(paranthetical, tokenBalanceUnknownBefore)
+	paranthetical := oneDec - yWeightRatio
+	amountY := paranthetical * tokenBalanceUnknownBefore
 
 	return amountY
 }

--- a/router/usecase/pools/balancer/amm_test.go
+++ b/router/usecase/pools/balancer/amm_test.go
@@ -1,67 +1,58 @@
 package balancer
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-func mustBigFloat(s string) *big.Float {
-	f, _, err := big.ParseFloat(s, 10, 256, big.ToNearestEven)
-	if err != nil {
-		panic(err)
-	}
-	return f
-}
-
 func TestSolveConstantFunctionInvariant(t *testing.T) {
 	tests := []struct {
 		name                    string
-		tokenBalanceFixedBefore *big.Float
-		tokenBalanceFixedAfter  *big.Float
-		tokenWeightFixed        *big.Float
-		tokenBalanceUnknown     *big.Float
-		tokenWeightUnknown      *big.Float
-		expectedResult          *big.Float
+		tokenBalanceFixedBefore float64
+		tokenBalanceFixedAfter  float64
+		tokenWeightFixed        float64
+		tokenBalanceUnknown     float64
+		tokenWeightUnknown      float64
+		expectedResult          float64
 		expectPanic             bool
 	}{
 		{
 			name:                    "change",
-			tokenBalanceFixedBefore: mustBigFloat("386971117259"),
-			tokenBalanceFixedAfter:  mustBigFloat("386971331294"),
-			tokenWeightFixed:        mustBigFloat("536870912000000"),
-			tokenBalanceUnknown:     mustBigFloat("7773284087995"),
-			tokenWeightUnknown:      mustBigFloat("536870912000000"),
-			expectedResult:          mustBigFloat("4299426.663496108929920041"),
+			tokenBalanceFixedBefore: 386971117259,
+			tokenBalanceFixedAfter:  386971331294,
+			tokenWeightFixed:        536870912000000,
+			tokenBalanceUnknown:     7773284087995,
+			tokenWeightUnknown:      536870912000000,
+			expectedResult:          4299426.663496108929920041,
 			expectPanic:             false,
 		},
 		{
 			name:                    "no change",
-			tokenBalanceFixedBefore: mustBigFloat("100"),
-			tokenBalanceFixedAfter:  mustBigFloat("100"),
-			tokenWeightFixed:        mustBigFloat("1"),
-			tokenBalanceUnknown:     mustBigFloat("100"),
-			tokenWeightUnknown:      mustBigFloat("1"),
-			expectedResult:          mustBigFloat("0"),
+			tokenBalanceFixedBefore: 100,
+			tokenBalanceFixedAfter:  100,
+			tokenWeightFixed:        1,
+			tokenBalanceUnknown:     100,
+			tokenWeightUnknown:      1,
+			expectedResult:          0,
 			expectPanic:             false,
 		},
 		{
 			name:                    "panic on zero weight",
-			tokenBalanceFixedBefore: mustBigFloat("100"),
-			tokenBalanceFixedAfter:  mustBigFloat("90"),
-			tokenWeightFixed:        mustBigFloat("0.5"),
-			tokenBalanceUnknown:     mustBigFloat("200"),
-			tokenWeightUnknown:      mustBigFloat("0"),
+			tokenBalanceFixedBefore: 100,
+			tokenBalanceFixedAfter:  90,
+			tokenWeightFixed:        0.5,
+			tokenBalanceUnknown:     200,
+			tokenWeightUnknown:      0,
 			expectPanic:             true,
 		},
 		{
 			name:                    "overflow handling",
-			tokenBalanceFixedBefore: mustBigFloat("1000000000000000000000000000000"),
-			tokenBalanceFixedAfter:  mustBigFloat("1"),
-			tokenWeightFixed:        mustBigFloat("1000000000000000000000000000000"),
-			tokenBalanceUnknown:     mustBigFloat("1000000000000000000000000000000"),
-			tokenWeightUnknown:      mustBigFloat("1"),
+			tokenBalanceFixedBefore: 1000000000000000000000000000000,
+			tokenBalanceFixedAfter:  1,
+			tokenWeightFixed:        1000000000000000000000000000000,
+			tokenBalanceUnknown:     1000000000000000000000000000000,
+			tokenWeightUnknown:      1,
 			expectPanic:             true,
 		},
 	}
@@ -85,7 +76,7 @@ func TestSolveConstantFunctionInvariant(t *testing.T) {
 			)
 
 			if !tc.expectPanic {
-				require.Equal(t, tc.expectedResult.String(), result.String())
+				require.InDelta(t, tc.expectedResult, result, 0.001) // Allow small floating point errors
 			}
 		})
 	}
@@ -94,11 +85,11 @@ func TestSolveConstantFunctionInvariant(t *testing.T) {
 func BenchmarkSolveConstantFunctionInvariant(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		solveConstantFunctionInvariant(
-			big.NewFloat(386971117259),
-			big.NewFloat(386971331294),
-			big.NewFloat(536870912000000),
-			big.NewFloat(7773284087995),
-			big.NewFloat(536870912000000),
+			386971117259,
+			386971331294,
+			536870912000000,
+			7773284087995,
+			536870912000000,
 		)
 	}
 }

--- a/router/usecase/pools/balancer/constants.go
+++ b/router/usecase/pools/balancer/constants.go
@@ -1,5 +1,3 @@
 package balancer
 
-import "math/big"
-
-var oneDec = big.NewFloat(1)
+const oneDec = 1.0

--- a/router/usecase/pools/balancer/pool.go
+++ b/router/usecase/pools/balancer/pool.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/big"
 
 	"github.com/osmosis-labs/osmosis/osmomath"
 	"github.com/osmosis-labs/sqs/domain"
@@ -35,20 +34,21 @@ func New(p poolmanagertypes.PoolI, tokenInDenom string, tokenOutDenom string, ta
 
 	var assets []PoolAsset
 	for _, asset := range pool.PoolAssets {
+		weightFloat, _ := asset.Weight.BigInt().Float64()
 		assets = append(assets, PoolAsset{
 			Token:  sqssdk.NewCoin(asset.Token.Denom, asset.Token.Amount),
-			Weight: new(big.Float).SetInt(asset.Weight.BigInt()),
+			Weight: weightFloat,
 		})
 	}
 
-	swapFee, ok := new(big.Float).SetString(pool.PoolParams.SwapFee.String())
-	if !ok {
-		panic("failed to parse swap fee")
+	swapFee, err := pool.PoolParams.SwapFee.Float64()
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse swap fee: %v", err))
 	}
 
-	exitFee, ok := new(big.Float).SetString(pool.PoolParams.ExitFee.String())
-	if !ok {
-		panic("failed to parse exit fee")
+	exitFee, err := pool.PoolParams.ExitFee.Float64()
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse exit fee: %v", err))
 	}
 
 	return &Pool{
@@ -69,11 +69,11 @@ func New(p poolmanagertypes.PoolI, tokenInDenom string, tokenOutDenom string, ta
 // governance. Instead they will be managed by the token holders of the pool.
 // The pool's token holders are specified in future_pool_governor.
 type PoolParams struct {
-	SwapFee *big.Float
+	SwapFee float64
 	// N.B.: exit fee is disabled during pool creation in x/poolmanager. While old
 	// pools can maintain a non-zero fee. No new pool can be created with non-zero
 	// fee anymore
-	ExitFee *big.Float
+	ExitFee float64
 }
 
 // Pool asset is an internal struct that combines the amount of the
@@ -85,7 +85,7 @@ type PoolAsset struct {
 	// the denomination must be unique amongst all PoolAssets for this pool.
 	Token sqssdk.Coin
 	// Weight that is not normalized. This weight must be less than 2^50
-	Weight *big.Float
+	Weight float64
 }
 
 // Pool is a wrapper around the balancer pool model.
@@ -114,18 +114,18 @@ func (p *Pool) CalcOutAmtGivenIn(
 	ctx sdk.Context,
 	tokensIn sdk.Coins,
 	tokenOutDenom string,
-	spreadFactor *big.Float,
+	spreadFactor float64,
 ) (sdk.Coin, error) {
 	tokenIn, poolAssetIn, poolAssetOut, err := p.parsePoolAssets(tokensIn, tokenOutDenom)
 	if err != nil {
 		return sdk.Coin{}, err
 	}
 
-	minusSpread := new(big.Float).Sub(oneDec, spreadFactor)
-	tokenInBFloat := new(big.Float).SetInt(tokenIn.Amount.BigInt())
-	tokenAmountInAfterFee := new(big.Float).Mul(tokenInBFloat, minusSpread)
-	poolTokenInBalance := &poolAssetIn.Token.AmountFloat
-	poolPostSwapInBalance := new(big.Float).Add(tokenAmountInAfterFee, poolTokenInBalance)
+	minusSpread := oneDec - spreadFactor
+	tokenInFloat, _ := tokenIn.Amount.BigInt().Float64()
+	tokenAmountInAfterFee := tokenInFloat * minusSpread
+	poolTokenInBalance := poolAssetIn.Token.AmountFloat
+	poolPostSwapInBalance := tokenAmountInAfterFee + poolTokenInBalance
 
 	// deduct spread factor on the tokensIn
 	// delta balanceOut is positive(tokens inside the pool decreases)
@@ -133,19 +133,18 @@ func (p *Pool) CalcOutAmtGivenIn(
 		poolTokenInBalance,
 		poolPostSwapInBalance,
 		poolAssetIn.Weight,
-		&poolAssetOut.Token.AmountFloat,
+		poolAssetOut.Token.AmountFloat,
 		poolAssetOut.Weight,
 	)
 
 	// We ignore the decimal component, as we round down the token amount out.
-	if tokenAmountOut.Sign() < 0 {
+	if tokenAmountOut < 0 {
 		return sdk.Coin{}, errorsmod.Wrapf(types.ErrInvalidMathApprox, "token amount must be positive")
 	}
 
-	bigInt := new(big.Int)
-	tokenAmountOut.Int(bigInt) // convert to big int ( truncated )
+	tokenAmountOutTruncated := int64(tokenAmountOut)
 
-	return sdk.Coin{Denom: tokenOutDenom, Amount: osmomath.NewIntFromBigInt(bigInt)}, nil
+	return sdk.Coin{Denom: tokenOutDenom, Amount: osmomath.NewInt(tokenAmountOutTruncated)}, nil
 }
 
 func (p *Pool) parsePoolAssetsByDenoms(tokenADenom, tokenBDenom string) (


### PR DESCRIPTION
This PR migrates from `big.Float` to `float64` for balancer pools. The  `float64` should have 52 bits of precision which should be more than enough and that in turn even further improves computations for balancer pools. Work is based on https://github.com/osmosis-labs/sqs/pull/657.

Previous:

```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/router/usecase/pools/balancer
cpu: AMD Ryzen 7 5700X3D 8-Core Processor
BenchmarkSolveConstantFunctionInvariant
BenchmarkSolveConstantFunctionInvariant-16       2535862               473.4 ns/op
PASS
ok      github.com/osmosis-labs/sqs/router/usecase/pools/balancer       1.752s
```

New:

```
goos: linux
goarch: amd64
pkg: github.com/osmosis-labs/sqs/router/usecase/pools/balancer
cpu: AMD Ryzen 7 5700X3D 8-Core Processor
BenchmarkSolveConstantFunctionInvariant
BenchmarkSolveConstantFunctionInvariant-16      275088930                4.540 ns/op
PASS
ok      github.com/osmosis-labs/sqs/router/usecase/pools/balancer       1.762s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified arithmetic operations throughout the application by transitioning from high-precision number handling to standard floating-point calculations.
  - Improved performance and reduced complexity by replacing specialized numeric libraries with native floating-point types.
- **Bug Fixes**
  - Enhanced error handling for numeric parsing and calculations, reducing the risk of unexpected failures during operations involving pool parameters and token amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->