### PR TITLE
BE-766 | Implement state dump/load for Ingest usecase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ load-test-ui:
 	$(DOCKER) compose -f locust/docker-compose.yml up --scale worker=4
 
 debug:
-	dlv --build-flags="-ldflags='-X github.com/osmosis-labs/sqs/version=${VERSION}'"  debug app/*.go
+	dlv --build-flags="-ldflags='-X github.com/osmosis-labs/sqs/version=${VERSION}'"  debug app/*.go -- --config config.json
 
 # Validates that SQS concentrated liquidity pool state is
 # consistent with the state of the chain.

--- a/app/sidecar_query_server.go
+++ b/app/sidecar_query_server.go
@@ -35,6 +35,7 @@ import (
 	chainregistryUseCase "github.com/osmosis-labs/sqs/chainregistry/usecase"
 	"github.com/osmosis-labs/sqs/domain/cosmos/auth/types"
 	ingestrpcdelivry "github.com/osmosis-labs/sqs/ingest/delivery/grpc"
+	ingestHttpDelivery "github.com/osmosis-labs/sqs/ingest/delivery/http"
 	ingestusecase "github.com/osmosis-labs/sqs/ingest/usecase"
 	"github.com/osmosis-labs/sqs/ingest/usecase/plugins/basefee"
 	orderbookclaimbot "github.com/osmosis-labs/sqs/ingest/usecase/plugins/orderbook/claimbot"
@@ -405,6 +406,13 @@ func NewSideCarQueryServer(ctx context.Context, appCodec codec.Codec, config dom
 		grpcIngestHandler, err := ingestrpcdelivry.NewIngestGRPCHandler(ingestUseCase, *grpcIngesterConfig, logger)
 		if err != nil {
 			panic(err)
+		}
+
+		ingestHttpDelivery.NewIngestHandler(e, ingestUseCase, logger)
+		if config.ServeFromState {
+			if err := ingestUseCase.LoadIngestStateFiles(); err != nil {
+				panic(fmt.Errorf("failed to load ingester state files: %w", err))
+			}
 		}
 
 		go func() {

--- a/domain/mvc/ingest.go
+++ b/domain/mvc/ingest.go
@@ -17,4 +17,12 @@ type IngestUsecase interface {
 	// RegisterEndBlockProcessPlugin registers the end block process plugin
 	// That is called at the end of the block
 	RegisterEndBlockProcessPlugin(plugin domain.EndBlockProcessPlugin)
+
+	// StoreIngestStateFiles stores the current ingest state into files
+	// Used for debugging.
+	StoreIngestStateFiles() error
+
+	// LoadIngestStateFiles loads the ingest state from files
+	// Used for debugging.
+	LoadIngestStateFiles() error
 }

--- a/domain/tokens.go
+++ b/domain/tokens.go
@@ -50,11 +50,11 @@ type DenomPoolLiquidityMap map[string]DenomPoolLiquidityData
 // pools with their individual contributions to the total.
 type DenomPoolLiquidityData struct {
 	// Total liquidity for this denom
-	TotalLiquidity          osmomath.Int
-	EffectiveTotalLiquidity osmomath.BigDec
+	TotalLiquidity          osmomath.Int    `json:"total_liquidity"`
+	EffectiveTotalLiquidity osmomath.BigDec `json:"effective_total_liquidity"`
 	// Mapping from pool ID to denom liquidity
 	// in that pool
-	Pools map[uint64]osmomath.Int
+	Pools map[uint64]osmomath.Int `json:"pools"`
 }
 
 // GAMMSharePrefix is the prefix for the GAMM share

--- a/ingest/delivery/http/ingest_handler.go
+++ b/ingest/delivery/http/ingest_handler.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/osmosis-labs/sqs/domain"
+	"github.com/osmosis-labs/sqs/domain/mvc"
+	"github.com/osmosis-labs/sqs/log"
+
+	"github.com/labstack/echo/v4"
+)
+
+type IngestHandler struct {
+	IngestUsecase mvc.IngestUsecase
+	logger        log.Logger
+}
+
+const routerResource = "/ingest"
+
+func formatRouterResource(resource string) string {
+	return routerResource + resource
+}
+
+// NewRouterHandler will initialize the pools/ resources endpoint
+func NewIngestHandler(
+	e *echo.Echo,
+	ingestUsecase mvc.IngestUsecase,
+	logger log.Logger,
+) {
+	handler := &IngestHandler{
+		IngestUsecase: ingestUsecase,
+		logger:        logger,
+	}
+
+	e.POST(formatRouterResource("/store-state"), handler.StoreRouterStateInFiles)
+}
+
+// TODO: authentication for the endpoint and enable only in dev mode.
+func (a *IngestHandler) StoreRouterStateInFiles(c echo.Context) error {
+	if err := a.IngestUsecase.StoreIngestStateFiles(); err != nil {
+		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, "Ingest state stored in files")
+}

--- a/ingest/delivery/http/ingest_handler.go
+++ b/ingest/delivery/http/ingest_handler.go
@@ -15,13 +15,13 @@ type IngestHandler struct {
 	logger        log.Logger
 }
 
-const routerResource = "/ingest"
+const ingestResource = "/ingest"
 
-func formatRouterResource(resource string) string {
-	return routerResource + resource
+func formatIngestResource(resource string) string {
+	return ingestResource + resource
 }
 
-// NewRouterHandler will initialize the pools/ resources endpoint
+// NewIngestHandler will initialize the pools/ resources endpoint
 func NewIngestHandler(
 	e *echo.Echo,
 	ingestUsecase mvc.IngestUsecase,
@@ -32,11 +32,11 @@ func NewIngestHandler(
 		logger:        logger,
 	}
 
-	e.POST(formatRouterResource("/store-state"), handler.StoreRouterStateInFiles)
+	e.POST(formatIngestResource("/store-state"), handler.StoreIngestStateInFiles)
 }
 
 // TODO: authentication for the endpoint and enable only in dev mode.
-func (a *IngestHandler) StoreRouterStateInFiles(c echo.Context) error {
+func (a *IngestHandler) StoreIngestStateInFiles(c echo.Context) error {
 	if err := a.IngestUsecase.StoreIngestStateFiles(); err != nil {
 		return c.JSON(domain.GetStatusCode(err), domain.ResponseError{Message: err.Error()})
 	}

--- a/ingest/usecase/ingest_usecase.go
+++ b/ingest/usecase/ingest_usecase.go
@@ -23,6 +23,7 @@ import (
 	sqsingesttypes "github.com/osmosis-labs/sqs/ingest/types"
 	"github.com/osmosis-labs/sqs/log"
 	routerusecase "github.com/osmosis-labs/sqs/router/usecase"
+	"github.com/osmosis-labs/sqs/router/usecase/routertesting/parsing"
 
 	"github.com/osmosis-labs/osmosis/v28/ingest/types/json"
 	"github.com/osmosis-labs/osmosis/v28/ingest/types/proto/types"
@@ -490,6 +491,21 @@ func (p *ingestUseCase) executeEndBlockProcessPlugins(ctx context.Context, block
 			p.logger.Error("error executing end block process plugin", zap.Error(err), zap.Uint64("block_height", blockHeight))
 		}
 	}
+}
+
+func (p *ingestUseCase) StoreIngestStateFiles() error {
+	return parsing.StoreIngest(p.denomLiquidityMap, "ingest.json")
+}
+
+func (p *ingestUseCase) LoadIngestStateFiles() error {
+	denomliquidityCap, err := parsing.LoadIngest("./state/ingest.json")
+	if err != nil {
+		return fmt.Errorf("failed to load ingest state files: %w", err)
+	}
+
+	p.denomLiquidityMap = denomliquidityCap
+
+	return nil
 }
 
 // processSQSModelMut processes the SQS model and updates it.

--- a/router/usecase/routertesting/parsing/mainnet_pools.go
+++ b/router/usecase/routertesting/parsing/mainnet_pools.go
@@ -23,6 +23,46 @@ type SerializedPool struct {
 	TickModel *ingesttypes.TickModel    `json:"tick_model,omitempty"`
 }
 
+func LoadIngest(ingestFile string) (domain.DenomPoolLiquidityMap, error) {
+	ingestBytes, err := os.ReadFile(ingestFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var denomLiquidityMap domain.DenomPoolLiquidityMap
+	err = json.Unmarshal(ingestBytes, &denomLiquidityMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+	}
+
+	return denomLiquidityMap, nil
+}
+
+func StoreIngest(denomLiquidityMap domain.DenomPoolLiquidityMap, ingestFile string) error {
+	_, err := os.Stat(ingestFile)
+	if os.IsNotExist(err) {
+		file, err := os.Create(ingestFile)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		ingestJSON, err := json.Marshal(denomLiquidityMap)
+		if err != nil {
+			return err
+		}
+
+		_, err = file.Write(ingestJSON)
+		if err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // StorePools stores the pools to a file.
 func StorePools(actualPools []ingesttypes.PoolI, tickModelMap map[uint64]*ingesttypes.TickModel, poolsFile string) error {
 	_, err := os.Stat(poolsFile)

--- a/scripts/state-dump.sh
+++ b/scripts/state-dump.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 HOSTNAME="http://localhost:9092"
 ROUTER_ENDPOINT="/router/store-state"
 TOKENS_ENDPOINT="/tokens/store-state"
+INGEST_ENDPOINT="/ingest/store-state"
 OUTPUT_DIR="${1:-./state}"
 
 EXPECTED_ROUTER_FILES=(
@@ -16,6 +17,10 @@ EXPECTED_ROUTER_FILES=(
 EXPECTED_TOKENS_FILES=(
     "tokens.json"
     "pool_denom_metadata.json"
+)
+
+EXPECTED_INGEST_FILES=(
+	"ingest.json"
 )
 
 echo "Starting state dump..."
@@ -34,6 +39,14 @@ move_files() {
     done
 }
 
+# Request ingest state
+echo "Requesting ingest state..."
+if ! curl -sS -X POST "${HOSTNAME}${INGEST_ENDPOINT}" -o /dev/null; then
+	echo "Error: curl request to ${HOSTNAME}${INGEST_ENDPOINT} failed." >&2
+	exit 1
+fi
+move_files "${EXPECTED_INGEST_FILES[@]}"
+
 # Request router state once
 echo "Requesting router state..."
 if ! curl -sS -X POST "${HOSTNAME}${ROUTER_ENDPOINT}" -o /dev/null; then
@@ -49,5 +62,6 @@ if ! curl -sS -X POST "${HOSTNAME}${TOKENS_ENDPOINT}" -o /dev/null; then
     exit 1
 fi
 move_files "${EXPECTED_TOKENS_FILES[@]}"
+
 
 echo "State dump completed successfully."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an HTTP endpoint to trigger storing the current ingest state to a file.
  - Added the ability to persist and restore ingest state for debugging purposes.
  - Extended the state dump script to support ingest state export.
  - Added HTTP ingest handler alongside gRPC for improved ingest service support.

- **Improvements**
  - Enhanced JSON serialization for liquidity data to ensure proper formatting in API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->