### PR TITLE
BE-755 | Timeout handling connecting to Tendermint

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -9,7 +9,6 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/osmosis-labs/sqs/chaininfo/client"
 	"github.com/osmosis-labs/sqs/domain"
 	sqslog "github.com/osmosis-labs/sqs/log"
 	"github.com/spf13/viper"
@@ -109,18 +108,6 @@ func main() {
 		panic(fmt.Errorf("error while creating logger: %s", err))
 	}
 	logger.Info("Starting sidecar query server")
-
-	chainClient, err := client.NewClient(config.ChainID, config.ChainTendermintRPCEndpoint)
-	if err != nil {
-		panic(err)
-	}
-
-	if _, err := chainClient.GetLatestHeight(ctx); err != nil {
-		if !config.SkipChainAvailabilityCheck {
-			panic(err)
-		}
-		logger.Error("Error getting latest height from chain client", zap.Error(err))
-	}
 
 	encCfg := app.MakeEncodingConfig()
 	sidecarQueryServer, err := NewSideCarQueryServer(ctx, encCfg.Marshaler, *config, logger)

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -28,6 +28,11 @@ import (
 
 	"github.com/osmosis-labs/osmosis/v28/app"
 	txfeestypes "github.com/osmosis-labs/osmosis/v28/x/txfees/types"
+	chaininfoclient "github.com/osmosis-labs/sqs/chaininfo/client"
+	chaininforepo "github.com/osmosis-labs/sqs/chaininfo/repository"
+	chaininfousecase "github.com/osmosis-labs/sqs/chaininfo/usecase"
+	chainregistryHttpDelivery "github.com/osmosis-labs/sqs/chainregistry/delivery/http"
+	chainregistryUseCase "github.com/osmosis-labs/sqs/chainregistry/usecase"
 	"github.com/osmosis-labs/sqs/domain/cosmos/auth/types"
 	ingestrpcdelivry "github.com/osmosis-labs/sqs/ingest/delivery/grpc"
 	ingestusecase "github.com/osmosis-labs/sqs/ingest/usecase"
@@ -37,19 +42,14 @@ import (
 	orderbookorderscache "github.com/osmosis-labs/sqs/ingest/usecase/plugins/orderbook/orderscache"
 	orderbookrepository "github.com/osmosis-labs/sqs/orderbook/repository"
 	orderbookusecase "github.com/osmosis-labs/sqs/orderbook/usecase"
-	"github.com/osmosis-labs/sqs/quotesimulator"
-	"github.com/osmosis-labs/sqs/sqsutil/datafetchers"
-
-	chaininforepo "github.com/osmosis-labs/sqs/chaininfo/repository"
-	chaininfousecase "github.com/osmosis-labs/sqs/chaininfo/usecase"
-	chainregistryHttpDelivery "github.com/osmosis-labs/sqs/chainregistry/delivery/http"
-	chainregistryUseCase "github.com/osmosis-labs/sqs/chainregistry/usecase"
 	passthroughHttpDelivery "github.com/osmosis-labs/sqs/passthrough/delivery/http"
 	passthroughUseCase "github.com/osmosis-labs/sqs/passthrough/usecase"
 	poolsHttpDelivery "github.com/osmosis-labs/sqs/pools/delivery/http"
 	poolsUseCase "github.com/osmosis-labs/sqs/pools/usecase"
+	"github.com/osmosis-labs/sqs/quotesimulator"
 	routerrepo "github.com/osmosis-labs/sqs/router/repository"
 	routerWorker "github.com/osmosis-labs/sqs/router/usecase/worker"
+	"github.com/osmosis-labs/sqs/sqsutil/datafetchers"
 	tokenshttpdelivery "github.com/osmosis-labs/sqs/tokens/delivery/http"
 	tokensusecase "github.com/osmosis-labs/sqs/tokens/usecase"
 	"github.com/osmosis-labs/sqs/tokens/usecase/pricing"
@@ -125,6 +125,25 @@ func NewSideCarQueryServer(ctx context.Context, appCodec codec.Codec, config dom
 	e.Use(middleware.InstrumentMiddleware)
 	e.Use(otelecho.Middleware("sqs"), middleware.TraceWithParamsMiddleware())
 
+	chainClient, err := chaininfoclient.NewClient(ctx, config.ChainID, config.ChainTendermintRPCEndpoint, config.ChainTendermintRPCEndpointTimeout)
+	if err != nil {
+		if !config.SkipChainAvailabilityCheck {
+			panic(err)
+		}
+		logger.Error("Error connecting to the chain", zap.Error(err))
+	}
+
+	if _, err := chainClient.GetLatestHeight(ctx); err != nil {
+		if !config.SkipChainAvailabilityCheck {
+			panic(err)
+		}
+		logger.Error("Error getting latest height from chain client", zap.Error(err))
+	}
+
+	// Initialize system handler
+	chainInfoRepository := chaininforepo.New()
+	chainInfoUseCase := chaininfousecase.NewChainInfoUsecase(chainInfoRepository, chainClient)
+
 	routerRepository := routerrepo.New(logger)
 
 	// Compute token metadata from chain denom.
@@ -185,10 +204,6 @@ func NewSideCarQueryServer(ctx context.Context, appCodec codec.Codec, config dom
 			panic(fmt.Errorf("failed to load router state files: %w", err))
 		}
 	}
-
-	// Initialize system handler
-	chainInfoRepository := chaininforepo.New()
-	chainInfoUseCase := chaininfousecase.NewChainInfoUsecase(chainInfoRepository)
 
 	cosmWasmPoolConfig := poolsUseCase.GetCosmWasmPoolConfig()
 

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -133,11 +133,13 @@ func NewSideCarQueryServer(ctx context.Context, appCodec codec.Codec, config dom
 		logger.Error("Error connecting to the chain", zap.Error(err))
 	}
 
-	if _, err := chainClient.GetLatestHeight(ctx); err != nil {
-		if !config.SkipChainAvailabilityCheck {
-			panic(err)
+	if chainClient != nil {
+		if _, err := chainClient.GetLatestHeight(ctx); err != nil {
+			if !config.SkipChainAvailabilityCheck {
+				panic(err)
+			}
+			logger.Error("Error getting latest height from chain client", zap.Error(err))
 		}
-		logger.Error("Error getting latest height from chain client", zap.Error(err))
 	}
 
 	// Initialize system handler

--- a/chaininfo/client/chain_client.go
+++ b/chaininfo/client/chain_client.go
@@ -3,27 +3,27 @@ package client
 import (
 	"context"
 
-	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
-	"github.com/cosmos/cosmos-sdk/client"
-
 	clpoolmodel "github.com/osmosis-labs/osmosis/v28/x/concentrated-liquidity/model"
 	cwpoolmodel "github.com/osmosis-labs/osmosis/v28/x/cosmwasmpool/model"
 	"github.com/osmosis-labs/osmosis/v28/x/gamm/pool-models/balancer"
 	"github.com/osmosis-labs/osmosis/v28/x/gamm/pool-models/stableswap"
 
+	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 )
 
 type Client interface {
 	GetLatestHeight(ctx context.Context) (uint64, error)
+	GetStatus(ctx context.Context) (*ctypes.ResultStatus, error)
 }
 
 type chainClient struct {
 	rpcClient *rpchttp.HTTP
 }
 
-func NewClient(chainID string, nodeURI string) (Client, error) {
-	rpcClient, err := client.NewClientFromNode(nodeURI)
+func NewClient(ctx context.Context, chainID string, nodeURI string, timeout uint) (Client, error) {
+	rpcClient, err := rpchttp.NewWithTimeout(nodeURI, "/websocket", timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -39,9 +39,19 @@ func NewClient(chainID string, nodeURI string) (Client, error) {
 	}, nil
 }
 
+// GetStatus returns the status of the chain client
+func (c chainClient) GetStatus(ctx context.Context) (*ctypes.ResultStatus, error) {
+	statusResult, err := c.rpcClient.Status(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return statusResult, nil
+}
+
 // IsConnected returns error if fails to connect to client. Nil otherwise
 func (c chainClient) GetLatestHeight(ctx context.Context) (uint64, error) {
-	statusResult, err := c.rpcClient.Status(ctx)
+	statusResult, err := c.GetStatus(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/chaininfo/client/chain_client.go
+++ b/chaininfo/client/chain_client.go
@@ -40,7 +40,7 @@ func NewClient(ctx context.Context, chainID string, nodeURI string, timeout uint
 }
 
 // GetStatus returns the status of the chain client
-func (c chainClient) GetStatus(ctx context.Context) (*ctypes.ResultStatus, error) {
+func (c *chainClient) GetStatus(ctx context.Context) (*ctypes.ResultStatus, error) {
 	statusResult, err := c.rpcClient.Status(ctx)
 	if err != nil {
 		return nil, err
@@ -50,7 +50,7 @@ func (c chainClient) GetStatus(ctx context.Context) (*ctypes.ResultStatus, error
 }
 
 // IsConnected returns error if fails to connect to client. Nil otherwise
-func (c chainClient) GetLatestHeight(ctx context.Context) (uint64, error) {
+func (c *chainClient) GetLatestHeight(ctx context.Context) (uint64, error) {
 	statusResult, err := c.GetStatus(ctx)
 	if err != nil {
 		return 0, err

--- a/chaininfo/usecase/chain_info_usecase.go
+++ b/chaininfo/usecase/chain_info_usecase.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	chaininfoclient "github.com/osmosis-labs/sqs/chaininfo/client"
 	chaininforepo "github.com/osmosis-labs/sqs/chaininfo/repository"
 	"github.com/osmosis-labs/sqs/domain"
 
@@ -14,6 +15,7 @@ import (
 
 type chainInfoUseCase struct {
 	chainInfoRepository chaininforepo.ChainInfoRepository
+	client              chaininfoclient.Client
 
 	// N.B. sometimes the node gets stuck and does not make progress.
 	// However, it returns 200 OK for the status endpoint and claims to be not catching up.
@@ -56,14 +58,19 @@ var (
 	_ domain.CandidateRouteSearchDataUpdateListener = &chainInfoUseCase{}
 )
 
-func NewChainInfoUsecase(chainInfoRepository chaininforepo.ChainInfoRepository) *chainInfoUseCase {
+func NewChainInfoUsecase(chainInfoRepository chaininforepo.ChainInfoRepository, client chaininfoclient.Client) *chainInfoUseCase {
 	return &chainInfoUseCase{
 		chainInfoRepository: chainInfoRepository,
+		client:              client,
 
 		lastSeenMx: sync.Mutex{},
 
 		lastIngestedHeight: 0,
 	}
+}
+
+func (p *chainInfoUseCase) GetClient() chaininfoclient.Client {
+	return p.client
 }
 
 func (p *chainInfoUseCase) GetLatestHeight() (uint64, error) {

--- a/domain/config.go
+++ b/domain/config.go
@@ -31,10 +31,11 @@ type Config struct {
 	LoggerIsProduction bool   `mapstructure:"logger-is-production"`
 	LoggerLevel        string `mapstructure:"logger-level"`
 
-	ChainTendermintRPCEndpoint string `mapstructure:"grpc-tendermint-rpc-endpoint"`
-	ChainGRPCGatewayEndpoint   string `mapstructure:"grpc-gateway-endpoint"`
-	ChainID                    string `mapstructure:"chain-id"`
-	SkipChainAvailabilityCheck bool   `mapstructure:"skip-chain-availability-check"`
+	ChainTendermintRPCEndpoint        string `mapstructure:"grpc-tendermint-rpc-endpoint"`
+	ChainTendermintRPCEndpointTimeout uint   `mapstructure:"grpc-tendermint-rpc-endpoint-timeout"` // Timeout in seconds
+	ChainGRPCGatewayEndpoint          string `mapstructure:"grpc-gateway-endpoint"`
+	ChainID                           string `mapstructure:"chain-id"`
+	SkipChainAvailabilityCheck        bool   `mapstructure:"skip-chain-availability-check"`
 
 	// Chain registry assets URL.
 	ChainRegistryAssetsFileURL string `mapstructure:"chain-registry-assets-url"`
@@ -71,17 +72,18 @@ type Config struct {
 const envPrefix = "SQS"
 
 var DefaultConfig = Config{
-	ServerAddress:                 ":9092",
-	LoggerFilename:                "sqs.log",
-	LoggerIsProduction:            false,
-	LoggerLevel:                   "info",
-	ChainTendermintRPCEndpoint:    "http://localhost:26657",
-	ChainGRPCGatewayEndpoint:      "localhost:9090",
-	ChainID:                       "osmosis-1",
-	SkipChainAvailabilityCheck:    false,
-	ChainRegistryAssetsFileURL:    "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/generated/frontend/assetlist.json",
-	ChainRegistryTokenFeesFileURL: "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/chain.json",
-	UpdateAssetsHeightInterval:    200,
+	ServerAddress:                     ":9092",
+	LoggerFilename:                    "sqs.log",
+	LoggerIsProduction:                false,
+	LoggerLevel:                       "info",
+	ChainTendermintRPCEndpoint:        "http://localhost:26657",
+	ChainTendermintRPCEndpointTimeout: 5,
+	ChainGRPCGatewayEndpoint:          "localhost:9090",
+	ChainID:                           "osmosis-1",
+	SkipChainAvailabilityCheck:        false,
+	ChainRegistryAssetsFileURL:        "https://raw.githubusercontent.com/osmosis-labs/assetlists/main/osmosis-1/generated/frontend/assetlist.json",
+	ChainRegistryTokenFeesFileURL:     "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/chain.json",
+	UpdateAssetsHeightInterval:        200,
 	FlightRecord: &FlightRecordConfig{
 		Enabled:          true,
 		TraceThresholdMS: 1000,

--- a/domain/mocks/chain_info_usecase_mock.go
+++ b/domain/mocks/chain_info_usecase_mock.go
@@ -27,7 +27,7 @@ func (m *ChainInfoClientMock) GetStatus(ctx context.Context) (*ctypes.ResultStat
 	if m.GetStatusFunc != nil {
 		return m.GetStatusFunc(ctx)
 	}
-	return nil, nil
+	return nil, nil // nolint:nilnil
 }
 
 // ChainInfoUsecaseMock is a mock implementation of the ChainInfoUsecase interface

--- a/domain/mocks/chain_info_usecase_mock.go
+++ b/domain/mocks/chain_info_usecase_mock.go
@@ -9,7 +9,10 @@ import (
 	ctypes "github.com/cometbft/cometbft/rpc/core/types"
 )
 
-var _ mvc.ChainInfoUsecase = &ChainInfoUsecaseMock{}
+var (
+	_ mvc.ChainInfoUsecase   = &ChainInfoUsecaseMock{}
+	_ chaininfoclient.Client = &ChainInfoClientMock{}
+)
 
 type ChainInfoClientMock struct {
 	GetLatestHeightFunc func(ctx context.Context) (uint64, error)

--- a/domain/mocks/chain_info_usecase_mock.go
+++ b/domain/mocks/chain_info_usecase_mock.go
@@ -1,8 +1,34 @@
 package mocks
 
-import "github.com/osmosis-labs/sqs/domain/mvc"
+import (
+	"context"
+
+	chaininfoclient "github.com/osmosis-labs/sqs/chaininfo/client"
+	"github.com/osmosis-labs/sqs/domain/mvc"
+
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+)
 
 var _ mvc.ChainInfoUsecase = &ChainInfoUsecaseMock{}
+
+type ChainInfoClientMock struct {
+	GetLatestHeightFunc func(ctx context.Context) (uint64, error)
+	GetStatusFunc       func(ctx context.Context) (*ctypes.ResultStatus, error)
+}
+
+func (m *ChainInfoClientMock) GetLatestHeight(ctx context.Context) (uint64, error) {
+	if m.GetLatestHeightFunc != nil {
+		return m.GetLatestHeightFunc(ctx)
+	}
+	return 0, nil
+}
+
+func (m *ChainInfoClientMock) GetStatus(ctx context.Context) (*ctypes.ResultStatus, error) {
+	if m.GetStatusFunc != nil {
+		return m.GetStatusFunc(ctx)
+	}
+	return nil, nil
+}
 
 // ChainInfoUsecaseMock is a mock implementation of the ChainInfoUsecase interface
 type ChainInfoUsecaseMock struct {
@@ -11,6 +37,7 @@ type ChainInfoUsecaseMock struct {
 	ValidatePriceUpdatesFunc                    func() error
 	ValidatePoolLiquidityUpdatesFunc            func() error
 	ValidateCandidateRouteSearchDataUpdatesFunc func() error
+	GetClientFunc                               func() chaininfoclient.Client
 }
 
 func (m *ChainInfoUsecaseMock) GetLatestHeight() (uint64, error) {
@@ -43,6 +70,13 @@ func (m *ChainInfoUsecaseMock) ValidatePoolLiquidityUpdates() error {
 func (m *ChainInfoUsecaseMock) ValidateCandidateRouteSearchDataUpdates() error {
 	if m.ValidateCandidateRouteSearchDataUpdatesFunc != nil {
 		return m.ValidateCandidateRouteSearchDataUpdatesFunc()
+	}
+	return nil
+}
+
+func (m *ChainInfoUsecaseMock) GetClient() chaininfoclient.Client {
+	if m.GetClientFunc != nil {
+		return m.GetClientFunc()
 	}
 	return nil
 }

--- a/domain/mvc/chainInfo.go
+++ b/domain/mvc/chainInfo.go
@@ -1,5 +1,7 @@
 package mvc
 
+import chaininfoclient "github.com/osmosis-labs/sqs/chaininfo/client"
+
 // ChainInfoUsecase is the interface that defines the methods for the chain info usecase
 type ChainInfoUsecase interface {
 	// GetLatestHeight returns the latest height stored
@@ -30,4 +32,7 @@ type ChainInfoUsecase interface {
 	// - 50 heights have passed since the last update
 	// - The initial candidate route search data update has not been received
 	ValidateCandidateRouteSearchDataUpdates() error
+
+	// GetClient returns the chain client used to interact with the chain.
+	GetClient() chaininfoclient.Client
 }

--- a/system/delivery/http/system_http_handler.go
+++ b/system/delivery/http/system_http_handler.go
@@ -2,12 +2,10 @@ package http
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/pprof"
 	"runtime"
 	"runtime/debug"
-	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -15,7 +13,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	echoSwagger "github.com/swaggo/echo-swagger"
 
-	"github.com/osmosis-labs/osmosis/v28/ingest/types/json"
 	"github.com/osmosis-labs/sqs/domain"
 	"github.com/osmosis-labs/sqs/domain/mvc"
 	"github.com/osmosis-labs/sqs/log"
@@ -24,20 +21,9 @@ import (
 )
 
 type SystemHandler struct {
-	logger      log.Logger
-	grpcAddress string
-	CIUsecase   mvc.ChainInfoUsecase
-	config      domain.Config
-}
-
-// Parse the response from the GRPC Gateway status endpoint
-type JsonResponse struct {
-	Result struct {
-		SyncInfo struct {
-			LatestBlockHeight string `json:"latest_block_height"`
-			CatchingUp        bool   `json:"catching_up"`
-		} `json:"sync_info"`
-	} `json:"result"`
+	Logger    log.Logger
+	CIUsecase mvc.ChainInfoUsecase
+	config    domain.Config
 }
 
 // ConfigPrivateResponse defines the response for the /config-private endpoint
@@ -54,10 +40,9 @@ const (
 // NewSystemHandler will initialize the /debug/ppof resources endpoint
 func NewSystemHandler(e *echo.Echo, config domain.Config, logger log.Logger, us mvc.ChainInfoUsecase) {
 	handler := &SystemHandler{
-		logger:      logger,
-		grpcAddress: config.ChainTendermintRPCEndpoint,
-		CIUsecase:   us,
-		config:      config,
+		Logger:    logger,
+		CIUsecase: us,
+		config:    config,
 	}
 
 	// if debug mod, enable additional profiles that are too intensive
@@ -142,38 +127,14 @@ func extractVersion(ldGlagsValueStr string) (string, error) {
 // GetHealthStatus handles health check requests for GRPC gateway
 func (h *SystemHandler) GetHealthStatus(c echo.Context) error {
 	// Check GRPC Gateway status
-	url := h.grpcAddress + "/status"
-	resp, err := http.Get(url)
-	if err != nil || resp == nil || resp.StatusCode != http.StatusOK {
-		h.logger.Error("Error checking GRPC gateway status", zap.Error(err))
+	statusResponse, err := h.CIUsecase.GetClient().GetStatus(c.Request().Context())
+	if err != nil {
+		h.Logger.Error("Error checking GRPC gateway status", zap.Error(err))
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "Error connecting to the Osmosis chain via GRPC gateway")
-	} else {
-		if resp.Body != nil {
-			defer resp.Body.Close()
-		}
-	}
-
-	var statusResponse JsonResponse
-
-	if resp == nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to get response from GRPC gateway")
-	}
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to read response body")
-	}
-
-	err = json.Unmarshal(bodyBytes, &statusResponse)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to parse JSON response")
 	}
 
 	// allow 10 blocks of difference before claiming node is not synced
-	latestChainHeight, err := strconv.ParseUint(statusResponse.Result.SyncInfo.LatestBlockHeight, 10, 64)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "Failed to parse latest block height from GRPC gateway")
-	}
+	latestChainHeight := uint64(statusResponse.SyncInfo.LatestBlockHeight)
 
 	// Check the latest height from chain info use case
 	// Errors if the height has not beein updated for more than 30 seconds
@@ -183,7 +144,7 @@ func (h *SystemHandler) GetHealthStatus(c echo.Context) error {
 	}
 
 	// Check if the node is catching up. Error if so.
-	if statusResponse.Result.SyncInfo.CatchingUp {
+	if statusResponse.SyncInfo.CatchingUp {
 		return echo.NewHTTPError(http.StatusServiceUnavailable, "Node is still catching up")
 	}
 

--- a/system/delivery/http/system_http_handler_test.go
+++ b/system/delivery/http/system_http_handler_test.go
@@ -1,14 +1,176 @@
 package http_test
 
 import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"github.com/osmosis-labs/sqs/system/delivery/http"
+	"github.com/labstack/echo/v4"
+	chaininfoclient "github.com/osmosis-labs/sqs/chaininfo/client"
+	"github.com/osmosis-labs/sqs/domain/mocks"
+	"github.com/osmosis-labs/sqs/log"
+	deliveryhttp "github.com/osmosis-labs/sqs/system/delivery/http"
+
+	ctypes "github.com/cometbft/cometbft/rpc/core/types"
+
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestExtractVersion(t *testing.T) {
+func TestGetHealthStatus(t *testing.T) {
+	tests := []struct {
+		name               string
+		setupMock          func(*mocks.ChainInfoUsecaseMock)
+		expectedStatusCode int
+		expectedBody       string
+	}{
+		{
+			name: "Healthy status",
+			setupMock: func(mock *mocks.ChainInfoUsecaseMock) {
+				mock.GetLatestHeightFunc = func() (uint64, error) {
+					return 100, nil
+				}
+				mock.ValidatePriceUpdatesFunc = func() error {
+					return nil
+				}
+				mock.ValidatePoolLiquidityUpdatesFunc = func() error {
+					return nil
+				}
+				mock.ValidateCandidateRouteSearchDataUpdatesFunc = func() error {
+					return nil
+				}
+				mock.GetClientFunc = func() chaininfoclient.Client {
+					return &mocks.ChainInfoClientMock{
+						GetStatusFunc: func(ctx context.Context) (*ctypes.ResultStatus, error) {
+							return &ctypes.ResultStatus{
+								SyncInfo: ctypes.SyncInfo{
+									LatestBlockHeight: 105,
+									CatchingUp:        false,
+								},
+							}, nil
+						},
+					}
+				}
+			},
+			expectedStatusCode: http.StatusOK,
+			expectedBody:       `{"chain_latest_height":"105","grpc_gateway_status":"running","store_latest_height":"100"}`,
+		},
+		{
+			name: "Error connecting to the Osmosis chain via GRPC gateway",
+			setupMock: func(mock *mocks.ChainInfoUsecaseMock) {
+				mock.GetClientFunc = func() chaininfoclient.Client {
+					return &mocks.ChainInfoClientMock{
+						GetStatusFunc: func(ctx context.Context) (*ctypes.ResultStatus, error) {
+							return nil, fmt.Errorf("client error")
+						},
+					}
+				}
+			},
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectedBody:       `Error connecting to the Osmosis chain via GRPC gateway`,
+		},
+		{
+			name: "Failed to get latest height from sqs store",
+			setupMock: func(mock *mocks.ChainInfoUsecaseMock) {
+				mock.GetLatestHeightFunc = func() (uint64, error) {
+					return 0, fmt.Errorf("error getting latest height from store")
+				}
+				mock.GetClientFunc = func() chaininfoclient.Client {
+					return &mocks.ChainInfoClientMock{
+						GetStatusFunc: func(ctx context.Context) (*ctypes.ResultStatus, error) {
+							return &ctypes.ResultStatus{}, nil
+						},
+					}
+				}
+			},
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedBody:       `Failed to get latest height from sqs store: error getting latest height from store`,
+		},
+		{
+			name: "Node catching up",
+			setupMock: func(mock *mocks.ChainInfoUsecaseMock) {
+				mock.GetClientFunc = func() chaininfoclient.Client {
+					return &mocks.ChainInfoClientMock{
+						GetStatusFunc: func(ctx context.Context) (*ctypes.ResultStatus, error) {
+							return &ctypes.ResultStatus{
+								SyncInfo: ctypes.SyncInfo{
+									CatchingUp: true,
+								},
+							}, nil
+						},
+					}
+				}
+			},
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectedBody:       `Node is still catching up`,
+		},
+		{
+			name: "Node not synced",
+			setupMock: func(mock *mocks.ChainInfoUsecaseMock) {
+				mock.GetLatestHeightFunc = func() (uint64, error) {
+					return 100, nil
+				}
+				mock.GetClientFunc = func() chaininfoclient.Client {
+					return &mocks.ChainInfoClientMock{
+						GetStatusFunc: func(ctx context.Context) (*ctypes.ResultStatus, error) {
+							return &ctypes.ResultStatus{
+								SyncInfo: ctypes.SyncInfo{
+									LatestBlockHeight: 120,
+									CatchingUp:        false,
+								},
+							}, nil
+						},
+					}
+				}
+			},
+			expectedStatusCode: http.StatusServiceUnavailable,
+			expectedBody:       `Node is not synced, chain height (120), store height (100), tolerance (10)`,
+		},
+	}
 
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/healthcheck", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+
+			mock := &mocks.ChainInfoUsecaseMock{}
+			if tt.setupMock != nil {
+				tt.setupMock(mock)
+			}
+
+			handler := &deliveryhttp.SystemHandler{
+				Logger:    &log.NoOpLogger{},
+				CIUsecase: mock,
+			}
+
+			// Act
+			err := handler.GetHealthStatus(c)
+
+			// Assert
+			if tt.expectedStatusCode == http.StatusOK {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+				httpError, ok := err.(*echo.HTTPError)
+				assert.True(t, ok)
+				assert.Equal(t, tt.expectedStatusCode, httpError.Code)
+				assert.Equal(t, tt.expectedBody, string(httpError.Message.(string)))
+			}
+
+			if tt.expectedStatusCode == http.StatusOK {
+				assert.Equal(t, tt.expectedStatusCode, rec.Code)
+				assert.JSONEq(t, tt.expectedBody, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestExtractVersion(t *testing.T) {
 	// Test cases
 	testCases := []struct {
 		name            string
@@ -44,7 +206,7 @@ func TestExtractVersion(t *testing.T) {
 	// Run tests
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := http.ExtractVersion(tc.ldFlagsValue)
+			result, err := deliveryhttp.ExtractVersion(tc.ldFlagsValue)
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expectedVersion, result)


### PR DESCRIPTION
This PR implements timeout handling when connecting to Tendermint. Handling is implemented in the same way as checking current ingested height, - if flag `skip-chain-availability-check` is provided and SQS timeouts on attempt to connect during the startup it would error but not panic and exit.

As a side effect tests for healthceck endpoint was implemented to allow for more confidence when changing related code areas and handler was cleaned up to reuse existing code than duplicate logic chain client logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for configuring a timeout for Tendermint RPC endpoint connections.
- **Refactor**
	- Streamlined health check logic to use direct status retrieval, improving reliability and reducing manual HTTP and JSON handling.
	- Enhanced initialization and usage of chain client and chain info use case for better maintainability.
- **Tests**
	- Introduced new mock implementations for improved test coverage of chain client and use case interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->