### PR TITLE
BE-749 | Fix pricing computation latency regression

### DIFF
--- a/domain/pipeline/iterator.go
+++ b/domain/pipeline/iterator.go
@@ -2,7 +2,8 @@ package pipeline
 
 import (
 	"fmt"
-	"sync"
+
+	"github.com/osmosis-labs/sqs/domain/sync/atomic"
 )
 
 // Iterator interface defines methods for filtering, sorting, and chunked access
@@ -14,7 +15,7 @@ type Iterator[K, V any] interface {
 }
 
 // NewMapIterator creates an iterator over map data
-func NewSyncMapIterator[K, V any](data *sync.Map, keys []K) *SyncMapIterator[K, V] {
+func NewSyncMapIterator[K comparable, V any](data *atomic.Map[K, V], keys []K) *SyncMapIterator[K, V] {
 	return &SyncMapIterator[K, V]{
 		data:  data,
 		keys:  keys,
@@ -23,8 +24,8 @@ func NewSyncMapIterator[K, V any](data *sync.Map, keys []K) *SyncMapIterator[K, 
 }
 
 // SyncMapIterator is a sample iterator for a map data structure
-type SyncMapIterator[K, V any] struct {
-	data  *sync.Map
+type SyncMapIterator[K comparable, V any] struct {
+	data  *atomic.Map[K, V]
 	keys  []K
 	index int
 }
@@ -35,17 +36,12 @@ func (it *SyncMapIterator[K, V]) Next() (V, error) {
 	if it.HasNext() {
 		key := it.keys[it.index]
 		it.index++
-		mp, ok := it.data.Load(key)
+		mp, ok := it.data.Get(key)
 		if !ok {
 			return *new(V), fmt.Errorf("key %v not found", key)
 		}
 
-		value, ok := mp.(V)
-		if !ok {
-			return *new(V), fmt.Errorf("invalid type assertion for key %v", key)
-		}
-
-		return value, nil
+		return mp, nil
 	}
 
 	return *new(V), fmt.Errorf("no more elements")

--- a/domain/pipeline/iterator_test.go
+++ b/domain/pipeline/iterator_test.go
@@ -2,8 +2,9 @@ package pipeline
 
 import (
 	"fmt"
-	"sync"
 	"testing"
+
+	"github.com/osmosis-labs/sqs/domain/sync/atomic"
 
 	"github.com/stretchr/testify/require"
 )
@@ -64,15 +65,15 @@ func TestSyncMapIteratorNext(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := sync.Map{}
+			m := &atomic.Map[string, testdata]{}
 			var keys []string
 
 			for _, v := range tt.data {
-				m.Store(v.key, v)
+				m.Set(v.key, v)
 				keys = append(keys, v.key)
 			}
 
-			it := NewSyncMapIterator[string, testdata](&m, keys)
+			it := NewSyncMapIterator(m, keys)
 
 			var result []testdata
 			for {
@@ -135,12 +136,12 @@ func TestSyncMapIteratorSetOffset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := sync.Map{}
+			m := &atomic.Map[string, testdata]{}
 			for _, v := range tt.data {
-				m.Store(v.key, v)
+				m.Set(v.key, v)
 			}
 
-			it := NewSyncMapIterator[string, testdata](&m, tt.keys)
+			it := NewSyncMapIterator(m, tt.keys)
 			it.SetOffset(tt.offset)
 
 			var result []testdata
@@ -253,7 +254,7 @@ func TestSyncMapIterator_Reset(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			it := &SyncMapIterator[string, int]{
-				data:  &sync.Map{},
+				data:  &atomic.Map[string, int]{},
 				keys:  tt.keys,
 				index: tt.initialIndex,
 			}

--- a/domain/pipeline/transformer.go
+++ b/domain/pipeline/transformer.go
@@ -2,7 +2,9 @@ package pipeline
 
 import (
 	"sort"
-	"sync"
+	// "sync"
+
+	"github.com/osmosis-labs/sqs/domain/sync/atomic"
 )
 
 // Transformer defines a generic interface for filtering and sorting data.
@@ -13,21 +15,22 @@ type Transformer[K, V any] interface {
 }
 
 // SyncMapTransformer is a generic data transformer for map data
-type SyncMapTransformer[K, V any] struct {
-	data *sync.Map
+type SyncMapTransformer[K comparable, V any] struct {
+	data *atomic.Map[K, V]
 	keys []K
 }
 
 // NewDataTransformer initializes a transformer with raw data.
-func NewSyncMapTransformer[K, V any](m *sync.Map) *SyncMapTransformer[K, V] {
+func NewSyncMapTransformer[K comparable, V any](m *atomic.Map[K, V]) *SyncMapTransformer[K, V] {
 	var keys []K
-	m.Range(func(key, value any) bool {
-		k, ok := key.(K)
-		if ok {
-			keys = append(keys, k)
-		}
-		return true // keep iterating
-	})
+	data, err := m.Load()
+	if err != nil {
+	}
+
+	for key := range data {
+		keys = append(keys, key)
+	}
+
 	return &SyncMapTransformer[K, V]{data: m, keys: keys}
 }
 
@@ -126,15 +129,10 @@ func (dt *SyncMapTransformer[K, V]) Clone() *SyncMapTransformer[K, V] {
 // load returns the value associated with the key.
 // If the key is not found, it returns a zero value of the value type and false.
 func (dt *SyncMapTransformer[K, V]) load(key K) (V, bool) {
-	mv, ok := dt.data.Load(key)
+	mv, ok := dt.data.Get(key)
 	if !ok {
 		return *new(V), false
 	}
 
-	v, ok := mv.(V)
-	if !ok {
-		return *new(V), false
-	}
-
-	return v, true
+	return mv, true
 }

--- a/domain/pipeline/transformer.go
+++ b/domain/pipeline/transformer.go
@@ -2,7 +2,6 @@ package pipeline
 
 import (
 	"sort"
-	// "sync"
 
 	"github.com/osmosis-labs/sqs/domain/sync/atomic"
 )
@@ -24,11 +23,10 @@ type SyncMapTransformer[K comparable, V any] struct {
 func NewSyncMapTransformer[K comparable, V any](m *atomic.Map[K, V]) *SyncMapTransformer[K, V] {
 	var keys []K
 	data, err := m.Load()
-	if err != nil {
-	}
-
-	for key := range data {
-		keys = append(keys, key)
+	if err == nil {
+		for key := range data {
+			keys = append(keys, key)
+		}
 	}
 
 	return &SyncMapTransformer[K, V]{data: m, keys: keys}

--- a/domain/pipeline/transformer_test.go
+++ b/domain/pipeline/transformer_test.go
@@ -2,11 +2,21 @@ package pipeline
 
 import (
 	"slices"
-	"sync"
 	"testing"
+
+	"github.com/osmosis-labs/sqs/domain/sync/atomic"
 
 	"github.com/stretchr/testify/require"
 )
+
+func newMap(data []int) *atomic.Map[int, int] {
+	m := map[int]int{}
+	for k, v := range data {
+		m[k] = v
+	}
+
+	return atomic.NewMap(m)
+}
 
 func TestSyncMapTransformer_Count(t *testing.T) {
 	tests := []struct {
@@ -33,12 +43,8 @@ func TestSyncMapTransformer_Count(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var m sync.Map
-			for k, v := range tt.data {
-				m.Store(k, v)
-			}
-
-			transformer := NewSyncMapTransformer[int, int](&m)
+			m := newMap(tt.data)
+			transformer := NewSyncMapTransformer(m)
 			got := transformer.Count()
 
 			require.Equal(t, tt.expected, got, "Expected count %d, but got %d", tt.expected, got)
@@ -112,17 +118,18 @@ func TestSyncMapTransformerRange(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Construct sync.Map and populate with initial data
-			m := sync.Map{}
+			m := &atomic.Map[string, int]{}
+
 			var keys []string
 
 			for _, v := range tc.initialData {
-				m.Store(v.key, v.value)
+				m.Set(v.key, v.value)
 				keys = append(keys, v.key)
 			}
 
 			// Create transformer, we are not using NewSyncMapTransformer because
 			// we want to keep the keys in a specific order
-			transformer := &SyncMapTransformer[string, int]{data: &m, keys: keys}
+			transformer := &SyncMapTransformer[string, int]{data: m, keys: keys}
 
 			// Collect keys and values during Range
 			var collectedKeys []string
@@ -196,12 +203,8 @@ func TestTransformerFilter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var m sync.Map
-			for k, v := range tt.data {
-				m.Store(k, v)
-			}
-
-			transformer := NewSyncMapTransformer[int, int](&m)
+			m := newMap(tt.data)
+			transformer := NewSyncMapTransformer(m)
 			transformer.Sort(func(a, b int) bool { return a < b }) // Sort the data to ensure the order is consistent
 			transformer.Filter(tt.filter)
 
@@ -240,11 +243,8 @@ func TestMapTransformerSort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var m sync.Map
-			for k, v := range tt.data {
-				m.Store(k, v)
-			}
-			transformer := NewSyncMapTransformer[int, int](&m)
+			m := newMap(tt.data)
+			transformer := NewSyncMapTransformer(m)
 			transformer.Sort(tt.less)
 
 			got := transformer.Data()
@@ -331,17 +331,17 @@ func TestSyncMapTransformerData(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Construct sync.Map and populate with initial data
-			m := sync.Map{}
+			m := &atomic.Map[string, int]{}
 			var keys []string
 
 			for _, v := range tc.initialData {
-				m.Store(v.key, v.value)
+				m.Set(v.key, v.value)
 				keys = append(keys, v.key)
 			}
 
 			// Create transformer, we are not using NewSyncMapTransformer because
 			// we want to keep the keys in a specific order
-			transformer := &SyncMapTransformer[string, int]{data: &m, keys: keys}
+			transformer := &SyncMapTransformer[string, int]{data: m, keys: keys}
 
 			// Collect values
 			collectedValues := transformer.Data()
@@ -397,17 +397,17 @@ func TestSyncMapTransformerClone(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Construct sync.Map and populate with initial data
-			m := sync.Map{}
+			m := &atomic.Map[string, int]{}
 			var keys []string
 
 			for _, v := range tc.initialData {
-				m.Store(v.key, v.value)
+				m.Set(v.key, v.value)
 				keys = append(keys, v.key)
 			}
 
 			// Create transformer, we are not using NewSyncMapTransformer because
 			// we want to keep the keys in a specific order
-			transformer := &SyncMapTransformer[string, int]{data: &m, keys: keys}
+			transformer := &SyncMapTransformer[string, int]{data: m, keys: keys}
 
 			// Clone the transformer
 			clonedTransformer := transformer.Clone()

--- a/domain/sync/atomic/map.go
+++ b/domain/sync/atomic/map.go
@@ -32,7 +32,7 @@ func (m *Map[K, V]) Store(data map[K]V) {
 
 	oldData, ok := m.data.Load().(map[K]V)
 	if !ok {
-		m.data.Store(make(map[K]V))
+		oldData = make(map[K]V)
 	}
 
 	newData := make(map[K]V)
@@ -52,7 +52,7 @@ func (m *Map[K, V]) Set(id K, v V) {
 
 	oldData, ok := m.data.Load().(map[K]V)
 	if !ok {
-		m.data.Store(make(map[K]V))
+		oldData = make(map[K]V)
 	}
 
 	newData := make(map[K]V)

--- a/domain/sync/atomic/map.go
+++ b/domain/sync/atomic/map.go
@@ -7,6 +7,16 @@ import (
 	"sync/atomic"
 )
 
+// NewMap initializes a new Map with the provided data.
+func NewMap[K comparable, V any](data map[K]V) *Map[K, V] {
+	m := &Map[K, V]{}
+	for k, v := range data {
+		m.Set(k, v)
+	}
+	return m
+}
+
+// Map is a thread-safe map that allows concurrent read and write operations.
 type Map[K comparable, V any] struct {
 	data atomic.Value
 	mu   sync.Mutex

--- a/domain/sync/atomic/map.go
+++ b/domain/sync/atomic/map.go
@@ -1,0 +1,77 @@
+package atomic
+
+import (
+	"fmt"
+	"maps"
+	"sync"
+	"sync/atomic"
+)
+
+type Map[K comparable, V any] struct {
+	data atomic.Value
+	mu   sync.Mutex
+}
+
+func (m *Map[K, V]) Store(data map[K]V) {
+	if len(data) == 0 {
+		return // no data to update
+	}
+
+	m.mu.Lock() // for writers
+	defer m.mu.Unlock()
+
+	oldData, ok := m.data.Load().(map[K]V)
+	if !ok {
+		m.data.Store(make(map[K]V))
+	}
+
+	newData := make(map[K]V)
+
+	maps.Copy(newData, oldData)
+
+	for denom, value := range data {
+		newData[denom] = value
+	}
+
+	m.data.Store(newData)
+}
+
+func (m *Map[K, V]) Set(id K, v V) {
+	m.mu.Lock() // for writers
+	defer m.mu.Unlock()
+
+	oldData, ok := m.data.Load().(map[K]V)
+	if !ok {
+		m.data.Store(make(map[K]V))
+	}
+
+	newData := make(map[K]V)
+
+	maps.Copy(newData, oldData)
+
+	newData[id] = v
+
+	m.data.Store(newData)
+}
+
+func (m *Map[K, V]) Load() (map[K]V, error) {
+	data, ok := m.data.Load().(map[K]V)
+	if !ok {
+		return make(map[K]V), fmt.Errorf("failed to cast map data")
+	}
+	return data, nil
+}
+
+func (m *Map[K, V]) Get(key K) (V, bool) {
+	data, ok := m.data.Load().(map[K]V)
+	if !ok {
+		return *new(V), false
+	}
+
+	result, exists := data[key]
+	if !exists {
+		return *new(V), false
+	}
+
+	return result, true
+}

--- a/domain/sync/atomic/map_test.go
+++ b/domain/sync/atomic/map_test.go
@@ -1,0 +1,129 @@
+package atomic
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMap_Set(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  map[string]int
+		input    map[string]int
+		expected map[string]int
+	}{
+		{
+			name:     "Set new values",
+			initial:  map[string]int{},
+			input:    map[string]int{"a": 1, "b": 2},
+			expected: map[string]int{"a": 1, "b": 2},
+		},
+		{
+			name:     "Update existing values",
+			initial:  map[string]int{"a": 1, "b": 2},
+			input:    map[string]int{"b": 3, "c": 4},
+			expected: map[string]int{"a": 1, "b": 3, "c": 4},
+		},
+		{
+			name:     "Set empty map",
+			initial:  map[string]int{"a": 1},
+			input:    map[string]int{},
+			expected: map[string]int{"a": 1},
+		},
+		{
+			name:     "Set nil map",
+			initial:  map[string]int{"a": 1},
+			input:    nil,
+			expected: map[string]int{"a": 1},
+		},
+		{
+			name:     "Set on empty initial map",
+			initial:  nil,
+			input:    map[string]int{"a": 1},
+			expected: map[string]int{"a": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Map[string, int]{}
+			if tt.initial != nil {
+				for key, value := range tt.initial {
+					m.Set(key, value)
+				}
+			}
+
+			for key, value := range tt.input {
+				m.Set(key, value)
+			}
+
+			result, err := m.Load()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("Expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestMap_Get(t *testing.T) {
+	tests := []struct {
+		name     string
+		initial  map[string]int
+		key      string
+		expected int
+		exists   bool
+	}{
+		{
+			name:     "Get existing value",
+			initial:  map[string]int{"a": 1, "b": 2},
+			key:      "a",
+			expected: 1,
+			exists:   true,
+		},
+		{
+			name:     "Get non-existent value",
+			initial:  map[string]int{"a": 1, "b": 2},
+			key:      "c",
+			expected: 0,
+			exists:   false,
+		},
+		{
+			name:     "Get from empty map",
+			initial:  map[string]int{},
+			key:      "a",
+			expected: 0,
+			exists:   false,
+		},
+		{
+			name:     "Get zero value",
+			initial:  map[string]int{"a": 0},
+			key:      "a",
+			expected: 0,
+			exists:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Map[string, int]{}
+
+			for key, value := range tt.initial {
+				m.Set(key, value)
+			}
+
+			result, exists := m.Get(tt.key)
+
+			if exists != tt.exists {
+				t.Errorf("Expected exists = %v, got %v", tt.exists, exists)
+			}
+
+			if result != tt.expected {
+				t.Errorf("Expected value %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -142,11 +142,7 @@ func (p *poolsUseCase) GetAllPools() (pools []ingesttypes.PoolI, err error) {
 	}
 
 	for _, pool := range data {
-		poolI, ok := pool.(ingesttypes.PoolI)
-		if !ok {
-			return nil, fmt.Errorf("failed to cast pool with value %v", pool)
-		}
-		pools = append(pools, poolI)
+		pools = append(pools, pool)
 	}
 
 	return pools, nil
@@ -246,14 +242,9 @@ func (p *poolsUseCase) GetTickModelMap(poolIDs []uint64) (map[uint64]*ingesttype
 
 // GetPool implements mvc.PoolsUsecase.
 func (p *poolsUseCase) GetPool(poolID uint64) (ingesttypes.PoolI, error) {
-	poolObj, ok := p.pools.Get(poolID)
+	pool, ok := p.pools.Get(poolID)
 	if !ok {
 		return nil, domain.PoolNotFoundError{PoolID: poolID}
-	}
-
-	pool, ok := poolObj.(ingesttypes.PoolI)
-	if !ok {
-		return nil, fmt.Errorf("failed to cast pool with ID %d", poolID)
 	}
 
 	return pool, nil
@@ -344,27 +335,27 @@ var getPoolsSortFuncs = map[string]func(a, b ingesttypes.PoolI, desc bool) bool{
 	},
 	"market.feesSpent7dUsd": func(a, b ingesttypes.PoolI, desc bool) bool {
 		if desc {
-			return a.GetFeesData().PoolFee.FeesSpent7d > b.GetFeesData().PoolFee.FeesSpent7d
+			return a.GetFeesData().FeesSpent7d > b.GetFeesData().FeesSpent7d
 		}
-		return a.GetFeesData().PoolFee.FeesSpent7d < b.GetFeesData().PoolFee.FeesSpent7d
+		return a.GetFeesData().FeesSpent7d < b.GetFeesData().FeesSpent7d
 	},
 	"market.feesSpent24hUsd": func(a, b ingesttypes.PoolI, desc bool) bool {
 		if desc {
-			return a.GetFeesData().PoolFee.FeesSpent24h > b.GetFeesData().PoolFee.FeesSpent24h
+			return a.GetFeesData().FeesSpent24h > b.GetFeesData().FeesSpent24h
 		}
-		return a.GetFeesData().PoolFee.FeesSpent24h < b.GetFeesData().PoolFee.FeesSpent24h
+		return a.GetFeesData().FeesSpent24h < b.GetFeesData().FeesSpent24h
 	},
 	"market.volume7dUsd": func(a, b ingesttypes.PoolI, desc bool) bool {
 		if desc {
-			return a.GetFeesData().PoolFee.Volume7d > b.GetFeesData().PoolFee.Volume7d
+			return a.GetFeesData().Volume7d > b.GetFeesData().Volume7d
 		}
-		return a.GetFeesData().PoolFee.Volume7d < b.GetFeesData().PoolFee.Volume7d
+		return a.GetFeesData().Volume7d < b.GetFeesData().Volume7d
 	},
 	"market.volume24hUsd": func(a, b ingesttypes.PoolI, desc bool) bool {
 		if desc {
-			return a.GetFeesData().PoolFee.Volume24h > b.GetFeesData().PoolFee.Volume24h
+			return a.GetFeesData().Volume24h > b.GetFeesData().Volume24h
 		}
-		return a.GetFeesData().PoolFee.Volume24h < b.GetFeesData().PoolFee.Volume24h
+		return a.GetFeesData().Volume24h < b.GetFeesData().Volume24h
 	},
 	"incentives.aprBreakdown.total.upper": func(a, b ingesttypes.PoolI, desc bool) bool {
 		if desc {
@@ -465,7 +456,7 @@ var filterPartialMatchSearch = func(tokenMetadataHolder TokenMetadataHolder, sea
 
 		poolNameByDenom = strings.Join(humanDenoms, "/")
 
-		search = strings.Replace(strings.ToLower(search), " ", "", -1)
+		search = strings.ReplaceAll(strings.ToLower(search), " ", "")
 
 		if strings.Contains(strings.ToLower(poolNameByDenom), search) {
 			return true

--- a/pools/usecase/pools_usecase.go
+++ b/pools/usecase/pools_usecase.go
@@ -16,6 +16,7 @@ import (
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
 	cosmwasmdomain "github.com/osmosis-labs/sqs/domain/cosmwasm"
 	"github.com/osmosis-labs/sqs/domain/pipeline"
+	"github.com/osmosis-labs/sqs/domain/sync/atomic"
 	ingesttypes "github.com/osmosis-labs/sqs/ingest/types"
 	"github.com/osmosis-labs/sqs/log"
 	"github.com/osmosis-labs/sqs/sqsutil/datafetchers"
@@ -54,7 +55,7 @@ type orderBookEntry struct {
 }
 
 type poolsUseCase struct {
-	pools               sync.Map
+	pools               *atomic.Map[uint64, ingesttypes.PoolI]
 	routerRepository    routerrepo.RouterRepository
 	tokenMetadataHolder TokenMetadataHolder
 
@@ -111,7 +112,7 @@ func NewPoolsUsecase(
 	}
 
 	return &poolsUseCase{
-		pools:               sync.Map{},
+		pools:               &atomic.Map[uint64, ingesttypes.PoolI]{},
 		routerRepository:    routerRepository,
 		tokenMetadataHolder: tokenMetadataHolder,
 
@@ -135,16 +136,18 @@ func NewPoolsUsecase(
 
 // GetAllPools returns all pools from the repository.
 func (p *poolsUseCase) GetAllPools() (pools []ingesttypes.PoolI, err error) {
-	p.pools.Range(func(key, value interface{}) bool {
-		pool, ok := value.(ingesttypes.PoolI)
-		if !ok {
-			err = fmt.Errorf("failed to cast pool with value %v", value)
-			return false
-		}
+	data, err := p.pools.Load()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load pools: %w", err)
+	}
 
-		pools = append(pools, pool)
-		return true
-	})
+	for _, pool := range data {
+		poolI, ok := pool.(ingesttypes.PoolI)
+		if !ok {
+			return nil, fmt.Errorf("failed to cast pool with value %v", pool)
+		}
+		pools = append(pools, poolI)
+	}
 
 	return pools, nil
 }
@@ -243,7 +246,7 @@ func (p *poolsUseCase) GetTickModelMap(poolIDs []uint64) (map[uint64]*ingesttype
 
 // GetPool implements mvc.PoolsUsecase.
 func (p *poolsUseCase) GetPool(poolID uint64) (ingesttypes.PoolI, error) {
-	poolObj, ok := p.pools.Load(poolID)
+	poolObj, ok := p.pools.Get(poolID)
 	if !ok {
 		return nil, domain.PoolNotFoundError{PoolID: poolID}
 	}
@@ -490,7 +493,7 @@ func (p *poolsUseCase) GetPools(opts ...domain.PoolsOption) ([]ingesttypes.PoolI
 		return nil, 0, nil
 	}
 
-	transformer := pipeline.NewSyncMapTransformer[uint64, ingesttypes.PoolI](&p.pools)
+	transformer := pipeline.NewSyncMapTransformer(p.pools)
 
 	// Apply filters
 	for _, applyFilter := range poolFilters {
@@ -569,7 +572,7 @@ func (p *poolsUseCase) GetPools(opts ...domain.PoolsOption) ([]ingesttypes.PoolI
 	if pagination := options.Pagination; pagination == nil {
 		pools = transformer.Data()
 	} else {
-		iterator := pipeline.NewSyncMapIterator[uint64, ingesttypes.PoolI](&p.pools, transformer.Keys())
+		iterator := pipeline.NewSyncMapIterator(p.pools, transformer.Keys())
 		paginator := pipeline.NewPaginator[uint64](iterator, pagination)
 		pools = paginator.GetPage()
 	}
@@ -592,7 +595,7 @@ func (p *poolsUseCase) StorePools(pools []ingesttypes.PoolI) error {
 			}
 		}
 
-		p.pools.Store(poolID, pool)
+		p.pools.Set(poolID, pool)
 
 		// If orderbook, update top liquidity pool for base and quote denom if it has higher liquidity capitalization.
 		sqsModel := pool.GetSQSPoolModel()


### PR DESCRIPTION
Fixes  pricing computation latency regression introduced in #656 replacing `sync.Map` with Copy On Write map to make  `GetPool`  and  `GetPools` operations non-blocking for readers.

Introduced package will be reused in other related ares with pricing re-computation, for example tokens use case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a generic thread-safe map for improved concurrent data access and management.

- **Refactor**
  - Migrated internal pool storage and related components to use the new atomic map.
  - Simplified sorting logic by flattening fee and volume data access.
  - Enhanced search filter string handling for better accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->