### PR TITLE
Fix: Missing price_info in exact out quotes

### DIFF
--- a/router/usecase/quote_in_given_out.go
+++ b/router/usecase/quote_in_given_out.go
@@ -154,6 +154,7 @@ func (q *quoteExactAmountOut) PrepareResult(ctx context.Context, scalingFactor o
 	q.EffectiveFee = q.quoteExactAmountIn.EffectiveFee
 	q.PriceImpact = q.quoteExactAmountIn.PriceImpact
 	q.InBaseOutQuoteSpotPrice = q.quoteExactAmountIn.InBaseOutQuoteSpotPrice
+	q.PriceInfo = q.quoteExactAmountIn.PriceInfo
 
 	for i, r := range q.Route {
 		route, ok := r.(*route.RouteWithOutAmount)


### PR DESCRIPTION
## Problem

Exact out (given out) quotes were missing the `price_info` field when `appendBaseFee=true` was specified, while exact in quotes correctly included this field.

## Root Cause

The `PrepareResult` method in `quoteExactAmountOut` was copying all fields from the internal `quoteExactAmountIn` except for the `PriceInfo` field.

## Solution

Added the missing `PriceInfo` field copy in the `PrepareResult` method:

```go
q.PriceInfo = q.quoteExactAmountIn.PriceInfo
```

## Testing

- All existing tests pass
- No breaking changes
- Fixes the inconsistency between exact in and exact out quote responses

## Example

Before fix:
```json
{
  "amount_in": "867426",
  "amount_out": { "denom": "ibc/...", "amount": "100000" },
  // ... other fields ...
  // price_info was missing
}
```

After fix:
```json
{
  "amount_in": "867426", 
  "amount_out": { "denom": "ibc/...", "amount": "100000" },
  // ... other fields ...
  "price_info": {
    "fee_coin": { "amount": "0" },
    "base_fee": "0.010000000000000000"
  }
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Populates `price_info` in exact-out (`quoteExactAmountOut`) responses by copying `PriceInfo` from the inner `quoteExactAmountIn` during `PrepareResult`.
> 
> - **Router / Quotes**:
>   - In `router/usecase/quote_in_given_out.go`, `quoteExactAmountOut.PrepareResult` now sets `q.PriceInfo = q.quoteExactAmountIn.PriceInfo` to include `price_info` in exact-out quote outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 165205c9d3076ce00c31405aa7e812dc16685825. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected price information propagation in quote processing to ensure accurate pricing details are consistently reflected in calculation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->