### PR TITLE
BE-752 | Bump max ingest message size

### DIFF
--- a/domain/config.go
+++ b/domain/config.go
@@ -156,7 +156,7 @@ var DefaultConfig = Config{
 	},
 	GRPCIngester: &GRPCIngesterConfig{
 		Enabled:                        true,
-		MaxReceiveMsgSizeBytes:         16777216,
+		MaxReceiveMsgSizeBytes:         20971520, // 20 MB
 		ServerAddress:                  ":50051",
 		ServerConnectionTimeoutSeconds: 10,
 		Plugins: []Plugin{


### PR DESCRIPTION
Bumps maximum ingest message size from 16MB to 20MB as we've reached the limit for current setting:

```
1:17PM ERR sqs_process_block_error err="rpc error: code = ResourceExhausted desc = grpc: received message larger than max (16794678 vs. 16777216)" module=server
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Increased the maximum size for gRPC ingester receive messages from 16 MB to 20 MB in the default configuration. This allows for handling larger messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->