### PR TITLE
BE-738 | Prioritize higher liquidity pools in the routing algorithm

### DIFF
--- a/domain/candidate_routes.go
+++ b/domain/candidate_routes.go
@@ -89,9 +89,23 @@ type CandidatePoolWrapper struct {
 	ID                uint64
 	PoolDenoms        []string
 	PoolLiquidityCap  *atomic.Uint64 // Note: the value is truncated if it is larger than uint64
+	Rating            float64
 	Balances          sdk.Coins
 	IsAlloyTransmuter bool
 	IsOrderbook       bool
+}
+
+
+func NewCandidatePoolWrapperWithRating(id uint64, p osmoingesttypes.SQSPool, rating float64) CandidatePoolWrapper {
+	return CandidatePoolWrapper{
+		ID:                id,
+		PoolDenoms:        p.PoolDenoms,
+		Rating:            rating,
+		PoolLiquidityCap:  sqsatomic.NewUint64(osmomath.SafeUint64(p.PoolLiquidityCap)),
+		Balances:          p.Balances,
+		IsAlloyTransmuter: p.CosmWasmPoolModel != nil && p.CosmWasmPoolModel.IsAlloyTransmuter(),
+		IsOrderbook:       p.CosmWasmPoolModel != nil && p.CosmWasmPoolModel.IsOrderbook(),
+	}
 }
 
 func NewCandidatePoolWrapper(id uint64, p osmoingesttypes.SQSPool) CandidatePoolWrapper {

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -229,9 +229,16 @@ func (p *ingestUseCase) sortAndStorePools(pools []sqsingesttypes.PoolI) {
 
 	sortedPools, _ := routerusecase.ValidateAndSortPools(pools, cosmWasmPoolConfig, routerConfig.PreferredPoolIDs, p.logger)
 
+	result := make([]sqsingesttypes.PoolI, len(sortedPools))
+	// Convert back to pools
+	for i, ratedPool := range sortedPools {
+		pool := ratedPool.Pool
+		result[i] = pool
+	}
+
 	// Sort the pools and store them in the router.
-	p.routerUsecase.SetSortedPools(sortedPools)
-	p.pricingRouterUsecase.SetSortedPools(sortedPools)
+	p.routerUsecase.SetSortedPools(result)
+	p.pricingRouterUsecase.SetSortedPools(result)
 }
 
 // parsePoolData parses the pool data and returns the pool objects.

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"sort"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/domain"
@@ -113,9 +112,9 @@ func (c candidateRouteFinder) FindCandidateRoutesOutGivenIn(ctx context.Context,
 		}
 
 		// Sort the pools by liquidity cap so that pools with higher liquidity cap are processed first
-		sort.Slice(denomData.SortedPools, func(i, j int) bool {
-			return denomData.SortedPools[i].GetPoolLiquidityCap() > denomData.SortedPools[j].GetPoolLiquidityCap()
-		})
+		// sort.Slice(denomData.SortedPools, func(i, j int) bool {
+		// 	return denomData.SortedPools[i].GetPoolLiquidityCap() > denomData.SortedPools[j].GetPoolLiquidityCap()
+		// })
 
 		for i := 0; i < len(denomData.SortedPools) && len(routes) < options.MaxRoutes; i++ {
 			if ok := visited[denomData.SortedPools[i].ID]; ok {

--- a/router/usecase/candidate_routes.go
+++ b/router/usecase/candidate_routes.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"sort"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/osmosis-labs/sqs/domain"
@@ -110,6 +111,11 @@ func (c candidateRouteFinder) FindCandidateRoutesOutGivenIn(ctx context.Context,
 		if len(denomData.SortedPools) == 0 {
 			c.logger.Debug("no pools found for denom in candidate route search", zap.String("denom", currenTokenInDenom))
 		}
+
+		// Sort the pools by liquidity cap so that pools with higher liquidity cap are processed first
+		sort.Slice(denomData.SortedPools, func(i, j int) bool {
+			return denomData.SortedPools[i].GetPoolLiquidityCap() > denomData.SortedPools[j].GetPoolLiquidityCap()
+		})
 
 		for i := 0; i < len(denomData.SortedPools) && len(routes) < options.MaxRoutes; i++ {
 			if ok := visited[denomData.SortedPools[i].ID]; ok {

--- a/router/usecase/router.go
+++ b/router/usecase/router.go
@@ -15,9 +15,9 @@ import (
 	poolmanagertypes "github.com/osmosis-labs/osmosis/v28/x/poolmanager/types"
 )
 
-type ratedPool struct {
-	pool   ingesttypes.PoolI
-	rating float64
+type RatedPool struct {
+	Pool   ingesttypes.PoolI
+	Rating float64
 }
 
 const (
@@ -43,7 +43,7 @@ func FilterPoolsByMinLiquidity(pools []ingesttypes.PoolI, minPoolLiquidityCap ui
 // according to the given configuration.
 // Filters out pools that have no tvl error set and have zero liquidity.
 // As a second return value, it returns the orderbook pools.
-func ValidateAndSortPools(pools []ingesttypes.PoolI, cosmWasmPoolsConfig domain.CosmWasmPoolRouterConfig, preferredPoolIDs []uint64, logger log.Logger) ([]ingesttypes.PoolI, []ingesttypes.PoolI) {
+func ValidateAndSortPools(pools []ingesttypes.PoolI, cosmWasmPoolsConfig domain.CosmWasmPoolRouterConfig, preferredPoolIDs []uint64, logger log.Logger) ([]RatedPool, []ingesttypes.PoolI) {
 	filteredPools := make([]ingesttypes.PoolI, 0, len(pools))
 
 	totalTVL := osmomath.ZeroInt()
@@ -116,11 +116,11 @@ func ValidateAndSortPools(pools []ingesttypes.PoolI, cosmWasmPoolsConfig domain.
 // - Pools with no error in TVL are prioritized by getting an even smaller boost.
 //
 // These heuristics are imperfect and subject to change.
-func sortPools(pools []ingesttypes.PoolI, transmuterCodeIDs map[uint64]struct{}, totalTVL osmomath.Int, preferredPoolIDsMap map[uint64]struct{}, logger log.Logger) []ingesttypes.PoolI {
+func sortPools(pools []ingesttypes.PoolI, transmuterCodeIDs map[uint64]struct{}, totalTVL osmomath.Int, preferredPoolIDsMap map[uint64]struct{}, logger log.Logger) []RatedPool {
 	logger.Debug("total tvl", zap.Stringer("total_tvl", totalTVL))
 	totalTVLFloat, _ := totalTVL.BigIntMut().Float64()
 
-	ratedPools := make([]ratedPool, 0, len(pools))
+	ratedPools := make([]RatedPool, 0, len(pools))
 	for _, pool := range pools {
 		// Initialize rating to TVL.
 		rating, _ := pool.GetPoolLiquidityCap().BigIntMut().Float64()
@@ -170,25 +170,27 @@ func sortPools(pools []ingesttypes.PoolI, transmuterCodeIDs map[uint64]struct{},
 			}
 		}
 
-		ratedPools = append(ratedPools, ratedPool{
-			pool:   pool,
-			rating: rating,
+		ratedPools = append(ratedPools, RatedPool{
+			Pool:   pool,
+			Rating: rating,
 		})
 	}
 
 	// Sort all pools by the rating score
 	sort.Slice(ratedPools, func(i, j int) bool {
-		return ratedPools[i].rating > ratedPools[j].rating
+		return ratedPools[i].Rating > ratedPools[j].Rating
 	})
 
-	logger.Debug("sorted pools", zap.Int("pool_count", len(ratedPools)))
-	// Convert back to pools
-	for i, ratedPool := range ratedPools {
-		pool := ratedPool.pool
+	return ratedPools
 
-		sqsModel := pool.GetSQSPoolModel()
-		logger.Debug("pool", zap.Int("index", i), zap.Any("pool", pool.GetId()), zap.Float64("rate", ratedPool.rating), zap.Stringer("pool_liquidity_cap", sqsModel.PoolLiquidityCap), zap.String("pool_liquidity_cap_error", sqsModel.PoolLiquidityCapError))
-		pools[i] = ratedPool.pool
-	}
-	return pools
+	// logger.Debug("sorted pools", zap.Int("pool_count", len(ratedPools)))
+	// // Convert back to pools
+	// for i, ratedPool := range ratedPools {
+	// 	pool := ratedPool.Pool
+	//
+	// 	sqsModel := pool.GetSQSPoolModel()
+	// 	logger.Debug("pool", zap.Int("index", i), zap.Any("pool", pool.GetId()), zap.Float64("rate", ratedPool.Rating), zap.Stringer("pool_liquidity_cap", sqsModel.PoolLiquidityCap), zap.String("pool_liquidity_cap_error", sqsModel.PoolLiquidityCapError))
+	// 	pools[i] = ratedPool.Pool
+	// }
+	// return pools
 }

--- a/router/usecase/worker/candidate_route_search_data_worker.go
+++ b/router/usecase/worker/candidate_route_search_data_worker.go
@@ -114,9 +114,10 @@ func (c *candidateRouteSearchDataWorker) compute(blockPoolMetaData domain.BlockP
 			mu.Lock()
 			sortedPools := make([]domain.CandidatePoolWrapper, len(sortedDenomPools))
 			for i := range sortedDenomPools {
-				sortedPools[i] = domain.NewCandidatePoolWrapper(
-					sortedDenomPools[i].GetId(),
-					sortedDenomPools[i].GetSQSPoolModel(),
+				sortedPools[i] = domain.NewCandidatePoolWrapperWithRating(
+					sortedDenomPools[i].Pool.GetId(),
+					sortedDenomPools[i].Pool.GetSQSPoolModel(),
+					sortedDenomPools[i].Rating,
 				)
 			}
 			candidateRouteData[denom] = &domain.CandidateRouteDenomData{


### PR DESCRIPTION
This PR adds logic that would sort considered candidates for a quote by liquidity cap to ensure that pools with highest liquidity are considered first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the order in which pools are processed during route discovery by prioritizing those with higher liquidity caps, potentially leading to more optimal route selection for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->