### PR TITLE
BE-654 | Fix e2e tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,7 +128,7 @@ NUMIA_TO_E2E_MAP = {
 # This is the number of tokens we allow being skipped due to being unlisted
 # or not having liquidity. This number is hand-picked arbitrarily. We have around ~350 tokens
 # at the time of writing this test and we leave a small buffer.
-ALLOWED_NUM_TOKENS_USDC_PAIR_SKIPPED = 75
+ALLOWED_NUM_TOKENS_USDC_PAIR_SKIPPED = 100
 # This is the minimum number of misc token pairs
 # that we expect to construct in setup.
 # Since our test setup is dynamic, it is important to

--- a/tests/quote_response.py
+++ b/tests/quote_response.py
@@ -16,6 +16,8 @@ class Pool:
         self.token_in_denom = kwargs.get('token_in_denom', None)
         self.token_out_denom = kwargs.get('token_out_denom', None)
         self.taker_fee = float(taker_fee)
+        self.liquidity_cap = int(kwargs.get('liquidity_cap', 0))
+
         code_id = kwargs.get('code_id', 0)
         # Only CW pools have code id
         if code_id:
@@ -33,10 +35,12 @@ class Route:
 # QuoteExactAmountInResponse represents the response format
 # of the /router/quote endpoint for Exact Amount In Quote.
 class QuoteExactAmountInResponse:
-    def __init__(self, amount_in, amount_out, route, effective_fee, price_impact, in_base_out_quote_spot_price, price_info=None):
+    def __init__(self, amount_in, amount_out, route, liquidity_cap, liquidity_cap_overflow, effective_fee, price_impact, in_base_out_quote_spot_price, price_info=None):
         self.amount_in = Coin(**amount_in)
         self.amount_out = int(amount_out)
         self.route = [Route(**r) for r in route]
+        self.liquidity_cap = int(liquidity_cap)
+        self.liquidity_cap_overflow = bool(liquidity_cap_overflow)
         self.effective_fee = Decimal(effective_fee)
         self.price_impact = Decimal(price_impact)
         self.in_base_out_quote_spot_price = Decimal(in_base_out_quote_spot_price)
@@ -60,10 +64,12 @@ class QuoteExactAmountInResponse:
 # QuoteExactAmountOutResponse represents the response format
 # of the /router/quote endpoint for Exact Amount Out Quote.
 class QuoteExactAmountOutResponse:
-    def __init__(self, amount_in, amount_out, route, effective_fee, price_impact, in_base_out_quote_spot_price):
+    def __init__(self, amount_in, amount_out, route, liquidity_cap, liquidity_cap_overflow, effective_fee, price_impact, in_base_out_quote_spot_price):
         self.amount_in = int(amount_in)
         self.amount_out = Coin(**amount_out)
         self.route = [Route(**r) for r in route]
+        self.liquidity_cap = int(liquidity_cap)
+        self.liquidity_cap_overflow = bool(liquidity_cap_overflow)
         self.effective_fee = Decimal(effective_fee)
         self.price_impact = Decimal(price_impact)
         self.in_base_out_quote_spot_price = Decimal(in_base_out_quote_spot_price)


### PR DESCRIPTION
Fix broken e2e tests due introduced `liquidity_cap` and `liquidity_cap_overflow` properties in the quote response under https://github.com/osmosis-labs/sqs/pull/671.