### PR TITLE
chore: remove SonarCloud integration from CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,37 +37,4 @@ jobs:
         name: code-coverage-report
         path: |
           coverage.out   
-          report.json   
-
-  sonarCloudTrigger:
-    needs: build
-    name: SonarCloud Trigger
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Download code coverage results
-        uses: actions/download-artifact@v4
-        with:
-          name: code-coverage-report
-#          path: app
-      - name: Analyze with SonarCloud
-        uses: sonarsource/sonarqube-scan-action@v7
-        with:
-#          projectBaseDir: app
-          args: >
-            -Dsonar.projectKey=osmosis-labs-sqs
-            -Dsonar.organization=osmosis-labs-polaris
-            -Dsonar.host.url=https://sonarcloud.io            
-            -Dsonar.go.coverage.reportPaths=coverage.out            
-            -Dsonar.go.tests.reportPaths=report.json
-            -Dsonar.sources=.
-            -Dsonar.tests=.
-            -Dsonar.test.inclusions=**/*_test.go,**/testdata/**
-            -Dsonar.language=go                        
-            -Dsonar.go.exclusions=**/vendor/**,**/*_mock.go
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          report.json


### PR DESCRIPTION
Remove SonarCloud integration from CI workflows. 
It is causing the build workflow to fail, and no longer needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed SonarCloud analysis integration from the build workflow. All build verification, automated testing, and code coverage archival processes continue to operate as before.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->