### PR TITLE
Update `maxSearchQueryLength` to `200`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## v28.3.12
+
+- #680 - CHAIN-1116 | Update pool search `maxSearchQueryLength`
+
 ## v28.3.11
 
 - #676 - BE-751 | Include token metadata into quote response

--- a/pkg/api/v1beta1/pools/http.go
+++ b/pkg/api/v1beta1/pools/http.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	maxSearchQueryLength = 150
+	maxSearchQueryLength = 200
 	maxDenoms            = 8
 )
 

--- a/pkg/api/v1beta1/pools/http.go
+++ b/pkg/api/v1beta1/pools/http.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	maxSearchQueryLength = 50
+	maxSearchQueryLength = 150
 	maxDenoms            = 8
 )
 

--- a/pkg/api/v1beta1/pools/http_test.go
+++ b/pkg/api/v1beta1/pools/http_test.go
@@ -219,7 +219,7 @@ func TestGetPoolsRequestFilter_UnmarshalHTTPRequest(t *testing.T) {
 		{
 			name: "Invalid Search ( too long )",
 			queryParams: map[string]string{
-				queryFilterSearch: "TestGetPoolsRequestFilter_UnmarshalHTTPRequest/Invalid_Search_(_too_long_)",
+				queryFilterSearch: "TestGetPoolsRequestFilter_UnmarshalHTTPRequest/Invalid_Search_(_too_long_very_long_search_query_that_exceeds_the_max_length_of_200_characters_lore_ipsum_dolor_sit_amet_consectetur_adipiscing_elit_sed_do_eiusmod_tempor_incididunt_ut",
 			},
 			expectError: true,
 		},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased the maximum allowed length for pool search queries from 50 to 200 characters, enabling more detailed filter[search] inputs without truncation.

* **Documentation**
  * Added a changelog entry for v28.3.12 noting the updated pool search query limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->